### PR TITLE
Docu/python backend

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for ClashRecruit service wrappers."""

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -1,3 +1,5 @@
+"""Core Clash API wrapper for player validation and profile lookups."""
+
 from typing import Literal
 
 import requests
@@ -10,8 +12,23 @@ REQUESTOPTIONS = Literal[
     "clan"
 ]
 
+
 class API:
-    def __init__(self, user_tag, api, headers):
+    """Represent a player session backed by Clash API data."""
+
+    def __init__(
+        self,
+        user_tag: str,
+        api: str | None,
+        headers: dict[str, str],
+    ) -> None:
+        """Initialize API session state for a player.
+
+        Args:
+            user_tag (str): Player tag for the current session.
+            api (str | None): Optional player API token for verification.
+            headers (dict[str, str]): HTTP headers for Clash API requests.
+        """
         self.headers = headers
         self.token = False
         self.user_tag = user_tag
@@ -25,25 +42,51 @@ class API:
         self.builder_trophies = 0
         self.townhall = 0
         self.townhallWeaponLevel = None
-    def check_player_api(self):
-        
-        url = f"https://api.clashofclans.com/v1/players/%23{self.user_tag}/verifytoken"
 
-        response = requests.post(url, headers=self.headers, json = self.json_data)
-        self.apistorage = response.json() # Important!! this storage now holds whether the api key is valid or not
+    def check_player_api(self) -> bool:
+        """Validate the provided player API token with Clash verification API.
+
+        Returns:
+            bool: ``True`` when the token is valid, otherwise ``False``.
+        """
+        url = (
+            "https://api.clashofclans.com/v1/players/"
+            f"%23{self.user_tag}/verifytoken"
+        )
+
+        response = requests.post(
+            url,
+            headers=self.headers,
+            json=self.json_data,
+        )
+        self.apistorage = response.json()
 
         status = self.apistorage.get("status")
 
         if status == "ok":
-            self.token = True # set token value to 1 in boolean. this makes it easy to check if token info is correct
+            self.token = True
 
         elif status == "invalid":
             self.reason = "API Token is incorrect"
 
-        else: self.reason = self.apistorage  
-        return self.token 
-    
-    def check_player(self, request: list[REQUESTOPTIONS] | None = None):
+        else: self.reason = self.apistorage
+        return self.token
+
+    def check_player(
+        self,
+        request: list[REQUESTOPTIONS] | None = None,
+    ) -> bool | dict[str, object]:
+        """Validate and load player data for session use.
+
+        Args:
+            request (list[REQUESTOPTIONS] | None, optional): Optional subset
+                of player fields to return instead of a boolean.
+
+        Returns:
+            bool | dict: ``True`` for successful validation,
+                ``False`` for invalid user/token states, or a filtered player
+                response dictionary when ``request`` is provided.
+        """
         if self.user_tag == "Guest":
             self.reason = "User is a Guest"
             return False
@@ -51,16 +94,16 @@ class API:
         response = requests.get(url, headers=self.headers)
         self.storage = response.json()
         reason = self.storage.get("reason")
-        
+
         if reason == "notFound":
             self.reason = "Player tag is incorrect"
-            return False  
-        
+            return False
+
         if reason == "accessDenied.invalidIp":
              self.reason = "Invalid IP"
              return False
-        
-        if self.json_data["token"] and self.check_player_api() == False: 
+
+        if self.json_data["token"] and self.check_player_api() == False:
             return False
 
         self.league = self.storage.get("leagueTier").get("name")
@@ -69,14 +112,14 @@ class API:
         else: self.league = 0
         self.townhall = self.storage.get("townHallLevel")
         self.builder_trophies = self.storage.get("builderBaseTrophies")
-        
+
         if self.townhall <= 17:
             self.townhallWeaponLevel = self.storage.get("townHallWeaponLevel")
-    
+
         self.recruiter_status = self.recruiting(self.storage)
         self.clantag = self.storage.get("clan", {}).get("tag", None)
-        if self.clantag: 
-            self.clantag = self.clantag[1:]            
+        if self.clantag:
+            self.clantag = self.clantag[1:]
         self.user_name = self.storage.get("name")
 
         if request:
@@ -96,15 +139,24 @@ class API:
             return response
 
         return True
-    
-    def recruiting(self, data : dict): 
+
+    def recruiting(self, data: dict[str, object]) -> bool:
+        """Return whether a player can recruit based on clan role membership.
+
+        Args:
+            data (dict): Player payload that includes clan and role fields.
+
+        Returns:
+            bool: ``True`` for leader/coleader/admin clan roles,
+                else ``False``.
+        """
         roles = ["leader", "coleader", "admin"]
-        
+
         clan_tag = data.get("clan", {}).get("tag", 0)
         if(clan_tag == 0):
             return False
-        
+
         if(data["role"].lower() not in roles):
             return False
-        
-        return True  
+
+        return True

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -1,5 +1,6 @@
-import requests
 from typing import Literal
+
+import requests
 
 REQUESTOPTIONS = Literal[
     "expLevel",

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -1,21 +1,51 @@
+"""API helpers for recruitee-facing clan search requests."""
+
 import requests
 
 
 class Recruitee:
-    def __init__(self, user_tag, townhall, league, headers):
+    """Wrap Clash API calls used by recruitee search routes."""
+
+    def __init__(
+        self,
+        user_tag: str | None,
+        headers: dict[str, str]
+    ) -> None:
+        """Initialize recruitee API context for clan search calls.
+
+        Args:
+            user_tag (str | None): Player tag for the current user.
+            townhall (int | None): Player Town Hall level.
+            league (int | None): Player league tier.
+            headers (dict[str, str]): HTTP headers for Clash API requests.
+        """
         self.headers = headers
         self.user_tag = user_tag
 
-    
-    def searchClan(self, filter, after = None):
+
+    def searchClan(
+        self,
+        filter: dict[str, object],
+        after: str | None = None,
+    ) -> dict[str, object]:
+        """Search clans using provided filters and optional pagination cursor.
+
+        Args:
+            filter (dict): Query filters forwarded to the Clash clan endpoint.
+            after (str | None, optional): Pagination cursor for the next page.
+
+        Returns:
+            dict: Response payload containing ``items``, ``after``, and
+                optional ``error`` metadata.
+        """
         url = f"https://api.clashofclans.com/v1/clans"
         if after:
             filter["after"] = after
-      
-        response = requests.get(url, 
-                                params = filter, 
+
+        response = requests.get(url,
+                                params = filter,
                                 headers = self.headers)
-        
+
         storage = response.json()
 
         error = None

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -1,4 +1,6 @@
 import requests
+
+
 class Recruitee:
     def __init__(self, user_tag, townhall, league, headers):
         self.headers = headers

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -1,42 +1,68 @@
-import requests
+"""API helpers for recruiter workflows and clan listing metadata."""
 
-from ..services.maxtownhall import refresh
+import requests
 
 
 class Recruiter:
+    """Wrap Clash API calls used by recruiter-facing routes."""
 
-    def __init__(self, user_tag, clan_tag, headers):
+    def __init__(self, clan_tag: str | None, headers: dict[str, str]) -> None:
+        """Initialize recruiter API context for a clan.
+
+        Args:
+            clan_tag (str | None): Clan tag used for clan API lookups.
+            headers (dict[str, str]): HTTP headers for Clash API requests.
+        """
         self.headers = headers
-        self.user_tag = user_tag
         self.clan_tag = clan_tag
-        self.requirements = []
-        # this may need to change
-        self.maxtownhall = refresh(self.headers)
-    
-    def pull_clan_requirements(self):
+        self.requirements: list[int | None] = []
 
-        response = requests.get(f"https://api.clashofclans.com/v1/clans?name=%23{self.clan_tag}", headers=self.headers)
+    def pull_clan_requirements(self) -> list[int | None]:
+        """Fetch and store current clan join requirements.
+
+        Returns:
+            list: Clan requirements in order `[league, builder, townhall]`.
+        """
+        response = requests.get(
+            f"https://api.clashofclans.com/v1/clans?name=%23{self.clan_tag}",
+            headers=self.headers,
+        )
         self.storage = response.json()
         long_list = self.storage.get("items")
         for i in range(len(long_list)):
             required_townhall = long_list[i].get('requiredTownhallLevel')
-            required_builder_trophies = long_list[i].get('requiredBuilderBaseTrophies')
+            required_builder_trophies = long_list[i].get(
+                "requiredBuilderBaseTrophies"
+            )
             required_league = 0
 
-        
-        self.new_clan_requirements(required_league, required_builder_trophies, required_townhall)
+
+        self.new_clan_requirements(
+            required_league,
+            required_builder_trophies,
+            required_townhall,
+        )
 
         return self.requirements
 
-    def lookup_clan(self, request=None):
+    def lookup_clan(self, request: str | None = None) -> dict[str, object]:
+        """Fetch clan metadata from the Clash API.
+
+        Args:
+            request (str | None, optional): Optional narrowed payload mode.
+                Supported values are ``"member_count"`` and
+                ``"description"``.
+
+        Returns:
+            dict: Clan metadata payload for the selected request mode.
         """
-        Used for looking up further clan stats
-        """
-        
-        response = requests.get(f"https://api.clashofclans.com/v1/clans/%23{self.clan_tag}", headers=self.headers)
-        response = response.json()  
-        rsp = {}
-        
+        response = requests.get(
+            f"https://api.clashofclans.com/v1/clans/%23{self.clan_tag}",
+            headers=self.headers,
+        )
+        response = response.json()
+        rsp: dict[str, object] = {}
+
         if request == None:
             rsp['name'] = response.get("name")
             rsp['type'] = response.get("type")
@@ -51,27 +77,43 @@ class Recruiter:
             rsp['warFrequency'] = response.get("warFrequency")
             rsp['clanPoints'] = response.get("clanPoints")
 
-        
+
         elif request == "member_count":
             rsp['member_count'] = response.get("members")
 
         elif request == "description":
             rsp["description"] = response.get("description")
-        
+
         return rsp
 
-        
-    def set_townhall_requirement(self, required_townhall):
+
+    def set_townhall_requirement(self, required_townhall: int | None) -> None:
+        """Set the required Town Hall value for this recruiter instance."""
         self.required_townhall = required_townhall
 
-    def set_builder_trophies_requirement(self, required_builder_trophies):
+    def set_builder_trophies_requirement(
+        self,
+        required_builder_trophies: int | None,
+    ) -> None:
+        """Set the required Builder Base trophies value."""
         self.required_builder_trophies = required_builder_trophies
 
-    def set_league_requirement(self, required_league):
+    def set_league_requirement(self, required_league: int | None) -> None:
+        """Set the required league value."""
         self.required_league = required_league
-     
-    def new_clan_requirements(self, required_league, required_builder_trophies, required_townhall):
+
+    def new_clan_requirements(
+        self,
+        required_league: int | None,
+        required_builder_trophies: int | None,
+        required_townhall: int | None,
+    ) -> None:
+        """Set all clan requirements and store them in canonical list order."""
         self.required_league = required_league
-        self.required_builder_trophies = required_builder_trophies 
+        self.required_builder_trophies = required_builder_trophies
         self.required_townhall = required_townhall
-        self.requirements = [self.required_league, self.required_builder_trophies, self.required_townhall]
+        self.requirements = [
+            self.required_league,
+            self.required_builder_trophies,
+            self.required_townhall,
+        ]

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -1,6 +1,6 @@
 import requests
 
-from ..services.maxtownhall import get_max_townhall_cached
+from ..services.maxtownhall import refresh
 
 
 class Recruiter:
@@ -11,7 +11,7 @@ class Recruiter:
         self.clan_tag = clan_tag
         self.requirements = []
         # this may need to change
-        self.maxtownhall = get_max_townhall_cached(self.headers)
+        self.maxtownhall = refresh(self.headers)
     
     def pull_clan_requirements(self):
 

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -1,5 +1,7 @@
 import requests
-from ..services.maxtownhall import refresh
+
+from ..services.maxtownhall import get_max_townhall_cached
+
 
 class Recruiter:
 
@@ -9,7 +11,7 @@ class Recruiter:
         self.clan_tag = clan_tag
         self.requirements = []
         # this may need to change
-        self.maxtownhall = refresh(self.headers)
+        self.maxtownhall = get_max_townhall_cached(self.headers)
     
     def pull_clan_requirements(self):
 

--- a/app.py
+++ b/app.py
@@ -1,16 +1,20 @@
+"""Flask application entrypoint and blueprint registration for ClashRecruit."""
+
 import os
+
 from flask import Flask
 from flask_cors import CORS
-from .services.clash_api_preflight import run_clash_api_preflight
+
 from .config import FLASKSECRETKEY
 from .routes.home_route import home_bp
-from .routes.session_state_route import session_state_bp
-from .routes.recruiter_route import recruiter_bp
-from .routes.recruitee_route import recruitee_bp
 from .routes.imported_clans_route import imported_clans_bp
-from .routes.search_clans_route import search_clans_bp
 from .routes.locations_route import locations_bp
+from .routes.recruitee_route import recruitee_bp
+from .routes.recruiter_route import recruiter_bp
 from .routes.saved_clans_route import saved_clans_bp
+from .routes.search_clans_route import search_clans_bp
+from .routes.session_state_route import session_state_bp
+from .services.clash_api_preflight import run_clash_api_preflight
 
 app = Flask(__name__)
 app.secret_key = FLASKSECRETKEY

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+"""Application configuration and environment-backed settings."""
+
 import os
 
 from dotenv import load_dotenv

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -8,10 +8,10 @@ from ..services.mongo_db_client import clan_collection
 
 home_bp = Blueprint("home", __name__)
 
-@home_bp.route("/", methods=["POST"])
+
+@home_bp.post("/")
 def home():
     """Validate a player, store session data, and return login details."""
-
     data = request.get_json()
 
     received_tag = data.get('playerTag')
@@ -40,19 +40,21 @@ def home():
         session["clan_tag"] = clan_tag
 
     return jsonify({
-        "message": status, 
+        "message": status,
         "receivedPlayerTag": reason,
         "recruit_status" : session.get("recruiter_status"),
         "player_name" : name,
         "clan_tag" : clan_tag
     })
 
-@home_bp.route("/database_count", methods=["GET"])
+
+@home_bp.get("/database_count")
 def database_count():
     """Return the current number of stored clans in the database."""
     return jsonify({"clan_count": clan_collection.count_documents({})})
 
-@home_bp.route("/logout", methods=["POST"])
+
+@home_bp.post("/logout")
 def logout():
     """Clear the current session and confirm logout."""
     session.clear()

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -21,7 +21,7 @@ def home():
     check_player_team = user.check_player()
     session["recruiter_status"] = user.recruiter_status
 
-    if check_player_team == True:
+    if check_player_team:
         status = True
         reason = "Valid User"
         name = user.user_name
@@ -42,9 +42,9 @@ def home():
     return jsonify({
         "message": status,
         "receivedPlayerTag": reason,
-        "recruit_status" : session.get("recruiter_status"),
-        "player_name" : name,
-        "clan_tag" : clan_tag
+        "recruit_status": session.get("recruiter_status"),
+        "player_name": name,
+        "clan_tag": clan_tag
     })
 
 

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -1,3 +1,5 @@
+"""Register home routes for login, logout, and database count requests."""
+
 from flask import Blueprint, jsonify, request, session
 
 from ..api.clash_api import API
@@ -8,7 +10,8 @@ home_bp = Blueprint("home", __name__)
 
 @home_bp.route("/", methods=["POST"])
 def home():
-    
+    """Validate a player, store session data, and return login details."""
+
     data = request.get_json()
 
     received_tag = data.get('playerTag')
@@ -46,9 +49,11 @@ def home():
 
 @home_bp.route("/database_count", methods=["GET"])
 def database_count():
+    """Return the current number of stored clans in the database."""
     return jsonify({"clan_count": clan_collection.count_documents({})})
 
 @home_bp.route("/logout", methods=["POST"])
 def logout():
+    """Clear the current session and confirm logout."""
     session.clear()
     return jsonify({"message": True})

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -1,7 +1,8 @@
-from flask import request, session, Blueprint, jsonify
-from ..services.mongo_db_client import clan_collection
+from flask import Blueprint, jsonify, request, session
+
 from ..api.clash_api import API
 from ..config import headers
+from ..services.mongo_db_client import clan_collection
 
 home_bp = Blueprint("home", __name__)
 

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -1,10 +1,12 @@
+"""Register routes for handling imported clans."""
+
 import re
 
 from flask import Blueprint, jsonify, request
 
-from ..services.import_clash_api_clans import ensure_imported_clan_inventory, get_imported_clan
+from ..services.import_clash_api_clans import (ensure_imported_clan_inventory,
+                                               get_imported_clan)
 from ..services.mongo_db_client import clan_collection
-
 
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
@@ -12,6 +14,7 @@ MAX_LIMIT = 200
 
 
 def _get_requested_limit(default_limit):
+    """Return the validated `limit` query param capped to allowed bounds."""
     raw_limit = request.args.get("limit")
     if raw_limit is None:
         return default_limit
@@ -25,6 +28,7 @@ def _get_requested_limit(default_limit):
 
 
 def _get_requested_offset():
+    """Return the validated `offset` query param with a minimum of zero."""
     raw_offset = request.args.get("offset")
     if raw_offset is None:
         return 0
@@ -38,6 +42,7 @@ def _get_requested_offset():
 
 
 def _build_imported_query(filters):
+    """Build a MongoDB query for imported clans from request filter data."""
     query = {
         "source": "clash_api_import",
     }
@@ -79,6 +84,7 @@ def _build_imported_query(filters):
 
 @imported_clans_bp.post("/imported_clans")
 def imported_clans_post():
+    """Return clan details for a tag or a filtered imported clan list."""
     default_limit = 10
     requested_limit = _get_requested_limit(default_limit)
     requested_offset = _get_requested_offset()

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify
+
 from ..services.mongo_db_client import location_collection
 
 locations_bp = Blueprint("locations", __name__)

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -6,13 +6,13 @@ from ..services.mongo_db_client import location_collection
 
 locations_bp = Blueprint("locations", __name__)
 
+
 @locations_bp.route("/clash_locations", methods=["GET"])
 def clash_locations():
     """Return all stored Clash of Clans locations as a JSON array."""
-        
     locations = list(location_collection.find({}, {"_id": 0}))
-    
+
     return jsonify(
         locations
     )
-    
+

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -1,12 +1,15 @@
+"""Register routes for retrieving stored Clash of Clans locations."""
+
 from flask import Blueprint, jsonify
 
 from ..services.mongo_db_client import location_collection
 
 locations_bp = Blueprint("locations", __name__)
 
-
 @locations_bp.route("/clash_locations", methods=["GET"])
 def clash_locations():
+    """Return all stored Clash of Clans locations as a JSON array."""
+        
     locations = list(location_collection.find({}, {"_id": 0}))
     
     return jsonify(

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -1,5 +1,9 @@
+"""Register routes for handling recruitee requests."""
+
 import re
+
 from flask import Blueprint, jsonify, request, session
+
 from ..services.import_clash_api_clans import ensure_imported_clan_inventory
 from ..services.mongo_db_client import clan_collection
 
@@ -7,7 +11,9 @@ recruitee_bp = Blueprint("recruitee", __name__)
 
 MAX_LIMIT = 200
 
+
 def _get_requested_limit(default_limit):
+    """Return the validated `limit` query param capped to allowed bounds."""
     raw_limit = request.args.get("limit")
     if raw_limit is None:
         return default_limit
@@ -19,7 +25,9 @@ def _get_requested_limit(default_limit):
 
     return max(1, min(parsed_limit, MAX_LIMIT))
 
+
 def _get_requested_offset():
+    """Return the validated `offset` query param with a minimum of zero."""
     raw_offset = request.args.get("offset")
     if raw_offset is None:
         return 0
@@ -33,15 +41,18 @@ def _get_requested_offset():
 
 
 def _should_refresh_imported_inventory():
+    """Return whether imported inventory should refresh for this request."""
     return _get_requested_offset() == 0
 
 
 def _should_include_total():
+    """Return whether the response should include paginated total metadata."""
     return request.args.get("includeTotal", "0") == "1"
 
 
 @recruitee_bp.get("/recruitee")
 def recruitee_get():
+    """Return clans for the current session with optional total metadata."""
     player_name = session.get("player_name", None)
     default_limit = 10
     requested_limit = _get_requested_limit(default_limit)
@@ -55,7 +66,9 @@ def recruitee_get():
     else:
         base_query = {
             "requirements.0": {"$lte": session.get("player_league")},
-            "requirements.1": {"$lte": session.get("player_builderbase_trophies")},
+            "requirements.1": {
+                "$lte": session.get("player_builderbase_trophies")
+            },
             "requirements.2": {"$lte": session.get("player_townhall")},
         }
 
@@ -80,6 +93,7 @@ def recruitee_get():
 
 @recruitee_bp.post("/recruitee")
 def recruitee_post():
+    """Return clan details by tag or a filtered clan list for recruitees."""
     DEFAULT_LIMIT = 10
     requested_limit = _get_requested_limit(DEFAULT_LIMIT)
     requested_offset = _get_requested_offset()

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -1,5 +1,5 @@
 import re
-from flask import Blueprint, session, jsonify, request
+from flask import Blueprint, jsonify, request, session
 from ..services.import_clash_api_clans import ensure_imported_clan_inventory
 from ..services.mongo_db_client import clan_collection
 

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -5,9 +5,7 @@ from ..services.mongo_db_client import clan_collection
 
 recruitee_bp = Blueprint("recruitee", __name__)
 
-
 MAX_LIMIT = 200
-
 
 def _get_requested_limit(default_limit):
     raw_limit = request.args.get("limit")
@@ -20,7 +18,6 @@ def _get_requested_limit(default_limit):
         return default_limit
 
     return max(1, min(parsed_limit, MAX_LIMIT))
-
 
 def _get_requested_offset():
     raw_offset = request.args.get("offset")

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -1,9 +1,11 @@
-from flask import Blueprint, request, session, jsonify
 from datetime import datetime, timedelta, timezone
+
+from flask import Blueprint, jsonify, request, session
+
 from ..api.recruiter_api import Recruiter
 from ..config import headers
+from ..services.maxtownhall import get_max_townhall_cached
 from ..services.mongo_db_client import clan_collection
-from ..services.maxtownhall import refresh
 
 recruiter_bp = Blueprint("recruiter", __name__)
 
@@ -34,7 +36,7 @@ def recruit():
             clan_description = user.lookup_clan("description")["description"]
             status = None
 
-        MAXTOWNHALL = refresh(headers)
+        MAXTOWNHALL = get_max_townhall_cached(headers)
         return jsonify({
             "oldRequiredLeague": required_league,
             "oldRequiredBuilderLeague": required_builder_league,

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -1,3 +1,5 @@
+"""Register routes for handling recruiter requests."""
+
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, jsonify, request, session
@@ -9,8 +11,10 @@ from ..services.mongo_db_client import clan_collection
 
 recruiter_bp = Blueprint("recruiter", __name__)
 
+
 @recruiter_bp.route("/recruiter", methods=['GET', 'POST'])
 def recruit():
+    """Return recruiter listing data or create, update, and remove listings."""
     if not session.get("recruiter_status"):
         return jsonify({"message": "Forbidden"}), 403
 
@@ -19,14 +23,16 @@ def recruit():
         "source": {"$ne": "clash_api_import"},
     })
 
-    user = Recruiter(session.get("player_tag"), session.get("clan_tag"), headers)
+    user = Recruiter(session.get("clan_tag"), headers)
     user.pull_clan_requirements()
     if request.method == "GET":
         if existing:
             required_league = existing["requirements"][0]
             required_builder_league = existing["requirements"][1]
             required_townhall = existing["requirements"][2]
-            clan_description = existing.get("clan_info", {}).get("description", "")
+            clan_description = existing.get("clan_info", {}).get(
+                "description", ""
+            )
             status = existing["expires"]
         else:
             required_league = user.requirements[0]
@@ -88,7 +94,10 @@ def recruit():
             status = data.get("expiry")
 
         clan_collection.update_one(
-            {"clan_tag": session.get("clan_tag"), "source": {"$ne": "clash_api_import"}},
+            {
+                "clan_tag": session.get("clan_tag"),
+                "source": {"$ne": "clash_api_import"},
+            },
             {"$set": query}
         )
         render_data = {

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -4,11 +4,10 @@ from flask import Blueprint, jsonify, request, session
 
 from ..api.recruiter_api import Recruiter
 from ..config import headers
-from ..services.maxtownhall import get_max_townhall_cached
+from ..services.maxtownhall import refresh
 from ..services.mongo_db_client import clan_collection
 
 recruiter_bp = Blueprint("recruiter", __name__)
-
 
 @recruiter_bp.route("/recruiter", methods=['GET', 'POST'])
 def recruit():
@@ -36,7 +35,7 @@ def recruit():
             clan_description = user.lookup_clan("description")["description"]
             status = None
 
-        MAXTOWNHALL = get_max_townhall_cached(headers)
+        MAXTOWNHALL = refresh(headers)
         return jsonify({
             "oldRequiredLeague": required_league,
             "oldRequiredBuilderLeague": required_builder_league,

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -1,3 +1,5 @@
+"""Register routes for saved a users saved clans."""
+
 from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import clan_collection, user_collection
@@ -8,6 +10,23 @@ MAX_SAVED_CLANS = 10
 
 
 def _hydrate_saved_clans(saved_clan_tags):
+    """Build saved clan response objects from stored clan tags.
+
+    For each saved clan tag, this helper looks up the matching clan listing in
+    the database and returns a normalized object for the response payload. If a
+    saved tag no longer has an active listing, the function still includes that
+    tag in the returned list with fallback values and marks the listing as
+    unavailable.
+
+    Args:
+        saved_clan_tags (list): The saved clan tags associated with the current
+            user.
+
+    Returns:
+        list: A list of hydrated saved clan objects in the same order as the
+            provided saved clan tags.
+    """
+
     listings = list(
         clan_collection.find(
             {"clan_tag": {"$in": saved_clan_tags}},
@@ -36,6 +55,8 @@ def _hydrate_saved_clans(saved_clan_tags):
 
 @saved_clans_bp.get("/saved-clans")
 def get_saved_clans():
+    """Return a JSON response with the current user's saved clans and limits."""
+
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -58,6 +79,12 @@ def get_saved_clans():
 
 @saved_clans_bp.post("/saved-clans/<clan_tag>")
 def add_saved_clan(clan_tag):
+    """Return a JSON response after saving a clan tag for the current user.
+
+    Args:
+        clan_tag (str): The clan tag to save for the current user.
+    """
+    
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -109,6 +136,13 @@ def add_saved_clan(clan_tag):
 
 @saved_clans_bp.delete("/saved-clans/<clan_tag>")
 def delete_saved_clan(clan_tag):
+    """Return a JSON response after removing a saved clan tag for the user.
+
+    Args:
+        clan_tag (str): The clan tag to remove from the current user's saved
+            clans.
+    """
+
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -2,7 +2,6 @@ from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import clan_collection, user_collection
 
-
 saved_clans_bp = Blueprint("saved_clans", __name__)
 
 MAX_SAVED_CLANS = 10

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -26,14 +26,21 @@ def _hydrate_saved_clans(saved_clan_tags):
         list: A list of hydrated saved clan objects in the same order as the
             provided saved clan tags.
     """
-
     listings = list(
         clan_collection.find(
             {"clan_tag": {"$in": saved_clan_tags}},
-            {"_id": 0, "clan_tag": 1, "name": 1, "requirements": 1, "clan_info": 1},
+            {
+                "_id": 0,
+                "clan_tag": 1,
+                "name": 1,
+                "requirements": 1,
+                "clan_info": 1,
+            },
         )
     )
-    listing_by_saved_tag = {listing["clan_tag"]: listing for listing in listings}
+    listing_by_saved_tag = {
+        listing["clan_tag"]: listing for listing in listings
+    }
 
     hydrated = []
     for saved_tag in saved_clan_tags:
@@ -43,8 +50,14 @@ def _hydrate_saved_clans(saved_clan_tags):
         hydrated.append(
             {
                 "clan_tag": saved_tag,
-                "name": (listing.get("name") if listing else None) or clan_info.get("name") or saved_tag,
-                "requirements": listing.get("requirements") if listing else None,
+                "name": (
+                    (listing.get("name") if listing else None)
+                    or clan_info.get("name")
+                    or saved_tag
+                ),
+                "requirements": (
+                    listing.get("requirements") if listing else None
+                ),
                 "clan_info": clan_info,
                 "listing_available": bool(listing),
             }
@@ -55,8 +68,7 @@ def _hydrate_saved_clans(saved_clan_tags):
 
 @saved_clans_bp.get("/saved-clans")
 def get_saved_clans():
-    """Return a JSON response with the current user's saved clans and limits."""
-
+    """Return the current user's saved clans and limits as JSON."""
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -84,7 +96,6 @@ def add_saved_clan(clan_tag):
     Args:
         clan_tag (str): The clan tag to save for the current user.
     """
-    
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -109,7 +120,10 @@ def add_saved_clan(clan_tag):
     if len(current_saved) >= MAX_SAVED_CLANS:
         return jsonify(
             {
-                "message": "You can save up to 10 clans. Remove one before saving another.",
+                "message": (
+                    "You can save up to 10 clans. Remove one before saving "
+                    "another."
+                ),
                 "count": len(current_saved),
                 "max_saved_clans": MAX_SAVED_CLANS,
             }
@@ -142,7 +156,6 @@ def delete_saved_clan(clan_tag):
         clan_tag (str): The clan tag to remove from the current user's saved
             clans.
     """
-
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -154,4 +167,6 @@ def delete_saved_clan(clan_tag):
         {"$pull": {"saved_clans": normalized_tag}},
     )
 
-    return jsonify({"message": "Saved clan removed.", "clan_tag": normalized_tag}), 200
+    return jsonify(
+        {"message": "Saved clan removed.", "clan_tag": normalized_tag}
+    ), 200

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -1,3 +1,5 @@
+"""Register routes for handling clan search requests."""
+
 from flask import Blueprint, jsonify, request, session
 
 from ..api.recruitee_api import Recruitee
@@ -6,8 +8,9 @@ from ..config import headers
 search_clans_bp = Blueprint("search_clans", __name__)
 
 
-@search_clans_bp.route("/search_clans", methods=["POST"])
+@search_clans_bp.post("/search_clans")
 def search_clans():
+    """Search clans using provided filters and return matching results."""
     filters = request.get_json() or {}
     user = Recruitee(
         session.get("player_tag"),
@@ -19,9 +22,15 @@ def search_clans():
 
     error = clans.get("error")
     if error:
-        if error.get("reason") == "badRequest" and error.get("message") == "At least one filtering parameter must exist":
+        if (
+            error.get("reason") == "badRequest"
+            and error.get("message")
+            == "At least one filtering parameter must exist"
+        ):
             return jsonify({
-                "error": "Add at least one random clan filter before searching.",
+                "error": (
+                    "Add at least one random clan filter before searching."
+                ),
                 "reason": error.get("reason"),
                 "message": error.get("message"),
             }), 400

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, jsonify, session
+from flask import Blueprint, jsonify, request, session
+
 from ..api.recruitee_api import Recruitee
 from ..config import headers
 

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -1,3 +1,5 @@
+"""Register routes for handling session state requests."""
+
 from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, session
@@ -8,56 +10,60 @@ from ..services.mongo_db_client import clan_collection
 
 session_state_bp = Blueprint("session_state", __name__)
 
+
 @session_state_bp.route("/session-state")
 def session_state():
-        username = session.get("player_name", "Guest")
-        recruit_status = bool(session.get("recruiter_status"))
-        has_active_listing = False
-        townhall = None
-        townhallWeaponLevel = None
-        clan_tag = session.get("clan_tag")
+    """Return current session status, player state, and active listing info."""
+    username = session.get("player_name", "Guest")
+    recruit_status = bool(session.get("recruiter_status"))
+    has_active_listing = False
+    townhall = None
+    townhallWeaponLevel = None
+    clan_tag = session.get("clan_tag")
 
-        if username != "Guest":  
-            player_tag = session.get("player_tag")
-            user = API(player_tag, None, headers)
-            user.check_player()
-            townhall = user.townhall
-            townhallWeaponLevel = user.townhallWeaponLevel
-            clan_tag = user.clantag or clan_tag
-        
-        if clan_tag:
-            now = datetime.now(timezone.utc)
-            listing = clan_collection.find_one(
-                {
-                    "clan_tag": clan_tag,
-                    "expires": {"$gt": now}
-                },
-                {"_id": 1}
-            )
-            has_active_listing = listing is not None
+    if username != "Guest":
+        player_tag = session.get("player_tag")
+        user = API(player_tag, None, headers)
+        user.check_player()
+        townhall = user.townhall
+        townhallWeaponLevel = user.townhallWeaponLevel
+        clan_tag = user.clantag or clan_tag
 
-        return jsonify(
-            username=username,
-            recruit_status=recruit_status,
-            has_active_listing=has_active_listing,
-            townhall=townhall,
-            townhallWeaponLevel=townhallWeaponLevel
+    if clan_tag:
+        now = datetime.now(timezone.utc)
+        listing = clan_collection.find_one(
+            {
+                "clan_tag": clan_tag,
+                "expires": {"$gt": now}
+            },
+            {"_id": 1}
         )
+        has_active_listing = listing is not None
+
+    return jsonify(
+        username=username,
+        recruit_status=recruit_status,
+        has_active_listing=has_active_listing,
+        townhall=townhall,
+        townhallWeaponLevel=townhallWeaponLevel
+    )
+
 
 @session_state_bp.route("/session-state/user-info")
 def session_state_user_info():
-        player_tag = session.get("player_tag", "Guest")
+    """Return extended player info for the current session when available."""
+    player_tag = session.get("player_tag", "Guest")
 
-        if player_tag == "Guest":
-            return jsonify({})
+    if player_tag == "Guest":
+        return jsonify({})
 
-        user = API(player_tag, None, headers)
-        stats = user.check_player([
-            "expLevel",
-            "leagueTier",
-            "builderBaseLeague",
-            "builderHallLevel",
-            "clan"
-        ])
+    user = API(player_tag, None, headers)
+    stats = user.check_player([
+        "expLevel",
+        "leagueTier",
+        "builderBaseLeague",
+        "builderHallLevel",
+        "clan"
+    ])
 
-        return jsonify(stats or {})
+    return jsonify(stats or {})

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timezone
+
 from flask import Blueprint, jsonify, session
-from ..services.mongo_db_client import clan_collection
+
 from ..api.clash_api import API
 from ..config import headers
+from ..services.mongo_db_client import clan_collection
 
 session_state_bp = Blueprint("session_state", __name__)
 

--- a/services/celery_app.py
+++ b/services/celery_app.py
@@ -1,8 +1,9 @@
+"""Shared Celery app configuration and periodic task scheduling."""
+
 import os
 from datetime import timedelta
 
 from celery import Celery
-
 
 app = Celery(
     "clash_recruiter",
@@ -22,5 +23,5 @@ app.conf.beat_schedule = {
 
 # Import task modules after creating the shared app so they register tasks
 # against this Celery instance.
-from . import refresh_db  # noqa: E402,F401
 from . import import_clash_api_clans  # noqa: E402,F401
+from . import refresh_db  # noqa: E402,F401

--- a/services/clash_api_preflight.py
+++ b/services/clash_api_preflight.py
@@ -3,11 +3,21 @@ Development preflight check for Clash API reachability.
 """
 
 import requests
+
 from ..config import headers
 
+
 def run_clash_api_preflight(headers=headers) -> None:
-    """
-    Call a lightweight Clash endpoint and raise if the API rejects this IP.
+    """Call a lightweight Clash endpoint and raise if the API rejects this IP.
+
+
+    Args:
+        headers (dict[str, str], optional): HTTP headers sent with the Clash of
+            Clans API request. Defaults to the module-level ``headers`` imported
+            from ``config``.
+
+    Raises:
+        Exception: Raised when the Clash API responds with an HTTP error status.
     """
     response = requests.get(
         "https://api.clashofclans.com/v1/locations/32000249/rankings/players?limit=1",

--- a/services/clash_api_preflight.py
+++ b/services/clash_api_preflight.py
@@ -1,6 +1,4 @@
-"""
-Development preflight check for Clash API reachability.
-"""
+"""Development preflight check for Clash API reachability."""
 
 import requests
 
@@ -13,14 +11,19 @@ def run_clash_api_preflight(headers=headers) -> None:
 
     Args:
         headers (dict[str, str], optional): HTTP headers sent with the Clash of
-            Clans API request. Defaults to the module-level ``headers`` imported
+            Clans API request. Defaults to the module-level ``headers``
+            imported
             from ``config``.
 
     Raises:
-        Exception: Raised when the Clash API responds with an HTTP error status.
+        Exception: Raised when the Clash API responds with an HTTP error
+            status.
     """
     response = requests.get(
-        "https://api.clashofclans.com/v1/locations/32000249/rankings/players?limit=1",
+        (
+            "https://api.clashofclans.com/v1/locations/32000249/"
+            "rankings/players?limit=1"
+        ),
         headers=headers,
     )
     status_code = response.status_code
@@ -28,7 +31,7 @@ def run_clash_api_preflight(headers=headers) -> None:
     if status_code >= 400:
         reason = response.json().get("reason", "unknown")
         raise Exception(f"HTTP {status_code}: {reason}")
-    
+
     return
 
 if __name__ == "__main__":

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -1,14 +1,29 @@
 import requests
+
 from ..config import headers
 from ..services.mongo_db_client import location_collection
 
-def get_locations(headers):
+
+def get_locations(headers=headers) -> list:
+    """Returns a list of locations returned from the Clash of Clans API.
+
+    Args:
+        headers (dict[str, str], optional): HTTP headers sent with the Clash of
+            Clans API request. Defaults to the module-level ``headers`` imported
+            from ``config``.
+
+    Returns:
+        list: The list of all locations returned from the Clash of Clans API.
+    """
+
     response = requests.get('https://api.clashofclans.com/v1/locations', headers=headers)
     list_of_locations = response.json().get("items", None)
 
     return list_of_locations
 
-def update_location_collection():
+def update_location_collection() -> None:
+    """Updates stored database locations on function call."""
+
     list_of_locations = get_locations(headers)
 
     for location in list_of_locations:

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -4,7 +4,7 @@ from ..config import headers
 from ..services.mongo_db_client import location_collection
 
 
-def get_locations(headers=headers) -> list:
+def get_locations(headers):
     """Returns a list of locations returned from the Clash of Clans API.
 
     Args:
@@ -21,7 +21,7 @@ def get_locations(headers=headers) -> list:
 
     return list_of_locations
 
-def update_location_collection() -> None:
+def update_location_collection():
     """Updates stored database locations on function call."""
 
     list_of_locations = get_locations(headers)

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -1,36 +1,41 @@
+"""Service for fetching and updating Clash of Clans location data."""
+
 import requests
 
 from ..config import headers
 from ..services.mongo_db_client import location_collection
 
 
-def get_locations(headers):
+def get_locations(headers) -> list:
     """Returns a list of locations returned from the Clash of Clans API.
 
     Args:
         headers (dict[str, str], optional): HTTP headers sent with the Clash of
-            Clans API request. Defaults to the module-level ``headers`` imported
+            Clans API request. Defaults to the module-level ``headers``
+            imported
             from ``config``.
 
     Returns:
         list: The list of all locations returned from the Clash of Clans API.
     """
-
-    response = requests.get('https://api.clashofclans.com/v1/locations', headers=headers)
+    response = requests.get(
+        "https://api.clashofclans.com/v1/locations",
+        headers=headers,
+    )
     list_of_locations = response.json().get("items", None)
 
     return list_of_locations
 
-def update_location_collection():
-    """Updates stored database locations on function call."""
 
+def update_location_collection() -> None:
+    """Updates stored database locations on function call."""
     list_of_locations = get_locations(headers)
 
     for location in list_of_locations:
         if location["name"] == "":
             continue
         if not location_collection.find_one({"id" : location.get("id")}):
-            location_collection.insert_one(            
+            location_collection.insert_one(
                 location
                 )
 

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -1,22 +1,30 @@
+"""Service for importing clans from the Clash of Clans API."""
+
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import requests
 from celery.signals import worker_ready
 
 from ..config import headers
 from .celery_app import app
-from .mongo_db_client import clan_collection, import_state_collection, location_collection
-
+from .mongo_db_client import (
+    clan_collection,
+    import_state_collection,
+    location_collection,
+)
 
 DISCOVERY_STALE_AFTER = timedelta(hours=6)
 IMPORTED_CLAN_RETENTION = timedelta(days=3)
 
 
-def _now():
+def _now() -> datetime:
+    """Return the current UTC time."""
     return datetime.now(timezone.utc)
 
 
-def _clean_tag(tag):
+def _clean_tag(tag: str | None) -> str | None:
+    """Return a cleaned clan tag, or ``None`` when the input is invalid."""
     if not tag:
         return None
     cleaned = str(tag).strip().upper().lstrip("#")
@@ -25,19 +33,26 @@ def _clean_tag(tag):
     return cleaned
 
 
-def _build_seed_key(seed):
+def _build_seed_key(seed: dict[str, Any]) -> str:
+    """Return a stable key used to persist seed pagination state."""
     return "|".join(
-        f"{key}:{value}" for key, value in sorted(seed.items()) if value not in (None, "")
+        f"{key}:{value}"
+        for key, value in sorted(seed.items())
+        if value not in (None, "")
     )
 
 
-def _seed_locations(limit=4):
-    locations = list(location_collection.find({}, {"_id": 0, "id": 1}).limit(limit))
+def _seed_locations(limit: int = 4) -> list[int]:
+    """Return a list of stored location IDs used to build discovery seeds."""
+    locations = list(
+        location_collection.find({}, {"_id": 0, "id": 1}).limit(limit)
+    )
     return [location.get("id") for location in locations if location.get("id")]
 
 
-def _build_discovery_seeds():
-    seeds = []
+def _build_discovery_seeds() -> list[dict[str, Any]]:
+    """Build the search seed combinations used for importing clans."""
+    seeds: list[dict[str, Any]] = []
     prefixes = ["a", "b", "c", "d", "e", "f", "m", "s", "t"]
     war_frequencies = ["always", "twicePerWeek", "oncePerWeek", "rarely"]
     member_ranges = [(10, 50), (15, 50), (20, 50), (25, 50)]
@@ -72,7 +87,8 @@ def _build_discovery_seeds():
     return seeds
 
 
-def _search_clans(filters):
+def _search_clans(filters: dict[str, Any]) -> dict[str, Any]:
+    """Search clans from Clash API and return items with cursor metadata."""
     response = requests.get(
         "https://api.clashofclans.com/v1/clans",
         params=filters,
@@ -87,11 +103,13 @@ def _search_clans(filters):
     }
 
 
-def _get_seed_state(seed_key):
+def _get_seed_state(seed_key: str) -> dict[str, Any] | None:
+    """Return persisted pagination state for a discovery seed key."""
     return import_state_collection.find_one({"seed_key": seed_key}, {"_id": 0})
 
 
-def _set_seed_after(seed_key, after):
+def _set_seed_after(seed_key: str, after: str | None) -> None:
+    """Persist the next-page cursor and run timestamp for a discovery seed."""
     import_state_collection.update_one(
         {"seed_key": seed_key},
         {
@@ -105,11 +123,13 @@ def _set_seed_after(seed_key, after):
     )
 
 
-def _reset_seed_after(seed_key):
+def _reset_seed_after(seed_key: str) -> None:
+    """Clear persisted pagination state for a discovery seed key."""
     _set_seed_after(seed_key, None)
 
 
-def _fetch_clan_detail(clan_tag):
+def _fetch_clan_detail(clan_tag: str | None) -> dict[str, Any] | None:
+    """Fetch detailed clan data from the Clash API for a clan tag."""
     clean_tag = _clean_tag(clan_tag)
     if not clean_tag:
         return None
@@ -128,7 +148,11 @@ def _fetch_clan_detail(clan_tag):
     return response.json()
 
 
-def _normalize_discovery_item(clan, seed_key):
+def _normalize_discovery_item(
+    clan: dict[str, Any],
+    seed_key: str,
+) -> dict[str, Any]:
+    """Normalize a search result clan into the imported clan document shape."""
     return {
         "clan_tag": _clean_tag(clan.get("tag")),
         "name": clan.get("name"),
@@ -150,7 +174,11 @@ def _normalize_discovery_item(clan, seed_key):
     }
 
 
-def _extract_requirements(search_clan=None, detail_clan=None):
+def _extract_requirements(
+    search_clan: dict[str, Any] | None = None,
+    detail_clan: dict[str, Any] | None = None,
+) -> list[int]:
+    """Extract listing requirements from API search and detail payloads."""
     search_clan = search_clan or {}
     detail_clan = detail_clan or {}
     required_league = 0
@@ -164,45 +192,84 @@ def _extract_requirements(search_clan=None, detail_clan=None):
         if detail_clan.get("requiredTownhallLevel") is not None
         else search_clan.get("requiredTownhallLevel", 0)
     )
-    return [required_league or 0, required_builder_trophies or 0, required_townhall or 0]
+    return [
+        required_league or 0,
+        required_builder_trophies or 0,
+        required_townhall or 0,
+    ]
 
 
-def _build_enriched_import_document(search_clan, detail_clan, seed_key):
+def _build_enriched_import_document(
+    search_clan: dict[str, Any],
+    detail_clan: dict[str, Any],
+    seed_key: str,
+) -> dict[str, Any]:
+    """Build an imported clan document enriched with detail endpoint data."""
     description = (detail_clan.get("description") or "").strip()
     return {
-        "clan_tag": _clean_tag(search_clan.get("tag") or detail_clan.get("tag")),
+        "clan_tag": _clean_tag(
+            search_clan.get("tag") or detail_clan.get("tag")
+        ),
         "name": detail_clan.get("name") or search_clan.get("name"),
         "source": "clash_api_import",
         "seed_key": seed_key,
-        "requirements": _extract_requirements(search_clan=search_clan, detail_clan=detail_clan),
+        "requirements": _extract_requirements(
+            search_clan=search_clan,
+            detail_clan=detail_clan,
+        ),
         "requirements_source": "clash_api",
         "last_discovered": _now(),
         "last_updated": _now(),
         "clan_info": {
             "description": description or None,
-            "location": detail_clan.get("location") or search_clan.get("location") or {},
-            "badge": detail_clan.get("badgeUrls", {}).get("medium") or search_clan.get("badgeUrls", {}).get("medium"),
-            "clan_level": detail_clan.get("clanLevel") if detail_clan.get("clanLevel") is not None else search_clan.get("clanLevel"),
-            "member_count": detail_clan.get("members") if detail_clan.get("members") is not None else search_clan.get("members"),
+            "location": (
+                detail_clan.get("location")
+                or search_clan.get("location")
+                or {}
+            ),
+            "badge": (
+                detail_clan.get("badgeUrls", {}).get("medium")
+                or search_clan.get("badgeUrls", {}).get("medium")
+            ),
+            "clan_level": (
+                detail_clan.get("clanLevel")
+                if detail_clan.get("clanLevel") is not None
+                else search_clan.get("clanLevel")
+            ),
+            "member_count": (
+                detail_clan.get("members")
+                if detail_clan.get("members") is not None
+                else search_clan.get("members")
+            ),
             "type": detail_clan.get("type") or search_clan.get("type"),
-            "warFrequency": detail_clan.get("warFrequency") or search_clan.get("warFrequency"),
-            "clanPoints": detail_clan.get("clanPoints") if detail_clan.get("clanPoints") is not None else search_clan.get("clanPoints"),
+            "warFrequency": (
+                detail_clan.get("warFrequency")
+                or search_clan.get("warFrequency")
+            ),
+            "clanPoints": (
+                detail_clan.get("clanPoints")
+                if detail_clan.get("clanPoints") is not None
+                else search_clan.get("clanPoints")
+            ),
         },
     }
 
 
-def _passes_quality_gate(clan):
+def _passes_quality_gate(clan: dict[str, Any]) -> bool:
+    """Return whether a clan satisfies minimum import quality thresholds."""
     members = clan.get("members") or 0
     clan_level = clan.get("clanLevel") or 0
     return members >= 20 and clan_level >= 5
 
 
 @app.task(name="discover_imported_clans_task")
-def discover_imported_clans_task():
+def discover_imported_clans_task() -> int:
+    """Run one discovery cycle as a Celery task and return import count."""
     return discover_imported_clans()
 
 
-def cleanup_old_imported_clans():
+def cleanup_old_imported_clans() -> int:
+    """Delete stale imported clans past retention and return delete count."""
     cutoff = _now() - IMPORTED_CLAN_RETENTION
     result = clan_collection.delete_many({
         "source": "clash_api_import",
@@ -211,7 +278,8 @@ def cleanup_old_imported_clans():
     return result.deleted_count
 
 
-def discover_imported_clans(max_seeds=12):
+def discover_imported_clans(max_seeds: int = 12) -> int:
+    """Discover and upsert imported clans using seed-based API searches."""
     max_imports_per_cycle = 30
     max_pages_per_seed = 3
     cleanup_old_imported_clans()
@@ -226,7 +294,10 @@ def discover_imported_clans(max_seeds=12):
         after = seed_state.get("after")
         pages_processed = 0
 
-        while pages_processed < max_pages_per_seed and discovered < max_imports_per_cycle:
+        while (
+            pages_processed < max_pages_per_seed
+            and discovered < max_imports_per_cycle
+        ):
             request_seed = seed.copy()
             if after:
                 request_seed["after"] = after
@@ -263,7 +334,11 @@ def discover_imported_clans(max_seeds=12):
                 if detail is None or not _passes_quality_gate(detail):
                     continue
 
-                enriched_document = _build_enriched_import_document(clan, detail, seed_key)
+                enriched_document = _build_enriched_import_document(
+                    clan,
+                    detail,
+                    seed_key,
+                )
                 clan_collection.update_one(
                     {"clan_tag": clan_tag, "source": "clash_api_import"},
                     {
@@ -272,8 +347,12 @@ def discover_imported_clans(max_seeds=12):
                             "source": enriched_document["source"],
                             "seed_key": enriched_document["seed_key"],
                             "requirements": enriched_document["requirements"],
-                            "requirements_source": enriched_document["requirements_source"],
-                            "last_discovered": enriched_document["last_discovered"],
+                            "requirements_source": enriched_document[
+                                "requirements_source"
+                            ],
+                            "last_discovered": enriched_document[
+                                "last_discovered"
+                            ],
                             "last_updated": enriched_document["last_updated"],
                             "clan_info": enriched_document["clan_info"],
                         },
@@ -293,7 +372,8 @@ def discover_imported_clans(max_seeds=12):
     return discovered
 
 
-def ensure_imported_clan_inventory(min_complete=30):
+def ensure_imported_clan_inventory(min_complete: int = 30) -> None:
+    """Ensure a recent minimum inventory of imported clans is available."""
     recent_threshold = _now() - DISCOVERY_STALE_AFTER
     complete_count = clan_collection.count_documents(
         {
@@ -308,12 +388,17 @@ def ensure_imported_clan_inventory(min_complete=30):
 
 
 @worker_ready.connect
-def run_import_refresh_on_worker_start(sender=None, **kwargs):
+def run_import_refresh_on_worker_start(
+    sender: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Queue an import discovery task when a Celery worker starts."""
     if sender is not None:
         sender.app.send_task("discover_imported_clans_task")
 
 
-def get_imported_clan(clan_tag):
+def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
+    """Return imported clan data, fetching and caching when absent."""
     clean_tag = _clean_tag(clan_tag)
     if not clean_tag:
         return None
@@ -341,7 +426,9 @@ def get_imported_clan(clan_tag):
                 "last_discovered": _now(),
                 "last_updated": _now(),
                 "clan_info": {
-                    "description": (detail.get("description") or "").strip() or None,
+                    "description": (
+                        (detail.get("description") or "").strip() or None
+                    ),
                     "location": detail.get("location") or {},
                     "badge": detail.get("badgeUrls", {}).get("medium"),
                     "clan_level": detail.get("clanLevel"),

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -1,55 +1,62 @@
-"""
-Caches the highest Townhall level for 24 hours into cache/. 
+"""Service for caching the highest Townhall level for 24 hours into cache."""
 
-Important Note:
-- If running this file standalone (not imported), you must provide the headers manually.
-"""
 import requests
 from diskcache import Cache
 
 cache = Cache("cache")
 
-def get_max_townhall(headers):
+
+def get_max_townhall(headers) -> int:
+    """Fetch and cache the current highest observed Town Hall level.
+
+    Args:
+        headers (dict[str, str]): HTTP headers sent with Clash of Clans API
+            requests.
+
+    Returns:
+        int: The highest Town Hall level from the top-ranked U.S. player.
+
+    Raises:
+        ValueError: If the API response does not include a valid
+            ``townHallLevel`` value.
     """
-    This function will return the current highest ranked player in the United States and pull their Townhall level.
-    """
-    response = requests.get('https://api.clashofclans.com/v1/locations/32000249/rankings/players?limit=1', headers=headers)
+    response = requests.get(
+        "https://api.clashofclans.com/v1/locations/32000249/"
+        "rankings/players?limit=1",
+        headers=headers,
+    )
     response = response.json()
     tag = response['items'][0]["tag"]
     tag = tag[1:]
-    response = requests.get(f"https://api.clashofclans.com/v1/players/%23{tag}", headers=headers)
+    response = requests.get(
+        f"https://api.clashofclans.com/v1/players/%23{tag}",
+        headers=headers,
+    )
     response = response.json()
-    MAXTOWNHALL = response.get("townHallLevel")
-    cache.set("MAXTOWNHALL", MAXTOWNHALL, 86400)
-    return MAXTOWNHALL
+    max_townhall = response.get("townHallLevel")
+    if max_townhall is None:
+        raise ValueError("Missing 'townHallLevel' in Clash API response.")
+
+    max_townhall = int(max_townhall)
+    cache.set("MAXTOWNHALL", max_townhall, 86400)
+    return max_townhall
 
 
-def refresh(headers):
+def refresh(headers) -> int:
+    """Return the cached maximum Town Hall level, refreshing when absent.
+
+    Args:
+        headers (dict[str, str]): HTTP headers sent with Clash of Clans API
+            requests when a refresh is needed.
+
+    Returns:
+        int: The cached maximum Town Hall level.
+
+    Raises:
+        ValueError: If a valid Town Hall level cannot be resolved.
     """
-    Returns the current highest Townhall level.
-    Checks the cache first, and calls the API only if needed.
-    """
-    if cache.get("MAXTOWNHALL") is None:
-        get_max_townhall(headers)
-    return cache.get("MAXTOWNHALL")
+    cached_value = cache.get("MAXTOWNHALL")
+    if cached_value is None:
+        return get_max_townhall(headers)
 
-if __name__ == "__main__":
-    
-    def check_cache():
-        """
-        This function is used to check the cache file for a value. If nothing is found, it will call get_max_townhall().
-        get_max_townhall() will return the MAXTOWNHALL constant into a cache folder. Access using cache.get("MAXTOWNHALL").
-        """
-        if cache.get("MAXTOWNHALL") == None:
-            get_max_townhall()
-            return False
-        return True
-    
-    cache_status = check_cache()
-    if cache_status:
-        print(f"Received from Cache. Maximum townhall = {cache.get('MAXTOWNHALL')}")
-        exit()
-    else:
-        print(f"Checked highest ranked player in the United States. Maximum townhall = {cache.get('MAXTOWNHALL')}")
-        exit()
-    
+    return int(cached_value)

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -1,23 +1,18 @@
 """
-Caches the highest Townhall level for 24 hours into cache. 
-"""
+Caches the highest Townhall level for 24 hours into cache/. 
 
+Important Note:
+- If running this file standalone (not imported), you must provide the headers manually.
+"""
 import requests
 from diskcache import Cache
 
 cache = Cache("cache")
 
-def get_max_townhall(headers) -> int:
-    """This function will return the current highest ranked player in the United States and pull their Townhall level.
-
-    Args:
-        headers (dict[str, str]): HTTP headers sent with the Clash of Clans API
-            requests.
-
-    Returns:
-        int: The townhall level returned by the API.
-    """    
-
+def get_max_townhall(headers):
+    """
+    This function will return the current highest ranked player in the United States and pull their Townhall level.
+    """
     response = requests.get('https://api.clashofclans.com/v1/locations/32000249/rankings/players?limit=1', headers=headers)
     response = response.json()
     tag = response['items'][0]["tag"]
@@ -29,19 +24,32 @@ def get_max_townhall(headers) -> int:
     return MAXTOWNHALL
 
 
-def get_max_townhall_cached(headers) -> int:
-    """Returns the current highest Townhall level.
+def refresh(headers):
+    """
+    Returns the current highest Townhall level.
     Checks the cache first, and calls the API only if needed.
-
-    Args:
-        headers (dict[str, str]): HTTP headers sent with the Clash of Clans API
-            requests.
-
-    Returns:
-        int: The townhall level returned by the API.
-    """    
-
+    """
     if cache.get("MAXTOWNHALL") is None:
         get_max_townhall(headers)
     return cache.get("MAXTOWNHALL")
+
+if __name__ == "__main__":
+    
+    def check_cache():
+        """
+        This function is used to check the cache file for a value. If nothing is found, it will call get_max_townhall().
+        get_max_townhall() will return the MAXTOWNHALL constant into a cache folder. Access using cache.get("MAXTOWNHALL").
+        """
+        if cache.get("MAXTOWNHALL") == None:
+            get_max_townhall()
+            return False
+        return True
+    
+    cache_status = check_cache()
+    if cache_status:
+        print(f"Received from Cache. Maximum townhall = {cache.get('MAXTOWNHALL')}")
+        exit()
+    else:
+        print(f"Checked highest ranked player in the United States. Maximum townhall = {cache.get('MAXTOWNHALL')}")
+        exit()
     

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -1,18 +1,23 @@
 """
-Caches the highest Townhall level for 24 hours into cache/. 
-
-Important Note:
-- If running this file standalone (not imported), you must provide the headers manually.
+Caches the highest Townhall level for 24 hours into cache. 
 """
+
 import requests
 from diskcache import Cache
 
 cache = Cache("cache")
 
-def get_max_townhall(headers):
-    """
-    This function will return the current highest ranked player in the United States and pull their Townhall level.
-    """
+def get_max_townhall(headers) -> int:
+    """This function will return the current highest ranked player in the United States and pull their Townhall level.
+
+    Args:
+        headers (dict[str, str]): HTTP headers sent with the Clash of Clans API
+            requests.
+
+    Returns:
+        int: The townhall level returned by the API.
+    """    
+
     response = requests.get('https://api.clashofclans.com/v1/locations/32000249/rankings/players?limit=1', headers=headers)
     response = response.json()
     tag = response['items'][0]["tag"]
@@ -24,32 +29,19 @@ def get_max_townhall(headers):
     return MAXTOWNHALL
 
 
-def refresh(headers):
-    """
-    Returns the current highest Townhall level.
+def get_max_townhall_cached(headers) -> int:
+    """Returns the current highest Townhall level.
     Checks the cache first, and calls the API only if needed.
-    """
+
+    Args:
+        headers (dict[str, str]): HTTP headers sent with the Clash of Clans API
+            requests.
+
+    Returns:
+        int: The townhall level returned by the API.
+    """    
+
     if cache.get("MAXTOWNHALL") is None:
         get_max_townhall(headers)
     return cache.get("MAXTOWNHALL")
-
-if __name__ == "__main__":
-    
-    def check_cache():
-        """
-        This function is used to check the cache file for a value. If nothing is found, it will call get_max_townhall().
-        get_max_townhall() will return the MAXTOWNHALL constant into a cache folder. Access using cache.get("MAXTOWNHALL").
-        """
-        if cache.get("MAXTOWNHALL") == None:
-            get_max_townhall()
-            return False
-        return True
-    
-    cache_status = check_cache()
-    if cache_status:
-        print(f"Received from Cache. Maximum townhall = {cache.get('MAXTOWNHALL')}")
-        exit()
-    else:
-        print(f"Checked highest ranked player in the United States. Maximum townhall = {cache.get('MAXTOWNHALL')}")
-        exit()
     

--- a/services/mongo_db_client.py
+++ b/services/mongo_db_client.py
@@ -1,6 +1,10 @@
+"""Create the MongoDB client and expose the application's collections."""
+
 import sys
+
 from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
+
 from ..config import DBURI
 
 uri = DBURI

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -1,6 +1,4 @@
-"""
-Refresh all clan membercount inside of the database.
-"""
+"""Refresh stored clan member counts on a periodic background schedule."""
 
 from datetime import datetime, timedelta, timezone
 
@@ -13,29 +11,34 @@ from .mongo_db_client import clan_collection
 
 THRESHOLD = timedelta(minutes=10)
 
+
 @app.task(name="refresh_membercount_task")
 def task():
+    """Run the member-count refresh cycle as a Celery task."""
     refresh_membercount()
 
 
 @worker_ready.connect
 def run_refresh_on_worker_start(sender=None, **kwargs):
-    """Queue the member count refresh task when the Celery worker starts."""
-    
+    """Queue the member-count refresh task when a Celery worker starts.
+
+    Args:
+        sender (Any, optional): Celery worker instance that triggered the
+            signal.
+        **kwargs: Additional Celery signal arguments.
+    """
     if sender is not None:
         sender.app.send_task("refresh_membercount_task")
 
+
 def refresh_membercount() -> None:
-    """Refresh the membercount of all clans that have not been updated in a certain
-    time determined by the threshold. 
-    """
-    
+    """Refresh member counts for clans with stale data."""
     outdated_entries = list(clan_collection.find({
         "last_updated" : { '$lte': datetime.now(timezone.utc) - THRESHOLD},
     }))
 
     for entry in outdated_entries:
-        clan = Recruiter(None, entry.get("clan_tag"), headers)
+        clan = Recruiter(entry.get("clan_tag"), headers)
         member_count = clan.lookup_clan("member_count").get("member_count")
         clan_collection.update_one(
                                    {
@@ -43,12 +46,12 @@ def refresh_membercount() -> None:
                                        "source": entry.get("source")
                                    },
                                    {'$set' :
-                                    {"last_updated" : datetime.now(timezone.utc),
+                                    {
+                                        "last_updated": datetime.now(
+                                            timezone.utc
+                                        ),
                                      "clan_info.member_count" : member_count
                                      }})
-
-    #testing
-    print(len(outdated_entries))
 
 if __name__ == "__main__":
     refresh_membercount()

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -3,11 +3,14 @@ Refresh all clan membercount inside of the database.
 """
 
 from datetime import datetime, timedelta, timezone
+
+from celery import Celery
+from celery.signals import worker_ready
+
 from ..api.recruiter_api import Recruiter
 from ..config import headers
-from .mongo_db_client import clan_collection
-from celery.signals import worker_ready
 from .celery_app import app
+from .mongo_db_client import clan_collection
 
 THRESHOLD = timedelta(minutes=10)
 
@@ -18,14 +21,16 @@ def task():
 
 @worker_ready.connect
 def run_refresh_on_worker_start(sender=None, **kwargs):
+    """Queue the member count refresh task when the Celery worker starts."""
+    
     if sender is not None:
         sender.app.send_task("refresh_membercount_task")
 
 def refresh_membercount() -> None:
-    """
-    Refresh the membercount of all clans that have not been updated in a certain
+    """Refresh the membercount of all clans that have not been updated in a certain
     time determined by the threshold. 
     """
+    
     outdated_entries = list(clan_collection.find({
         "last_updated" : { '$lte': datetime.now(timezone.utc) - THRESHOLD},
     }))
@@ -42,9 +47,6 @@ def refresh_membercount() -> None:
                                     {"last_updated" : datetime.now(timezone.utc),
                                      "clan_info.member_count" : member_count
                                      }})
-    
-    #testing
-    print(len(outdated_entries))
 
 if __name__ == "__main__":
     refresh_membercount()

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -4,7 +4,6 @@ Refresh all clan membercount inside of the database.
 
 from datetime import datetime, timedelta, timezone
 
-from celery import Celery
 from celery.signals import worker_ready
 
 from ..api.recruiter_api import Recruiter
@@ -47,6 +46,9 @@ def refresh_membercount() -> None:
                                     {"last_updated" : datetime.now(timezone.utc),
                                      "clan_info.member_count" : member_count
                                      }})
+
+    #testing
+    print(len(outdated_entries))
 
 if __name__ == "__main__":
     refresh_membercount()


### PR DESCRIPTION
Summary
This PR performs a Python style and documentation cleanup across the backend codebase to align with PEP 8 and the repo’s docstring conventions.

What Changed
Normalized line lengths to <= 79 characters in tracked Python files.
Removed trailing whitespace across Python modules.
Standardized blank-line spacing:
Two blank lines between top-level definitions.
Correct docstring spacing for modules, classes, and functions.
Improved and completed route/service/API docstrings for clarity and consistency.
Added module docstrings
Cleaned up API module quality:
Added type hints in api/clash_api.py and api/recruitee_api.py.
Refined api/recruiter_api.py constructor and updated call sites to match actual usage.
Removed unnecessary inline comments.
Removed broken if __name__ == "__main__" block from services/maxtownhall.py.
Updated services/maxtownhall.py so refresh() returns int (raises on invalid API payload instead of returning None).