### PR TITLE
Make backend imports side-effect free for DB init

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,11 +15,10 @@ from .routes.saved_clans_route import saved_clans_bp
 from .routes.search_clans_route import search_clans_bp
 from .routes.session_state_route import session_state_bp
 from .services.clash_api_preflight import run_clash_api_preflight
+from .services.mongo_db_client import initialize_mongo
 
 app = Flask(__name__)
 app.secret_key = FLASKSECRETKEY
-if os.getenv("CLASH_DEV_PREFLIGHT", "False").lower() == "true":
-    run_clash_api_preflight()
 
 CORS(
     app,
@@ -36,5 +35,15 @@ app.register_blueprint(search_clans_bp)
 app.register_blueprint(locations_bp)
 app.register_blueprint(saved_clans_bp)
 
+
+def run_startup_tasks_from_env() -> None:
+    """Run optional startup tasks gated by environment flags."""
+    if os.getenv("CLASH_DEV_PREFLIGHT", "False").lower() == "true":
+        run_clash_api_preflight()
+    if os.getenv("CLASH_INIT_DB_ON_START", "False").lower() == "true":
+        initialize_mongo()
+
+
 if __name__ == "__main__":
+    run_startup_tasks_from_env()
     app.run(port=5000)

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request, session
 
 from ..api.clash_api import API
 from ..config import headers
-from ..services.mongo_db_client import clan_collection
+from ..services.mongo_db_client import get_clan_collection
 
 home_bp = Blueprint("home", __name__)
 
@@ -51,6 +51,7 @@ def home():
 @home_bp.get("/database_count")
 def database_count():
     """Return the current number of stored clans in the database."""
+    clan_collection = get_clan_collection()
     return jsonify({"clan_count": clan_collection.count_documents({})})
 
 

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, request
 
 from ..services.import_clash_api_clans import (ensure_imported_clan_inventory,
                                                get_imported_clan)
-from ..services.mongo_db_client import clan_collection
+from ..services.mongo_db_client import get_clan_collection
 
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
@@ -85,6 +85,7 @@ def _build_imported_query(filters):
 @imported_clans_bp.post("/imported_clans")
 def imported_clans_post():
     """Return clan details for a tag or a filtered imported clan list."""
+    clan_collection = get_clan_collection()
     default_limit = 10
     requested_limit = _get_requested_limit(default_limit)
     requested_offset = _get_requested_offset()

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -2,7 +2,7 @@
 
 from flask import Blueprint, jsonify
 
-from ..services.mongo_db_client import location_collection
+from ..services.mongo_db_client import get_location_collection
 
 locations_bp = Blueprint("locations", __name__)
 
@@ -10,6 +10,7 @@ locations_bp = Blueprint("locations", __name__)
 @locations_bp.route("/clash_locations", methods=["GET"])
 def clash_locations():
     """Return all stored Clash of Clans locations as a JSON array."""
+    location_collection = get_location_collection()
     locations = list(location_collection.find({}, {"_id": 0}))
 
     return jsonify(

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -5,7 +5,7 @@ import re
 from flask import Blueprint, jsonify, request, session
 
 from ..services.import_clash_api_clans import ensure_imported_clan_inventory
-from ..services.mongo_db_client import clan_collection
+from ..services.mongo_db_client import get_clan_collection
 
 recruitee_bp = Blueprint("recruitee", __name__)
 
@@ -53,6 +53,7 @@ def _should_include_total():
 @recruitee_bp.get("/recruitee")
 def recruitee_get():
     """Return clans for the current session with optional total metadata."""
+    clan_collection = get_clan_collection()
     player_name = session.get("player_name", None)
     default_limit = 10
     requested_limit = _get_requested_limit(default_limit)
@@ -94,6 +95,7 @@ def recruitee_get():
 @recruitee_bp.post("/recruitee")
 def recruitee_post():
     """Return clan details by tag or a filtered clan list for recruitees."""
+    clan_collection = get_clan_collection()
     DEFAULT_LIMIT = 10
     requested_limit = _get_requested_limit(DEFAULT_LIMIT)
     requested_offset = _get_requested_offset()

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -7,7 +7,7 @@ from flask import Blueprint, jsonify, request, session
 from ..api.recruiter_api import Recruiter
 from ..config import headers
 from ..services.maxtownhall import refresh
-from ..services.mongo_db_client import clan_collection
+from ..services.mongo_db_client import get_clan_collection
 
 recruiter_bp = Blueprint("recruiter", __name__)
 
@@ -17,6 +17,8 @@ def recruit():
     """Return recruiter listing data or create, update, and remove listings."""
     if not session.get("recruiter_status"):
         return jsonify({"message": "Forbidden"}), 403
+
+    clan_collection = get_clan_collection()
 
     existing = clan_collection.find_one({
         "clan_tag": session.get("clan_tag"),

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -2,7 +2,7 @@
 
 from flask import Blueprint, jsonify, session
 
-from ..services.mongo_db_client import clan_collection, user_collection
+from ..services.mongo_db_client import get_clan_collection, get_user_collection
 
 saved_clans_bp = Blueprint("saved_clans", __name__)
 
@@ -26,6 +26,7 @@ def _hydrate_saved_clans(saved_clan_tags):
         list: A list of hydrated saved clan objects in the same order as the
             provided saved clan tags.
     """
+    clan_collection = get_clan_collection()
     listings = list(
         clan_collection.find(
             {"clan_tag": {"$in": saved_clan_tags}},
@@ -69,6 +70,7 @@ def _hydrate_saved_clans(saved_clan_tags):
 @saved_clans_bp.get("/saved-clans")
 def get_saved_clans():
     """Return the current user's saved clans and limits as JSON."""
+    user_collection = get_user_collection()
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -96,6 +98,7 @@ def add_saved_clan(clan_tag):
     Args:
         clan_tag (str): The clan tag to save for the current user.
     """
+    user_collection = get_user_collection()
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
@@ -156,6 +159,7 @@ def delete_saved_clan(clan_tag):
         clan_tag (str): The clan tag to remove from the current user's saved
             clans.
     """
+    user_collection = get_user_collection()
     player_tag = session.get("player_tag")
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, session
 
 from ..api.clash_api import API
 from ..config import headers
-from ..services.mongo_db_client import clan_collection
+from ..services.mongo_db_client import get_clan_collection
 
 session_state_bp = Blueprint("session_state", __name__)
 
@@ -30,6 +30,7 @@ def session_state():
         clan_tag = user.clantag or clan_tag
 
     if clan_tag:
+        clan_collection = get_clan_collection()
         now = datetime.now(timezone.utc)
         listing = clan_collection.find_one(
             {

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -3,7 +3,7 @@
 import requests
 
 from ..config import headers
-from ..services.mongo_db_client import location_collection
+from ..services.mongo_db_client import get_location_collection
 
 
 def get_locations(headers) -> list:
@@ -29,6 +29,7 @@ def get_locations(headers) -> list:
 
 def update_location_collection() -> None:
     """Updates stored database locations on function call."""
+    location_collection = get_location_collection()
     list_of_locations = get_locations(headers)
 
     for location in list_of_locations:

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -9,9 +9,9 @@ from celery.signals import worker_ready
 from ..config import headers
 from .celery_app import app
 from .mongo_db_client import (
-    clan_collection,
-    import_state_collection,
-    location_collection,
+    get_clan_collection,
+    get_import_state_collection,
+    get_location_collection,
 )
 
 DISCOVERY_STALE_AFTER = timedelta(hours=6)
@@ -21,6 +21,21 @@ IMPORTED_CLAN_RETENTION = timedelta(days=3)
 def _now() -> datetime:
     """Return the current UTC time."""
     return datetime.now(timezone.utc)
+
+
+def _clan_collection():
+    """Return the clans collection lazily."""
+    return get_clan_collection()
+
+
+def _import_state_collection():
+    """Return the import-state collection lazily."""
+    return get_import_state_collection()
+
+
+def _location_collection():
+    """Return the location collection lazily."""
+    return get_location_collection()
 
 
 def _clean_tag(tag: str | None) -> str | None:
@@ -45,7 +60,7 @@ def _build_seed_key(seed: dict[str, Any]) -> str:
 def _seed_locations(limit: int = 4) -> list[int]:
     """Return a list of stored location IDs used to build discovery seeds."""
     locations = list(
-        location_collection.find({}, {"_id": 0, "id": 1}).limit(limit)
+        _location_collection().find({}, {"_id": 0, "id": 1}).limit(limit)
     )
     return [location.get("id") for location in locations if location.get("id")]
 
@@ -105,12 +120,12 @@ def _search_clans(filters: dict[str, Any]) -> dict[str, Any]:
 
 def _get_seed_state(seed_key: str) -> dict[str, Any] | None:
     """Return persisted pagination state for a discovery seed key."""
-    return import_state_collection.find_one({"seed_key": seed_key}, {"_id": 0})
+    return _import_state_collection().find_one({"seed_key": seed_key}, {"_id": 0})
 
 
 def _set_seed_after(seed_key: str, after: str | None) -> None:
     """Persist the next-page cursor and run timestamp for a discovery seed."""
-    import_state_collection.update_one(
+    _import_state_collection().update_one(
         {"seed_key": seed_key},
         {
             "$set": {
@@ -271,7 +286,7 @@ def discover_imported_clans_task() -> int:
 def cleanup_old_imported_clans() -> int:
     """Delete stale imported clans past retention and return delete count."""
     cutoff = _now() - IMPORTED_CLAN_RETENTION
-    result = clan_collection.delete_many({
+    result = _clan_collection().delete_many({
         "source": "clash_api_import",
         "last_discovered": {"$lt": cutoff},
     })
@@ -339,7 +354,7 @@ def discover_imported_clans(max_seeds: int = 12) -> int:
                     detail,
                     seed_key,
                 )
-                clan_collection.update_one(
+                _clan_collection().update_one(
                     {"clan_tag": clan_tag, "source": "clash_api_import"},
                     {
                         "$set": {
@@ -375,7 +390,7 @@ def discover_imported_clans(max_seeds: int = 12) -> int:
 def ensure_imported_clan_inventory(min_complete: int = 30) -> None:
     """Ensure a recent minimum inventory of imported clans is available."""
     recent_threshold = _now() - DISCOVERY_STALE_AFTER
-    complete_count = clan_collection.count_documents(
+    complete_count = _clan_collection().count_documents(
         {
             "source": "clash_api_import",
             "last_discovered": {"$gte": recent_threshold},
@@ -403,7 +418,7 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
     if not clean_tag:
         return None
 
-    clan = clan_collection.find_one(
+    clan = _clan_collection().find_one(
         {"clan_tag": clean_tag, "source": "clash_api_import"},
         {"_id": 0},
     )
@@ -414,7 +429,7 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
     if detail is None:
         return None
 
-    clan_collection.update_one(
+    _clan_collection().update_one(
         {"clan_tag": clean_tag, "source": "clash_api_import"},
         {
             "$set": {
@@ -441,7 +456,7 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
         },
         upsert=True,
     )
-    return clan_collection.find_one(
+    return _clan_collection().find_one(
         {"clan_tag": clean_tag, "source": "clash_api_import"},
         {"_id": 0},
     )

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -1,9 +1,15 @@
 """Service for caching the highest Townhall level for 24 hours into cache."""
 
+from functools import lru_cache
+
 import requests
 from diskcache import Cache
 
-cache = Cache("cache")
+
+@lru_cache(maxsize=1)
+def get_cache() -> Cache:
+    """Return a cached diskcache handle initialized on first use."""
+    return Cache("cache")
 
 
 def get_max_townhall(headers) -> int:
@@ -38,7 +44,7 @@ def get_max_townhall(headers) -> int:
         raise ValueError("Missing 'townHallLevel' in Clash API response.")
 
     max_townhall = int(max_townhall)
-    cache.set("MAXTOWNHALL", max_townhall, 86400)
+    get_cache().set("MAXTOWNHALL", max_townhall, 86400)
     return max_townhall
 
 
@@ -55,7 +61,7 @@ def refresh(headers) -> int:
     Raises:
         ValueError: If a valid Town Hall level cannot be resolved.
     """
-    cached_value = cache.get("MAXTOWNHALL")
+    cached_value = get_cache().get("MAXTOWNHALL")
     if cached_value is None:
         return get_max_townhall(headers)
 

--- a/services/mongo_db_client.py
+++ b/services/mongo_db_client.py
@@ -1,52 +1,100 @@
-"""Create the MongoDB client and expose the application's collections."""
+"""Create lazy MongoDB accessors and explicit startup initialization hooks."""
 
-import sys
+from functools import lru_cache
+from typing import Any
 
+from pymongo.collection import Collection
+from pymongo.database import Database
+from pymongo.errors import PyMongoError
 from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
 
-from ..config import DBURI
+from .. import config
 
-uri = DBURI
-# Create a new client and connect to the server
-client = MongoClient(uri, server_api=ServerApi('1'))
-# Send a ping to confirm a successful connection
 
-try:
-    client.admin.command('ping')
-    print("Pinged your deployment. You successfully connected to MongoDB!")
-except Exception as e:
-    print(e)
-    sys.exit("Could not connect to DB. Check IP?")
+class MongoDependencyError(RuntimeError):
+    """Raised when MongoDB is required but unavailable."""
 
-clan_info_db = client["clan_info_db"]
-location_collection = clan_info_db["locations"]
-clan_collection = clan_info_db["clans"]
-user_collection = clan_info_db["users"]
-import_state_collection = clan_info_db["import_state"]
 
-clan_collection.create_index("expires", expireAfterSeconds=0)
-user_collection.create_index("player_tag", unique=True)
+@lru_cache(maxsize=1)
+def get_mongo_client() -> MongoClient:
+    """Return the shared MongoDB client for this process."""
+    db_uri = (config.DBURI or "").strip()
+    if not db_uri:
+        raise MongoDependencyError(
+            "DBURI is missing. Set DBURI before using MongoDB."
+        )
+    return MongoClient(db_uri, server_api=ServerApi("1"))
 
-try:
+
+def _get_database() -> Database[Any]:
+    """Return the application database handle."""
+    return get_mongo_client()["clan_info_db"]
+
+
+def get_location_collection() -> Collection[Any]:
+    """Return the locations collection."""
+    return _get_database()["locations"]
+
+
+def get_clan_collection() -> Collection[Any]:
+    """Return the clans collection."""
+    return _get_database()["clans"]
+
+
+def get_user_collection() -> Collection[Any]:
+    """Return the users collection."""
+    return _get_database()["users"]
+
+
+def get_import_state_collection() -> Collection[Any]:
+    """Return the import state collection."""
+    return _get_database()["import_state"]
+
+
+def _ping_mongo() -> None:
+    """Check MongoDB availability by issuing a ping command."""
+    try:
+        get_mongo_client().admin.command("ping")
+    except PyMongoError as exc:
+        raise MongoDependencyError("Could not connect to MongoDB.") from exc
+
+
+def _ensure_indexes() -> None:
+    """Create indexes required by the application."""
+    clan_collection = get_clan_collection()
+    user_collection = get_user_collection()
+    import_state_collection = get_import_state_collection()
+
+    clan_collection.create_index("expires", expireAfterSeconds=0)
+    user_collection.create_index("player_tag", unique=True)
     clan_collection.create_index([("clan_tag", 1), ("source", 1)], unique=True)
-except Exception:
-    pass
 
-clan_collection.create_index("source")
-clan_collection.create_index("last_updated")
-clan_collection.create_index([("last_updated", -1), ("clan_tag", 1)])
-clan_collection.create_index("requirements.0")
-clan_collection.create_index("requirements.1")
-clan_collection.create_index("requirements.2")
-clan_collection.create_index("last_discovered")
-clan_collection.create_index("last_enriched")
-clan_collection.create_index("detail_status")
-clan_collection.create_index("clan_info.location.id")
-clan_collection.create_index("clan_info.location.name")
-clan_collection.create_index("clan_info.member_count")
-clan_collection.create_index("clan_info.clan_level")
-clan_collection.create_index("clan_info.clanPoints")
-clan_collection.create_index("clan_info.warFrequency")
+    clan_collection.create_index("source")
+    clan_collection.create_index("last_updated")
+    clan_collection.create_index([("last_updated", -1), ("clan_tag", 1)])
+    clan_collection.create_index("requirements.0")
+    clan_collection.create_index("requirements.1")
+    clan_collection.create_index("requirements.2")
+    clan_collection.create_index("last_discovered")
+    clan_collection.create_index("last_enriched")
+    clan_collection.create_index("detail_status")
+    clan_collection.create_index("clan_info.location.id")
+    clan_collection.create_index("clan_info.location.name")
+    clan_collection.create_index("clan_info.member_count")
+    clan_collection.create_index("clan_info.clan_level")
+    clan_collection.create_index("clan_info.clanPoints")
+    clan_collection.create_index("clan_info.warFrequency")
 
-import_state_collection.create_index("seed_key", unique=True)
+    import_state_collection.create_index("seed_key", unique=True)
+
+
+def initialize_mongo() -> None:
+    """Run explicit startup checks and index initialization for MongoDB."""
+    _ping_mongo()
+    _ensure_indexes()
+
+
+def reset_mongo_client_cache() -> None:
+    """Reset cached Mongo client state for tests."""
+    get_mongo_client.cache_clear()

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -7,7 +7,7 @@ from celery.signals import worker_ready
 from ..api.recruiter_api import Recruiter
 from ..config import headers
 from .celery_app import app
-from .mongo_db_client import clan_collection
+from .mongo_db_client import get_clan_collection
 
 THRESHOLD = timedelta(minutes=10)
 
@@ -33,6 +33,7 @@ def run_refresh_on_worker_start(sender=None, **kwargs):
 
 def refresh_membercount() -> None:
     """Refresh member counts for clans with stale data."""
+    clan_collection = get_clan_collection()
     outdated_entries = list(clan_collection.find({
         "last_updated" : { '$lte': datetime.now(timezone.utc) - THRESHOLD},
     }))

--- a/tests/test_imports_side_effect_free.py
+++ b/tests/test_imports_side_effect_free.py
@@ -1,0 +1,73 @@
+"""Regression tests for import-time backend side effects."""
+
+import importlib
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_PARENT = PROJECT_ROOT.parent
+if str(PROJECT_PARENT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_PARENT))
+
+
+MODULES_TO_IMPORT = [
+    "ClashRecruit.app",
+    "ClashRecruit.routes.home_route",
+    "ClashRecruit.routes.session_state_route",
+    "ClashRecruit.routes.recruiter_route",
+    "ClashRecruit.routes.recruitee_route",
+    "ClashRecruit.routes.locations_route",
+    "ClashRecruit.routes.saved_clans_route",
+    "ClashRecruit.routes.imported_clans_route",
+    "ClashRecruit.services.import_clash_api_clans",
+    "ClashRecruit.services.refresh_db",
+]
+
+
+class ImportSideEffectsTests(unittest.TestCase):
+    def _clear_repo_modules(self):
+        for module_name in list(sys.modules):
+            if module_name == "ClashRecruit" or module_name.startswith("ClashRecruit."):
+                sys.modules.pop(module_name, None)
+
+    def test_importing_backend_modules_does_not_create_mongo_client(self):
+        self._clear_repo_modules()
+
+        with patch.dict(
+            os.environ,
+            {
+                "DBURI": "",
+                "CLASH_INIT_DB_ON_START": "False",
+                "CLASH_DEV_PREFLIGHT": "False",
+            },
+            clear=False,
+        ):
+            with patch("pymongo.mongo_client.MongoClient") as mock_client:
+                for module_name in MODULES_TO_IMPORT:
+                    importlib.import_module(module_name)
+
+        self.assertFalse(mock_client.called)
+
+    def test_backend_modules_import_cleanly_without_runtime_side_effects(self):
+        self._clear_repo_modules()
+
+        with patch.dict(
+            os.environ,
+            {
+                "DBURI": "",
+                "CLASH_INIT_DB_ON_START": "False",
+                "CLASH_DEV_PREFLIGHT": "False",
+            },
+            clear=False,
+        ):
+            for module_name in MODULES_TO_IMPORT:
+                with self.subTest(module=module_name):
+                    importlib.import_module(module_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Make backend imports side-effect free for DB init

## Summary
This PR aims to make backend imports side-effect free.

The main goal is to ensure importing backend modules does not require live infrastructure (MongoDB, disk cache, etc.) and does not run startup work implicitly.

## What Changed

### 1. Mongo access refactor (`services/mongo_db_client.py`)
- Replaced import-time Mongo initialization with **lazy getters**:
  - `get_mongo_client()`
  - `get_clan_collection()`, `get_user_collection()`, `get_location_collection()`, `get_import_state_collection()`
- Added explicit `DBURI` validation.
- Removed import-time ping/index creation side effects.
- Added explicit startup hook:
  - `initialize_mongo()`
- Added internal helpers for ping/index setup and optional cache reset for tests.

### 2. Explicit startup behavior (`app.py`)
- Moved startup infra behavior behind `run_startup_tasks_from_env()`.
- Startup DB/preflight tasks now run only when app startup explicitly triggers them (not on import).

### 3. Route/service callsite cleanup
- Replaced top-level imports of live Mongo collection objects with getter-based access inside functions in:
  - `routes/home_route.py`
  - `routes/session_state_route.py`
  - `routes/recruiter_route.py`
  - `routes/recruitee_route.py`
  - `routes/locations_route.py`
  - `routes/saved_clans_route.py`
  - `routes/imported_clans_route.py`
  - `services/get_locations.py`
  - `services/refresh_db.py`
  - `services/import_clash_api_clans.py`

### 4. Non-Mongo import safety
- Updated `services/maxtownhall.py` to lazily initialize diskcache (`get_cache()`), removing import-time filesystem/cache initialization.

### 5. Regression protection
- Added `tests/test_imports_side_effect_free.py` to guard against import-time side effects:
  - verifies imports do not create `MongoClient`
  - verifies backend modules import cleanly under import-safety env settings

## Why
Previously, importing backend modules could:
- create a Mongo client at import time,
- ping DB and create indexes during import,
- exit the process from imported modules,
- initialize diskcache/filesystem infra during import.

That behavior is horrible for CI, tests, and tooling. This PR makes startup dependencies explicit and runtime-only.

## Scope
- Focused on import safety and DB-init behavior.
- No intended business-logic/endpoint behavior changes beyond moving infra initialization out of import-time execution.

## Validation
- `python -m unittest tests/test_imports_side_effect_free.py` passes.
- Import smoke checks for app/routes/services pass without requiring live DB when startup flags are disabled.
