### PR TITLE
Test/backend pytest adoption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules/
 
 # testing
 coverage/
+.ruff_cache/
 
 # production build
 build/

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -102,8 +102,8 @@ class API:
             return False
 
         if reason == "accessDenied.invalidIp":
-             self.reason = "Invalid IP"
-             return False
+            self.reason = "Invalid IP"
+            return False
 
         if self.json_data["token"] and not self.check_player_api():
             return False

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -5,11 +5,7 @@ from typing import Literal
 import requests
 
 REQUESTOPTIONS = Literal[
-    "expLevel",
-    "leagueTier",
-    "builderBaseLeague",
-    "builderHallLevel",
-    "clan"
+    "expLevel", "leagueTier", "builderBaseLeague", "builderHallLevel", "clan"
 ]
 
 
@@ -33,9 +29,7 @@ class API:
         self.token = False
         self.user_tag = user_tag
         self.user_name = "Guest"
-        self.json_data = {
-            "token": api
-        }
+        self.json_data = {"token": api}
         self.clantag = ""
         self.recruiter_status = ""
         self.league = 0
@@ -69,9 +63,9 @@ class API:
         elif status == "invalid":
             self.reason = "API Token is incorrect"
 
-        else: 
+        else:
             self.reason = self.apistorage
-        
+
         return self.token
 
     def check_player(
@@ -110,10 +104,10 @@ class API:
 
         self.league = self.storage.get("leagueTier").get("name")
 
-        if self.league != 'Unranked':
+        if self.league != "Unranked":
             self.league = int(self.league[-2:])
 
-        else: 
+        else:
             self.league = 0
 
         self.townhall = self.storage.get("townHallLevel")
@@ -129,9 +123,7 @@ class API:
         self.user_name = self.storage.get("name")
 
         if request:
-            response = {
-                "player_tag": self.user_tag
-            }
+            response = {"player_tag": self.user_tag}
 
             for request_key in request:
                 response[request_key] = self.storage.get(request_key, None)
@@ -159,10 +151,10 @@ class API:
         roles = ["leader", "coleader", "admin"]
 
         clan_tag = data.get("clan", {}).get("tag", 0)
-        if(clan_tag == 0):
+        if clan_tag == 0:
             return False
 
-        if(data["role"].lower() not in roles):
+        if data["role"].lower() not in roles:
             return False
 
         return True

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -69,7 +69,9 @@ class API:
         elif status == "invalid":
             self.reason = "API Token is incorrect"
 
-        else: self.reason = self.apistorage
+        else: 
+            self.reason = self.apistorage
+        
         return self.token
 
     def check_player(
@@ -103,13 +105,17 @@ class API:
              self.reason = "Invalid IP"
              return False
 
-        if self.json_data["token"] and self.check_player_api() == False:
+        if self.json_data["token"] and not self.check_player_api():
             return False
 
         self.league = self.storage.get("leagueTier").get("name")
+
         if self.league != 'Unranked':
             self.league = int(self.league[-2:])
-        else: self.league = 0
+
+        else: 
+            self.league = 0
+
         self.townhall = self.storage.get("townHallLevel")
         self.builder_trophies = self.storage.get("builderBaseTrophies")
 

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -38,7 +38,7 @@ class Recruitee:
             dict: Response payload containing ``items``, ``after``, and
                 optional ``error`` metadata.
         """
-        url = f"https://api.clashofclans.com/v1/clans"
+        url = "https://api.clashofclans.com/v1/clans"
         if after:
             filter["after"] = after
 

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -6,11 +6,7 @@ import requests
 class Recruitee:
     """Wrap Clash API calls used by recruitee search routes."""
 
-    def __init__(
-        self,
-        user_tag: str | None,
-        headers: dict[str, str]
-    ) -> None:
+    def __init__(self, user_tag: str | None, headers: dict[str, str]) -> None:
         """Initialize recruitee API context for clan search calls.
 
         Args:
@@ -19,7 +15,6 @@ class Recruitee:
         """
         self.headers = headers
         self.user_tag = user_tag
-
 
     def searchClan(
         self,
@@ -40,9 +35,7 @@ class Recruitee:
         if after:
             filter["after"] = after
 
-        response = requests.get(url,
-                                params = filter,
-                                headers = self.headers)
+        response = requests.get(url, params=filter, headers=self.headers)
 
         storage = response.json()
 
@@ -55,7 +48,7 @@ class Recruitee:
             }
 
         return {
-        "items": storage.get("items", []),
-        "after": storage.get("paging", {}).get("cursors", {}).get("after"),
-        "error": error,
-    }
+            "items": storage.get("items", []),
+            "after": storage.get("paging", {}).get("cursors", {}).get("after"),
+            "error": error,
+        }

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -15,8 +15,6 @@ class Recruitee:
 
         Args:
             user_tag (str | None): Player tag for the current user.
-            townhall (int | None): Player Town Hall level.
-            league (int | None): Player league tier.
             headers (dict[str, str]): HTTP headers for Clash API requests.
         """
         self.headers = headers

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -63,7 +63,7 @@ class Recruiter:
         response = response.json()
         rsp: dict[str, object] = {}
 
-        if request == None:
+        if request is None:
             rsp['name'] = response.get("name")
             rsp['type'] = response.get("type")
             rsp['description'] = response.get("description")

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -30,12 +30,11 @@ class Recruiter:
         self.storage = response.json()
         long_list = self.storage.get("items")
         for i in range(len(long_list)):
-            required_townhall = long_list[i].get('requiredTownhallLevel')
+            required_townhall = long_list[i].get("requiredTownhallLevel")
             required_builder_trophies = long_list[i].get(
                 "requiredBuilderBaseTrophies"
             )
             required_league = 0
-
 
         self.new_clan_requirements(
             required_league,
@@ -64,43 +63,26 @@ class Recruiter:
         rsp: dict[str, object] = {}
 
         if request is None:
-            rsp['name'] = response.get("name")
-            rsp['type'] = response.get("type")
-            rsp['description'] = response.get("description")
-            rsp['location'] = {
+            rsp["name"] = response.get("name")
+            rsp["type"] = response.get("type")
+            rsp["description"] = response.get("description")
+            rsp["location"] = {
                 "id": response.get("location", {}).get("id"),
                 "name": response.get("location", {}).get("name"),
             }
-            rsp['badge'] = response.get("badgeUrls").get("medium")
-            rsp['clan_level'] = response.get("clanLevel")
-            rsp['member_count'] = response.get("members")
-            rsp['warFrequency'] = response.get("warFrequency")
-            rsp['clanPoints'] = response.get("clanPoints")
-
+            rsp["badge"] = response.get("badgeUrls").get("medium")
+            rsp["clan_level"] = response.get("clanLevel")
+            rsp["member_count"] = response.get("members")
+            rsp["warFrequency"] = response.get("warFrequency")
+            rsp["clanPoints"] = response.get("clanPoints")
 
         elif request == "member_count":
-            rsp['member_count'] = response.get("members")
+            rsp["member_count"] = response.get("members")
 
         elif request == "description":
             rsp["description"] = response.get("description")
 
         return rsp
-
-
-    def set_townhall_requirement(self, required_townhall: int | None) -> None:
-        """Set the required Town Hall value for this recruiter instance."""
-        self.required_townhall = required_townhall
-
-    def set_builder_trophies_requirement(
-        self,
-        required_builder_trophies: int | None,
-    ) -> None:
-        """Set the required Builder Base trophies value."""
-        self.required_builder_trophies = required_builder_trophies
-
-    def set_league_requirement(self, required_league: int | None) -> None:
-        """Set the required league value."""
-        self.required_league = required_league
 
     def new_clan_requirements(
         self,

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -28,13 +28,15 @@ class Recruiter:
             headers=self.headers,
         )
         self.storage = response.json()
-        long_list = self.storage.get("items")
+        long_list = self.storage.get("items") or []
+        required_townhall = 0
+        required_builder_trophies = 0
+        required_league = 0
         for i in range(len(long_list)):
             required_townhall = long_list[i].get("requiredTownhallLevel")
             required_builder_trophies = long_list[i].get(
                 "requiredBuilderBaseTrophies"
             )
-            required_league = 0
 
         self.new_clan_requirements(
             required_league,

--- a/app.py
+++ b/app.py
@@ -20,11 +20,7 @@ from .services.mongo_db_client import initialize_mongo
 app = Flask(__name__)
 app.secret_key = FLASKSECRETKEY
 
-CORS(
-    app,
-    supports_credentials=True,
-    origins=["http://localhost:3000"]
-)
+CORS(app, supports_credentials=True, origins=["http://localhost:3000"])
 
 app.register_blueprint(home_bp)
 app.register_blueprint(session_state_bp)

--- a/config.py
+++ b/config.py
@@ -7,9 +7,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 headers = {
-    "Content-Type" : "application/json",
-    "Authorization" : os.getenv("APIKEY")
+    "Content-Type": "application/json",
+    "Authorization": os.getenv("APIKEY"),
 }
 
-DBURI = os.getenv('DBURI')
+DBURI = os.getenv("DBURI")
 FLASKSECRETKEY = os.getenv("FLASKSECRETKEY")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ line-length = 79
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = ["-v", "-q"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 79
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.32.5
 diskcache==5.6.3
 celery==5.6.2
 redis==7.2.0
+ruff==0.15.9

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -14,8 +14,8 @@ def home():
     """Validate a player, store session data, and return login details."""
     data = request.get_json()
 
-    received_tag = data.get('playerTag')
-    received_token = data.get('apiToken')
+    received_tag = data.get("playerTag")
+    received_token = data.get("apiToken")
     session["player_tag"] = received_tag
     user = API(received_tag, received_token, headers)
     check_player_team = user.check_player()
@@ -39,13 +39,15 @@ def home():
         clan_tag = user.clantag
         session["clan_tag"] = clan_tag
 
-    return jsonify({
-        "message": status,
-        "receivedPlayerTag": reason,
-        "recruit_status": session.get("recruiter_status"),
-        "player_name": name,
-        "clan_tag": clan_tag
-    })
+    return jsonify(
+        {
+            "message": status,
+            "receivedPlayerTag": reason,
+            "recruit_status": session.get("recruiter_status"),
+            "player_name": name,
+            "clan_tag": clan_tag,
+        }
+    )
 
 
 @home_bp.get("/database_count")

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -4,8 +4,10 @@ import re
 
 from flask import Blueprint, jsonify, request
 
-from ..services.import_clash_api_clans import (ensure_imported_clan_inventory,
-                                               get_imported_clan)
+from ..services.import_clash_api_clans import (
+    ensure_imported_clan_inventory,
+    get_imported_clan,
+)
 from ..services.mongo_db_client import get_clan_collection
 
 imported_clans_bp = Blueprint("imported_clans", __name__)

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -107,20 +107,24 @@ def imported_clans_post():
     total = clan_collection.count_documents(query)
     items = list(
         clan_collection.find(query, {"_id": 0})
-        .sort([
-            ("last_discovered", -1),
-            ("last_updated", -1),
-            ("clan_info.clan_level", -1),
-            ("clan_info.member_count", -1),
-            ("clan_tag", 1),
-        ])
+        .sort(
+            [
+                ("last_discovered", -1),
+                ("last_updated", -1),
+                ("clan_info.clan_level", -1),
+                ("clan_info.member_count", -1),
+                ("clan_tag", 1),
+            ]
+        )
         .skip(requested_offset)
         .limit(requested_limit)
     )
 
-    return jsonify({
-        "items": items,
-        "total": total,
-        "limit": requested_limit,
-        "offset": requested_offset,
-    })
+    return jsonify(
+        {
+            "items": items,
+            "total": total,
+            "limit": requested_limit,
+            "offset": requested_offset,
+        }
+    )

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -13,7 +13,4 @@ def clash_locations():
     location_collection = get_location_collection()
     locations = list(location_collection.find({}, {"_id": 0}))
 
-    return jsonify(
-        locations
-    )
-
+    return jsonify(locations)

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -84,12 +84,14 @@ def recruitee_get():
         return jsonify(data)
 
     total = clan_collection.count_documents(base_query)
-    return jsonify({
-        "items": data,
-        "total": total,
-        "limit": requested_limit,
-        "offset": requested_offset,
-    })
+    return jsonify(
+        {
+            "items": data,
+            "total": total,
+            "limit": requested_limit,
+            "offset": requested_offset,
+        }
+    )
 
 
 @recruitee_bp.post("/recruitee")
@@ -167,9 +169,11 @@ def recruitee_post():
         return jsonify(data)
 
     total = clan_collection.count_documents(query)
-    return jsonify({
-        "items": data,
-        "total": total,
-        "limit": requested_limit,
-        "offset": requested_offset,
-    })
+    return jsonify(
+        {
+            "items": data,
+            "total": total,
+            "limit": requested_limit,
+            "offset": requested_offset,
+        }
+    )

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -152,7 +152,10 @@ def recruitee_post():
 
     location_id = filters.get("location_id", None)
     if location_id:
-        query["clan_info.location.id"] = int(location_id)
+        try:
+            query["clan_info.location.id"] = int(location_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "Invalid location_id"}), 400
     else:
         location_name = filters.get("location", None)
         if location_name:

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -57,7 +57,24 @@ def recruit():
             }
         )
 
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
+    listing_status = data.get("status")
+    if listing_status not in {"new", "update", "removeListing"}:
+        return jsonify({"message": "Invalid listing status."}), 400
+
+    if listing_status == "removeListing":
+        deleted = clan_collection.delete_one(
+            {
+                "clan_tag": session.get("clan_tag"),
+                "source": {"$ne": "clash_api_import"},
+            }
+        )
+        if deleted.deleted_count:
+            message = "Successfully deleted entry."
+            return jsonify({"message": message}), 200
+
+        return jsonify({"message": "Failed to delete."}), 404
+
     new_required_league = data.get("requiredLeague", None)
     new_required_builder_league = data.get("requiredBuilderLeague", None)
     new_required_townhall = data.get("requiredTownhall", None)
@@ -66,7 +83,7 @@ def recruit():
     user.requirements[2] = new_required_townhall
     clan_info = user.lookup_clan()
 
-    if data.get("status") == "new":
+    if listing_status == "new":
         expiry = datetime.now(timezone.utc) + timedelta(days=7)
         clan_info["description"] = data.get("description")
         data = {
@@ -84,7 +101,7 @@ def recruit():
         render_data["status"] = expiry
         render_data["message"] = "Listing created successfully."
 
-    elif data.get("status") == "update":
+    elif listing_status == "update":
         query = {
             "source": "live_listing",
             "requirements": user.requirements,
@@ -110,18 +127,5 @@ def recruit():
             "status": status,
             "message": "Listing updated successfully.",
         }
-
-    elif data.get("status") == "removeListing":
-        deleted = clan_collection.delete_one(
-            {
-                "clan_tag": session.get("clan_tag"),
-                "source": {"$ne": "clash_api_import"},
-            }
-        )
-        if deleted.deleted_count:
-            message = "Successfully deleted entry."
-            return jsonify({"message": message}), 200
-
-        return jsonify({"message": "Failed to delete."}), 404
 
     return jsonify(render_data), 200

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -12,7 +12,7 @@ from ..services.mongo_db_client import get_clan_collection
 recruiter_bp = Blueprint("recruiter", __name__)
 
 
-@recruiter_bp.route("/recruiter", methods=['GET', 'POST'])
+@recruiter_bp.route("/recruiter", methods=["GET", "POST"])
 def recruit():
     """Return recruiter listing data or create, update, and remove listings."""
     if not session.get("recruiter_status"):
@@ -20,10 +20,12 @@ def recruit():
 
     clan_collection = get_clan_collection()
 
-    existing = clan_collection.find_one({
-        "clan_tag": session.get("clan_tag"),
-        "source": {"$ne": "clash_api_import"},
-    })
+    existing = clan_collection.find_one(
+        {
+            "clan_tag": session.get("clan_tag"),
+            "source": {"$ne": "clash_api_import"},
+        }
+    )
 
     user = Recruiter(session.get("clan_tag"), headers)
     user.pull_clan_requirements()
@@ -44,14 +46,16 @@ def recruit():
             status = None
 
         MAXTOWNHALL = refresh(headers)
-        return jsonify({
-            "oldRequiredLeague": required_league,
-            "oldRequiredBuilderLeague": required_builder_league,
-            "oldRequiredTownhall": required_townhall,
-            "MAXTOWNHALL": MAXTOWNHALL,
-            "clanDescription": clan_description,
-            "status": status
-        })
+        return jsonify(
+            {
+                "oldRequiredLeague": required_league,
+                "oldRequiredBuilderLeague": required_builder_league,
+                "oldRequiredTownhall": required_townhall,
+                "MAXTOWNHALL": MAXTOWNHALL,
+                "clanDescription": clan_description,
+                "status": status,
+            }
+        )
 
     data = request.get_json()
     new_required_league = data.get("requiredLeague", None)
@@ -73,7 +77,7 @@ def recruit():
             "player_tag": session.get("player_tag"),
             "clan_info": clan_info,
             "last_updated": datetime.now(timezone.utc),
-            "expires": expiry
+            "expires": expiry,
         }
         render_data = data.copy()
         clan_collection.insert_one(data)
@@ -85,7 +89,7 @@ def recruit():
             "source": "live_listing",
             "requirements": user.requirements,
             "clan_info.description": data.get("description"),
-            "last_updated": datetime.now(timezone.utc)
+            "last_updated": datetime.now(timezone.utc),
         }
 
         if data.get("updateExpiry") is True:
@@ -100,18 +104,20 @@ def recruit():
                 "clan_tag": session.get("clan_tag"),
                 "source": {"$ne": "clash_api_import"},
             },
-            {"$set": query}
+            {"$set": query},
         )
         render_data = {
             "status": status,
-            "message": "Listing updated successfully."
+            "message": "Listing updated successfully.",
         }
 
     elif data.get("status") == "removeListing":
-        deleted = clan_collection.delete_one({
-            "clan_tag": session.get("clan_tag"),
-            "source": {"$ne": "clash_api_import"},
-        })
+        deleted = clan_collection.delete_one(
+            {
+                "clan_tag": session.get("clan_tag"),
+                "source": {"$ne": "clash_api_import"},
+            }
+        )
         if deleted.deleted_count:
             message = "Successfully deleted entry."
             return jsonify({"message": message}), 200

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -75,10 +75,13 @@ def get_saved_clans():
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
 
-    user_doc = user_collection.find_one(
-        {"player_tag": player_tag},
-        {"_id": 0, "saved_clans": 1},
-    ) or {}
+    user_doc = (
+        user_collection.find_one(
+            {"player_tag": player_tag},
+            {"_id": 0, "saved_clans": 1},
+        )
+        or {}
+    )
     saved_clan_tags = user_doc.get("saved_clans", [])
     hydrated = _hydrate_saved_clans(saved_clan_tags)
 
@@ -105,10 +108,13 @@ def add_saved_clan(clan_tag):
 
     normalized_tag = clan_tag.lstrip("#")
 
-    current_doc = user_collection.find_one(
-        {"player_tag": player_tag},
-        {"_id": 0, "saved_clans": 1},
-    ) or {}
+    current_doc = (
+        user_collection.find_one(
+            {"player_tag": player_tag},
+            {"_id": 0, "saved_clans": 1},
+        )
+        or {}
+    )
     current_saved = current_doc.get("saved_clans", [])
     if normalized_tag in current_saved:
         return jsonify(

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -25,17 +25,21 @@ def search_clans():
             and error.get("message")
             == "At least one filtering parameter must exist"
         ):
-            return jsonify({
-                "error": (
-                    "Add at least one random clan filter before searching."
-                ),
-                "reason": error.get("reason"),
-                "message": error.get("message"),
-            }), 400
+            return jsonify(
+                {
+                    "error": (
+                        "Add at least one random clan filter before searching."
+                    ),
+                    "reason": error.get("reason"),
+                    "message": error.get("message"),
+                }
+            ), 400
 
-        return jsonify({
-            "error": error.get("message") or "Failed to search clans.",
-            "reason": error.get("reason"),
-        }), error.get("status") or 400
+        return jsonify(
+            {
+                "error": error.get("message") or "Failed to search clans.",
+                "reason": error.get("reason"),
+            }
+        ), error.get("status") or 400
 
     return jsonify(clans)

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -14,8 +14,6 @@ def search_clans():
     filters = request.get_json() or {}
     user = Recruitee(
         session.get("player_tag"),
-        session.get("player_townhall"),
-        session.get("player_league"),
         headers,
     )
     clans = user.searchClan(filters, filters.get("after"))

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -33,11 +33,7 @@ def session_state():
         clan_collection = get_clan_collection()
         now = datetime.now(timezone.utc)
         listing = clan_collection.find_one(
-            {
-                "clan_tag": clan_tag,
-                "expires": {"$gt": now}
-            },
-            {"_id": 1}
+            {"clan_tag": clan_tag, "expires": {"$gt": now}}, {"_id": 1}
         )
         has_active_listing = listing is not None
 
@@ -46,7 +42,7 @@ def session_state():
         recruit_status=recruit_status,
         has_active_listing=has_active_listing,
         townhall=townhall,
-        townhallWeaponLevel=townhallWeaponLevel
+        townhallWeaponLevel=townhallWeaponLevel,
     )
 
 
@@ -59,12 +55,14 @@ def session_state_user_info():
         return jsonify({})
 
     user = API(player_tag, None, headers)
-    stats = user.check_player([
-        "expLevel",
-        "leagueTier",
-        "builderBaseLeague",
-        "builderHallLevel",
-        "clan"
-    ])
+    stats = user.check_player(
+        [
+            "expLevel",
+            "leagueTier",
+            "builderBaseLeague",
+            "builderHallLevel",
+            "clan",
+        ]
+    )
 
     return jsonify(stats or {})

--- a/services/celery_app.py
+++ b/services/celery_app.py
@@ -8,6 +8,10 @@ from celery import Celery
 app = Celery(
     "clash_recruiter",
     broker=os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+    include=[
+        "ClashRecruit.services.import_clash_api_clans",
+        "ClashRecruit.services.refresh_db",
+    ],
 )
 
 app.conf.beat_schedule = {
@@ -20,8 +24,3 @@ app.conf.beat_schedule = {
         "schedule": timedelta(days=1),
     },
 }
-
-# Import task modules after creating the shared app so they register tasks
-# against this Celery instance.
-from . import import_clash_api_clans  # noqa: E402,F401
-from . import refresh_db  # noqa: E402,F401

--- a/services/clash_api_preflight.py
+++ b/services/clash_api_preflight.py
@@ -34,5 +34,6 @@ def run_clash_api_preflight(headers=headers) -> None:
 
     return
 
+
 if __name__ == "__main__":
     run_clash_api_preflight()

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -35,10 +35,9 @@ def update_location_collection() -> None:
     for location in list_of_locations:
         if location["name"] == "":
             continue
-        if not location_collection.find_one({"id" : location.get("id")}):
-            location_collection.insert_one(
-                location
-                )
+        if not location_collection.find_one({"id": location.get("id")}):
+            location_collection.insert_one(location)
+
 
 if __name__ == "__main__":
     update_location_collection()

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -75,29 +75,35 @@ def _build_discovery_seeds() -> list[dict[str, Any]]:
     location_ids = _seed_locations(limit=6)
 
     for prefix in prefixes:
-        seeds.append({
-            "name": prefix,
-            "minMembers": 10,
-            "limit": 10,
-        })
+        seeds.append(
+            {
+                "name": prefix,
+                "minMembers": 10,
+                "limit": 10,
+            }
+        )
 
     for war_frequency in war_frequencies:
         for min_members, max_members in member_ranges:
-            seeds.append({
-                "warFrequency": war_frequency,
-                "minMembers": min_members,
-                "maxMembers": max_members,
-                "limit": 10,
-            })
+            seeds.append(
+                {
+                    "warFrequency": war_frequency,
+                    "minMembers": min_members,
+                    "maxMembers": max_members,
+                    "limit": 10,
+                }
+            )
 
     for location_id in location_ids:
         for min_level in min_levels:
-            seeds.append({
-                "locationId": location_id,
-                "minClanLevel": min_level,
-                "minMembers": 10,
-                "limit": 10,
-            })
+            seeds.append(
+                {
+                    "locationId": location_id,
+                    "minClanLevel": min_level,
+                    "minMembers": 10,
+                    "limit": 10,
+                }
+            )
 
     return seeds
 
@@ -289,10 +295,12 @@ def discover_imported_clans_task() -> int:
 def cleanup_old_imported_clans() -> int:
     """Delete stale imported clans past retention and return delete count."""
     cutoff = _now() - IMPORTED_CLAN_RETENTION
-    result = _clan_collection().delete_many({
-        "source": "clash_api_import",
-        "last_discovered": {"$lt": cutoff},
-    })
+    result = _clan_collection().delete_many(
+        {
+            "source": "clash_api_import",
+            "last_discovered": {"$lt": cutoff},
+        }
+    )
     return result.deleted_count
 
 

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -120,7 +120,10 @@ def _search_clans(filters: dict[str, Any]) -> dict[str, Any]:
 
 def _get_seed_state(seed_key: str) -> dict[str, Any] | None:
     """Return persisted pagination state for a discovery seed key."""
-    return _import_state_collection().find_one({"seed_key": seed_key}, {"_id": 0})
+    return _import_state_collection().find_one(
+        {"seed_key": seed_key},
+        {"_id": 0},
+    )
 
 
 def _set_seed_after(seed_key: str, after: str | None) -> None:

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -32,7 +32,7 @@ def get_max_townhall(headers) -> int:
         headers=headers,
     )
     response = response.json()
-    tag = response['items'][0]["tag"]
+    tag = response["items"][0]["tag"]
     tag = tag[1:]
     response = requests.get(
         f"https://api.clashofclans.com/v1/players/%23{tag}",

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -34,25 +34,29 @@ def run_refresh_on_worker_start(sender=None, **kwargs):
 def refresh_membercount() -> None:
     """Refresh member counts for clans with stale data."""
     clan_collection = get_clan_collection()
-    outdated_entries = list(clan_collection.find({
-        "last_updated" : { '$lte': datetime.now(timezone.utc) - THRESHOLD},
-    }))
+    outdated_entries = list(
+        clan_collection.find(
+            {
+                "last_updated": {
+                    "$lte": datetime.now(timezone.utc) - THRESHOLD
+                },
+            }
+        )
+    )
 
     for entry in outdated_entries:
         clan = Recruiter(entry.get("clan_tag"), headers)
         member_count = clan.lookup_clan("member_count").get("member_count")
         clan_collection.update_one(
-                                   {
-                                       "clan_tag" : clan.clan_tag,
-                                       "source": entry.get("source")
-                                   },
-                                   {'$set' :
-                                    {
-                                        "last_updated": datetime.now(
-                                            timezone.utc
-                                        ),
-                                     "clan_info.member_count" : member_count
-                                     }})
+            {"clan_tag": clan.clan_tag, "source": entry.get("source")},
+            {
+                "$set": {
+                    "last_updated": datetime.now(timezone.utc),
+                    "clan_info.member_count": member_count,
+                }
+            },
+        )
+
 
 if __name__ == "__main__":
     refresh_membercount()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ PROJECT_PARENT = PROJECT_ROOT.parent
 if str(PROJECT_PARENT) not in sys.path:
     sys.path.insert(0, str(PROJECT_PARENT))
 
-
 @pytest.fixture
 def app() -> Flask:
     return Flask(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_PARENT = PROJECT_ROOT.parent
+if str(PROJECT_PARENT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_PARENT))
+
+
+@pytest.fixture
+def app() -> Flask:
+    return Flask(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ PROJECT_PARENT = PROJECT_ROOT.parent
 if str(PROJECT_PARENT) not in sys.path:
     sys.path.insert(0, str(PROJECT_PARENT))
 
+
 @pytest.fixture
 def app() -> Flask:
     return Flask(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,24 @@ if str(PROJECT_PARENT) not in sys.path:
 
 @pytest.fixture
 def app() -> Flask:
-    return Flask(__name__)
+    from ClashRecruit.app import app as clash_app
+
+    clash_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+    )
+    return clash_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+@pytest.fixture
+def set_session(client):
+    def _set_session(**values):
+        with client.session_transaction() as sess:
+            sess.update(values)
+
+    return _set_session

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,6 @@
+KNOWN_STABLE_TAG = "2PP"
+
+MOCK_HEADERS = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer test-token",
+}

--- a/tests/routes/test_home_database_count_route.py
+++ b/tests/routes/test_home_database_count_route.py
@@ -1,0 +1,16 @@
+def test_database_count_returns_mocked_count(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    class DummyCollection:
+        def count_documents(self, query):
+            assert query == {}
+            return 42
+
+    monkeypatch.setattr(
+        home_route, "get_clan_collection", lambda: DummyCollection()
+        )
+
+    response = client.get("/database_count")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"clan_count": 42}

--- a/tests/routes/test_home_login_route.py
+++ b/tests/routes/test_home_login_route.py
@@ -1,0 +1,97 @@
+class DummyAPI:
+    instances = []
+
+    def __init__(self, player_tag, api_token, headers):
+        self.player_tag = player_tag
+        self.api_token = api_token
+        self.headers = headers
+        self.recruiter_status = True
+        self.user_name = "test_player"
+        self.clantag = "TESTCLAN"
+        self.league = 5
+        self.townhall = 13
+        self.builder_trophies = 2400
+        self.reason = None
+        DummyAPI.instances.append(self)
+
+    def check_player(self):
+        return True
+
+
+class InvalidDummyAPI(DummyAPI):
+    def __init__(self, player_tag, api_token, headers):
+        super().__init__(player_tag, api_token, headers)
+        self.recruiter_status = False
+        self.user_name = "Guest"
+        self.clantag = None
+        self.reason = "Player tag is incorrect"
+
+    def check_player(self):
+        return False
+
+
+def test_home_login_valid_player_sets_session(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post(
+        "/",
+        json={"playerTag": "PLAYER123", "apiToken": "token-123"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": True,
+        "receivedPlayerTag": "Valid User",
+        "recruit_status": True,
+        "player_name": "test_player",
+        "clan_tag": "TESTCLAN",
+    }
+    assert DummyAPI.instances[0].player_tag == "PLAYER123"
+    assert DummyAPI.instances[0].api_token == "token-123"
+
+    with client.session_transaction() as session:
+        assert session["player_tag"] == "PLAYER123"
+        assert session["recruiter_status"] is True
+        assert session["player_name"] == "test_player"
+        assert session["clan_tag"] == "TESTCLAN"
+        assert session["player_league"] == 5
+        assert session["player_townhall"] == 13
+        assert session["player_builderbase_trophies"] == 2400
+
+
+def test_home_login_invalid_player_sets_failure_session(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.home_route as home_route
+
+    monkeypatch.setattr(home_route, "API", InvalidDummyAPI)
+
+    response = client.post(
+        "/",
+        json={"playerTag": "BADTAG", "apiToken": "token-123"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": False,
+        "receivedPlayerTag": "Player tag is incorrect",
+        "recruit_status": False,
+        "player_name": "Guest",
+        "clan_tag": None,
+    }
+
+    with client.session_transaction() as session:
+        assert session["player_tag"] == "BADTAG"
+        assert session["recruiter_status"] is False
+        assert session["player_name"] == "Guest"
+        assert session["clan_tag"] is None
+        assert "player_league" not in session
+        assert "player_townhall" not in session
+        assert "player_builderbase_trophies" not in session

--- a/tests/routes/test_home_logout_route.py
+++ b/tests/routes/test_home_logout_route.py
@@ -1,0 +1,13 @@
+def test_logout_clears_session_and_returns_success(client, set_session):
+    set_session(
+        player_tag="P123", 
+        player_name="SomeUser", 
+        recruiter_status=True
+        )
+
+    response = client.post("/logout")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": True}
+    with client.session_transaction() as sess:
+        assert dict(sess) == {}

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -1,0 +1,167 @@
+def test_imported_clans_post_filters_and_paginates(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    refresh_calls = []
+
+    class DummyCursor:
+        def __init__(self, docs):
+            self.docs = docs
+            self.sort_fields = None
+            self.skip_count = None
+            self.limit_count = None
+
+        def sort(self, fields):
+            self.sort_fields = fields
+            return self
+
+        def skip(self, count):
+            self.skip_count = count
+            return self
+
+        def limit(self, count):
+            self.limit_count = count
+            return self
+
+        def __iter__(self):
+            start = self.skip_count or 0
+            stop = start + self.limit_count
+            return iter(self.docs[start:stop])
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.cursor = DummyCursor(
+                [
+                    {"clan_tag": "ONE", "name": "First"},
+                    {"clan_tag": "TWO", "name": "Second"},
+                    {"clan_tag": "THREE", "name": "Third"},
+                ]
+            )
+            self.count_query = None
+            self.find_query = None
+            self.find_projection = None
+
+        def count_documents(self, query):
+            self.count_query = query
+            return 3
+
+        def find(self, query, projection):
+            self.find_query = query
+            self.find_projection = projection
+            return self.cursor
+
+    collection = DummyClanCollection()
+
+    def fake_refresh():
+        refresh_calls.append(True)
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "ensure_imported_clan_inventory",
+        fake_refresh,
+    )
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/imported_clans?limit=1&offset=1",
+        json={
+            "filters": {
+                "name": "  Test.*  ",
+                "minClanLevel": 12,
+                "clanPoints": 40000,
+                "requirements": {"members": {"min": 30, "max": 45}},
+                "warFrequency": "always",
+                "location": "Canada",
+            }
+        },
+    )
+
+    expected_query = {
+        "source": "clash_api_import",
+        "name": {"$regex": "Test\\.\\*", "$options": "i"},
+        "clan_info.clan_level": {"$gte": 12},
+        "clan_info.clanPoints": {"$gte": 40000},
+        "clan_info.member_count": {"$gte": 30, "$lte": 45},
+        "clan_info.warFrequency": "always",
+        "clan_info.location.name": "Canada",
+    }
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [{"clan_tag": "TWO", "name": "Second"}],
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+    }
+    assert refresh_calls == [True]
+    assert collection.count_query == expected_query
+    assert collection.find_query == expected_query
+    assert collection.find_projection == {"_id": 0}
+    assert collection.cursor.sort_fields == [
+        ("last_discovered", -1),
+        ("last_updated", -1),
+        ("clan_info.clan_level", -1),
+        ("clan_info.member_count", -1),
+        ("clan_tag", 1),
+    ]
+    assert collection.cursor.skip_count == 1
+    assert collection.cursor.limit_count == 1
+
+
+def test_imported_clans_post_returns_clan_by_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    lookup_calls = []
+
+    def fake_get_imported_clan(clan_tag):
+        lookup_calls.append(clan_tag)
+        return {"clan_tag": clan_tag, "name": "test_clan"}
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_imported_clan",
+        fake_get_imported_clan,
+    )
+
+    response = client.post("/imported_clans", json={"clanTag": "TEST123"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"clan_tag": "TEST123", "name": "test_clan"}
+    assert lookup_calls == ["TEST123"]
+
+
+def test_imported_clans_post_returns_404_for_missing_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_imported_clan",
+        lambda clan_tag: None,
+    )
+
+    response = client.post("/imported_clans", json={"clan_tag": "MISSING"})
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Imported clan not found"}

--- a/tests/routes/test_locations_route.py
+++ b/tests/routes/test_locations_route.py
@@ -1,0 +1,35 @@
+def test_clash_locations_returns_locations_without_mongo_ids(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.locations_route as locations_route
+
+    class DummyLocationCollection:
+        def __init__(self):
+            self.find_query = None
+            self.find_projection = None
+
+        def find(self, query, projection):
+            self.find_query = query
+            self.find_projection = projection
+            return [
+                {"id": 32000007, "name": "Canada"},
+                {"id": 32000006, "name": "United States"},
+            ]
+
+    collection = DummyLocationCollection()
+    monkeypatch.setattr(
+        locations_route,
+        "get_location_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/clash_locations")
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"id": 32000007, "name": "Canada"},
+        {"id": 32000006, "name": "United States"},
+    ]
+    assert collection.find_query == {}
+    assert collection.find_projection == {"_id": 0}

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -1,0 +1,206 @@
+class DummyCursor:
+    def __init__(self, docs):
+        self.docs = docs
+        self.sort_fields = None
+        self.skip_count = None
+        self.limit_count = None
+
+    def sort(self, fields):
+        self.sort_fields = fields
+        return self
+
+    def skip(self, count):
+        self.skip_count = count
+        return self
+
+    def limit(self, count):
+        self.limit_count = count
+        return self
+
+    def __iter__(self):
+        start = self.skip_count or 0
+        stop = start + self.limit_count
+        return iter(self.docs[start:stop])
+
+
+class DummyClanCollection:
+    def __init__(self, docs=None, tag_result=None):
+        self.cursor = DummyCursor(docs or [])
+        self.tag_result = tag_result
+        self.count_query = None
+        self.find_query = None
+        self.find_projection = None
+        self.find_one_query = None
+        self.find_one_projection = None
+
+    def count_documents(self, query):
+        self.count_query = query
+        return len(self.cursor.docs)
+
+    def find(self, query, projection):
+        self.find_query = query
+        self.find_projection = projection
+        return self.cursor
+
+    def find_one(self, query, projection):
+        self.find_one_query = query
+        self.find_one_projection = projection
+        return self.tag_result
+
+
+def test_recruitee_get_filters_logged_in_player_with_total(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    refresh_calls = []
+    collection = DummyClanCollection(
+        [
+            {"clan_tag": "TEST1", "name": "test_clan_1"},
+            {"clan_tag": "TEST2", "name": "test_clan_2"},
+            {"clan_tag": "TEST3", "name": "test_clan_3"},
+        ]
+    )
+
+    set_session(
+        player_name="test_player",
+        player_league=5,
+        player_builderbase_trophies=2200,
+        player_townhall=13,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: refresh_calls.append(True),
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?includeTotal=1&limit=1&offset=1")
+
+    expected_query = {
+        "requirements.0": {"$lte": 5},
+        "requirements.1": {"$lte": 2200},
+        "requirements.2": {"$lte": 13},
+    }
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [{"clan_tag": "TEST2", "name": "test_clan_2"}],
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+    }
+    assert refresh_calls == []
+    assert collection.find_query == expected_query
+    assert collection.count_query == expected_query
+    assert collection.find_projection == {"_id": 0}
+    assert collection.cursor.sort_fields == [
+        ("last_updated", -1),
+        ("clan_tag", 1),
+    ]
+    assert collection.cursor.skip_count == 1
+    assert collection.cursor.limit_count == 1
+
+
+def test_recruitee_post_filters_and_paginates_with_total(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    refresh_calls = []
+    collection = DummyClanCollection(
+        [
+            {"clan_tag": "TEST1", "name": "test_clan_1"},
+            {"clan_tag": "TEST2", "name": "test_clan_2"},
+            {"clan_tag": "TEST3", "name": "test_clan_3"},
+        ]
+    )
+
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: refresh_calls.append(True),
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee?includeTotal=1&limit=2&offset=0",
+        json={
+            "filters": {
+                "name": "  Test.*  ",
+                "requirements": {
+                    "townhall": 12,
+                    "league": 4,
+                    "members": {"min": 30, "max": 45},
+                },
+                "minClanLevel": 10,
+                "clanPoints": 35000,
+                "warFrequency": "always",
+                "location_id": "32000007",
+            }
+        },
+    )
+
+    expected_query = {
+        "name": {"$regex": "Test\\.\\*", "$options": "i"},
+        "requirements.2": {"$gte": 12},
+        "requirements.0": {"$gte": 4},
+        "clan_info.clan_level": {"$gte": 10},
+        "clan_info.clanPoints": {"$gte": 35000},
+        "clan_info.member_count": {"$gte": 30, "$lte": 45},
+        "clan_info.warFrequency": "always",
+        "clan_info.location.id": 32000007,
+    }
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [
+            {"clan_tag": "TEST1", "name": "test_clan_1"},
+            {"clan_tag": "TEST2", "name": "test_clan_2"},
+        ],
+        "total": 3,
+        "limit": 2,
+        "offset": 0,
+    }
+    assert refresh_calls == [True]
+    assert collection.find_query == expected_query
+    assert collection.count_query == expected_query
+    assert collection.find_projection == {"_id": 0}
+    assert collection.cursor.sort_fields == [
+        ("last_updated", -1),
+        ("clan_tag", 1),
+    ]
+    assert collection.cursor.skip_count == 0
+    assert collection.cursor.limit_count == 2
+
+
+def test_recruitee_post_returns_404_for_missing_clan_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(tag_result=None)
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"clanTag": "MISSING"})
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Clan not found"}
+    assert collection.find_one_query == {"clan_tag": "MISSING"}
+    assert collection.find_one_projection == {"_id": 0}

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -108,6 +108,47 @@ def test_recruitee_get_filters_logged_in_player_with_total(
     assert collection.cursor.limit_count == 1
 
 
+def test_recruitee_get_returns_guest_default_raw_list(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    refresh_calls = []
+    collection = DummyClanCollection(
+        [
+            {"clan_tag": "TEST1", "name": "test_clan_1"},
+            {"clan_tag": "TEST2", "name": "test_clan_2"},
+        ]
+    )
+
+    set_session(player_name="Guest")
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: refresh_calls.append(True),
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee")
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"clan_tag": "TEST1", "name": "test_clan_1"},
+        {"clan_tag": "TEST2", "name": "test_clan_2"},
+    ]
+    assert refresh_calls == [True]
+    assert collection.find_query == {}
+    assert collection.count_query is None
+    assert collection.cursor.skip_count == 0
+    assert collection.cursor.limit_count == 10
+
+
 def test_recruitee_post_filters_and_paginates_with_total(
     client,
     monkeypatch,
@@ -183,6 +224,130 @@ def test_recruitee_post_filters_and_paginates_with_total(
     ]
     assert collection.cursor.skip_count == 0
     assert collection.cursor.limit_count == 2
+
+
+def test_recruitee_post_returns_clan_by_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        tag_result={"clan_tag": "TEST123", "name": "test_clan"}
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"clanTag": "TEST123"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"clan_tag": "TEST123", "name": "test_clan"}
+    assert collection.find_one_query == {"clan_tag": "TEST123"}
+    assert collection.find_one_projection == {"_id": 0}
+    assert collection.find_query is None
+
+
+def test_recruitee_post_filters_by_location_name_without_location_id(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    refresh_calls = []
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST123", "name": "test_clan"}]
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: refresh_calls.append(True),
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"location": "International"}},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"clan_tag": "TEST123", "name": "test_clan"}
+    ]
+    assert refresh_calls == [True]
+    assert collection.find_query == {
+        "clan_info.location.name": "International",
+    }
+    assert collection.count_query is None
+
+
+def test_recruitee_uses_defaults_for_invalid_limit_and_offset(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST123", "name": "test_clan"}]
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?includeTotal=1&limit=bad&offset=bad")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [{"clan_tag": "TEST123", "name": "test_clan"}],
+        "total": 1,
+        "limit": 10,
+        "offset": 0,
+    }
+    assert collection.find_query == {}
+    assert collection.count_query == {}
+    assert collection.cursor.skip_count == 0
+    assert collection.cursor.limit_count == 10
+
+
+def test_recruitee_post_returns_400_for_invalid_location_id(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "ensure_imported_clan_inventory",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"location_id": "not-a-number"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid location_id"}
+    assert collection.find_query is None
 
 
 def test_recruitee_post_returns_404_for_missing_clan_tag(

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -111,6 +111,34 @@ def test_recruiter_get_returns_existing_listing(
     assert DummyRecruiter.instances[0].lookup_modes == []
 
 
+def test_recruiter_get_returns_default_listing_and_lookup_description(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing=None)
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.get("/recruiter")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "oldRequiredLeague": 1,
+        "oldRequiredBuilderLeague": 2,
+        "oldRequiredTownhall": 3,
+        "MAXTOWNHALL": 17,
+        "clanDescription": "test_clan_description",
+        "status": None,
+    }
+    assert collection.find_one_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert DummyRecruiter.instances[0].pull_called is True
+    assert DummyRecruiter.instances[0].lookup_modes == ["description"]
+
+
 def test_recruiter_post_creates_new_listing(
     client,
     monkeypatch,
@@ -191,6 +219,45 @@ def test_recruiter_post_updates_listing_and_refreshes_expiry(
     assert isinstance(set_doc["expires"], datetime)
 
 
+def test_recruiter_post_updates_listing_and_preserves_provided_expiry(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "update",
+            "requiredLeague": 6,
+            "requiredBuilderLeague": 2600,
+            "requiredTownhall": 14,
+            "description": "updated_description",
+            "updateExpiry": False,
+            "expiry": "provided_expiry",
+        },
+    )
+    update_query, update_doc = collection.update_call
+    set_doc = update_doc["$set"]
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "provided_expiry",
+        "message": "Listing updated successfully.",
+    }
+    assert update_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert set_doc["source"] == "live_listing"
+    assert set_doc["requirements"] == [6, 2600, 14]
+    assert set_doc["clan_info.description"] == "updated_description"
+    assert "expires" not in set_doc
+
+
 def test_recruiter_post_removes_listing(
     client,
     monkeypatch,
@@ -214,3 +281,61 @@ def test_recruiter_post_removes_listing(
         "clan_tag": "TEST123",
         "source": {"$ne": "clash_api_import"},
     }
+
+
+def test_recruiter_post_remove_listing_returns_404_when_not_deleted(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(
+        existing={"requirements": [1, 2, 3]},
+        deleted_count=0,
+    )
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={"status": "removeListing"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"message": "Failed to delete."}
+    assert collection.delete_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+
+
+def test_recruiter_post_returns_400_for_unknown_status(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post("/recruiter", json={"status": "unexpected"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"message": "Invalid listing status."}
+    assert collection.inserted_doc is None
+    assert collection.update_call is None
+    assert collection.delete_query is None
+
+
+def test_recruiter_post_returns_400_for_missing_json_status(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post("/recruiter")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"message": "Invalid listing status."}

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -1,0 +1,216 @@
+from datetime import datetime
+
+
+class DummyDeleteResult:
+    def __init__(self, deleted_count):
+        self.deleted_count = deleted_count
+
+
+class DummyClanCollection:
+    def __init__(self, existing=None, deleted_count=1):
+        self.existing = existing
+        self.deleted_count = deleted_count
+        self.find_one_query = None
+        self.inserted_doc = None
+        self.update_call = None
+        self.delete_query = None
+
+    def find_one(self, query):
+        self.find_one_query = query
+        return self.existing
+
+    def insert_one(self, doc):
+        self.inserted_doc = doc
+
+    def update_one(self, query, update):
+        self.update_call = (query, update)
+
+    def delete_one(self, query):
+        self.delete_query = query
+        return DummyDeleteResult(self.deleted_count)
+
+
+class DummyRecruiter:
+    instances = []
+
+    def __init__(self, clan_tag, headers):
+        self.clan_tag = clan_tag
+        self.headers = headers
+        self.requirements = [1, 2, 3]
+        self.pull_called = False
+        self.lookup_modes = []
+        DummyRecruiter.instances.append(self)
+
+    def pull_clan_requirements(self):
+        self.pull_called = True
+        return self.requirements
+
+    def lookup_clan(self, mode=None):
+        self.lookup_modes.append(mode)
+        if mode == "description":
+            return {"description": "test_clan_description"}
+
+        return {
+            "name": "test_clan",
+            "description": "original_description",
+            "member_count": 40,
+        }
+
+
+def setup_recruiter_route(monkeypatch, collection):
+    import ClashRecruit.routes.recruiter_route as recruiter_route
+
+    DummyRecruiter.instances = []
+    monkeypatch.setattr(recruiter_route, "Recruiter", DummyRecruiter)
+    monkeypatch.setattr(
+        recruiter_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(recruiter_route, "refresh", lambda headers: 17)
+    return recruiter_route
+
+
+def test_recruiter_get_forbidden_without_recruiter_status(client):
+    response = client.get("/recruiter")
+
+    assert response.status_code == 403
+    assert response.get_json() == {"message": "Forbidden"}
+
+
+def test_recruiter_get_returns_existing_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    existing = {
+        "requirements": [4, 1800, 12],
+        "clan_info": {"description": "existing_description"},
+        "expires": "existing_expiry",
+    }
+    collection = DummyClanCollection(existing=existing)
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.get("/recruiter")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "oldRequiredLeague": 4,
+        "oldRequiredBuilderLeague": 1800,
+        "oldRequiredTownhall": 12,
+        "MAXTOWNHALL": 17,
+        "clanDescription": "existing_description",
+        "status": "existing_expiry",
+    }
+    assert collection.find_one_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert DummyRecruiter.instances[0].pull_called is True
+    assert DummyRecruiter.instances[0].lookup_modes == []
+
+
+def test_recruiter_post_creates_new_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(
+        recruiter_status=True,
+        clan_tag="TEST123",
+        player_tag="PLAYER123",
+    )
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 2400,
+            "requiredTownhall": 13,
+            "description": "new_description",
+        },
+    )
+    response_json = response.get_json()
+
+    assert response.status_code == 200
+    assert response_json["message"] == "Listing created successfully."
+    assert response_json["source"] == "live_listing"
+    assert response_json["requirements"] == [5, 2400, 13]
+    assert response_json["name"] == "test_clan"
+    assert response_json["clan_tag"] == "TEST123"
+    assert response_json["player_tag"] == "PLAYER123"
+    assert response_json["clan_info"]["description"] == "new_description"
+    assert response_json["expires"] == response_json["status"]
+
+    assert collection.inserted_doc["source"] == "live_listing"
+    assert collection.inserted_doc["requirements"] == [5, 2400, 13]
+    assert collection.inserted_doc["clan_info"]["description"] == (
+        "new_description"
+    )
+    assert isinstance(collection.inserted_doc["last_updated"], datetime)
+    assert isinstance(collection.inserted_doc["expires"], datetime)
+
+
+def test_recruiter_post_updates_listing_and_refreshes_expiry(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "update",
+            "requiredLeague": 6,
+            "requiredBuilderLeague": 2600,
+            "requiredTownhall": 14,
+            "description": "updated_description",
+            "updateExpiry": True,
+        },
+    )
+    update_query, update_doc = collection.update_call
+    set_doc = update_doc["$set"]
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Listing updated successfully."
+    assert update_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert set_doc["source"] == "live_listing"
+    assert set_doc["requirements"] == [6, 2600, 14]
+    assert set_doc["clan_info.description"] == "updated_description"
+    assert isinstance(set_doc["last_updated"], datetime)
+    assert isinstance(set_doc["expires"], datetime)
+
+
+def test_recruiter_post_removes_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(
+        existing={"requirements": [1, 2, 3]},
+        deleted_count=1,
+    )
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={"status": "removeListing"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Successfully deleted entry."}
+    assert collection.delete_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }

--- a/tests/routes/test_saved_clans_authorized_route.py
+++ b/tests/routes/test_saved_clans_authorized_route.py
@@ -67,6 +67,104 @@ def test_saved_clans_get_hydrates_available_and_missing_listings(
     }
 
 
+def test_saved_clans_get_returns_empty_saved_list(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def find_one(self, query, projection):
+            assert query == {"player_tag": "PLAYER123"}
+            assert projection == {"_id": 0, "saved_clans": 1}
+            return {"saved_clans": []}
+
+    class DummyClanCollection:
+        def find(self, query, projection):
+            assert query == {"clan_tag": {"$in": []}}
+            assert projection == {
+                "_id": 0,
+                "clan_tag": 1,
+                "name": 1,
+                "requirements": 1,
+                "clan_info": 1,
+            }
+            return []
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: DummyUserCollection(),
+    )
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_clan_collection",
+        lambda: DummyClanCollection(),
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "saved_clans": [],
+        "count": 0,
+        "max_saved_clans": 10,
+    }
+
+
+def test_saved_clans_get_uses_clan_info_name_when_top_level_name_missing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def find_one(self, query, projection):
+            return {"saved_clans": ["ABC123"]}
+
+    class DummyClanCollection:
+        def find(self, query, projection):
+            return [
+                {
+                    "clan_tag": "ABC123",
+                    "requirements": [1, 2, 3],
+                    "clan_info": {"name": "test_clan_info"},
+                }
+            ]
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: DummyUserCollection(),
+    )
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_clan_collection",
+        lambda: DummyClanCollection(),
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "saved_clans": [
+            {
+                "clan_tag": "ABC123",
+                "name": "test_clan_info",
+                "requirements": [1, 2, 3],
+                "clan_info": {"name": "test_clan_info"},
+                "listing_available": True,
+            }
+        ],
+        "count": 1,
+        "max_saved_clans": 10,
+    }
+
+
 def test_saved_clans_post_adds_normalized_tag(
     client,
     monkeypatch,

--- a/tests/routes/test_saved_clans_authorized_route.py
+++ b/tests/routes/test_saved_clans_authorized_route.py
@@ -1,0 +1,227 @@
+def test_saved_clans_get_hydrates_available_and_missing_listings(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def find_one(self, query, projection):
+            assert query == {"player_tag": "PLAYER123"}
+            assert projection == {"_id": 0, "saved_clans": 1}
+            return {"saved_clans": ["ABC123", "MISSING"]}
+
+    class DummyClanCollection:
+        def find(self, query, projection):
+            assert query == {"clan_tag": {"$in": ["ABC123", "MISSING"]}}
+            assert projection == {
+                "_id": 0,
+                "clan_tag": 1,
+                "name": 1,
+                "requirements": 1,
+                "clan_info": 1,
+            }
+            return [
+                {
+                    "clan_tag": "ABC123",
+                    "name": "test_clan",
+                    "requirements": [1, 2, 3],
+                    "clan_info": {"name": "test_clan_info"},
+                }
+            ]
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: DummyUserCollection(),
+    )
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_clan_collection",
+        lambda: DummyClanCollection(),
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "saved_clans": [
+            {
+                "clan_tag": "ABC123",
+                "name": "test_clan",
+                "requirements": [1, 2, 3],
+                "clan_info": {"name": "test_clan_info"},
+                "listing_available": True,
+            },
+            {
+                "clan_tag": "MISSING",
+                "name": "MISSING",
+                "requirements": None,
+                "clan_info": {},
+                "listing_available": False,
+            },
+        ],
+        "count": 2,
+        "max_saved_clans": 10,
+    }
+
+
+def test_saved_clans_post_adds_normalized_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def __init__(self):
+            self.update_call = None
+
+        def find_one(self, query, projection):
+            assert query == {"player_tag": "PLAYER123"}
+            assert projection == {"_id": 0, "saved_clans": 1}
+            return {"saved_clans": ["EXISTING"]}
+
+        def update_one(self, query, update, upsert=False):
+            self.update_call = (query, update, upsert)
+
+    user_collection = DummyUserCollection()
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: user_collection,
+    )
+
+    response = client.post("/saved-clans/%23ABC123")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": "Clan saved.",
+        "clan_tag": "ABC123",
+        "count": 2,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.update_call == (
+        {"player_tag": "PLAYER123"},
+        {
+            "$addToSet": {"saved_clans": "ABC123"},
+            "$setOnInsert": {"player_tag": "PLAYER123"},
+        },
+        True,
+    )
+
+
+def test_saved_clans_post_returns_existing_without_update(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def __init__(self):
+            self.update_called = False
+
+        def find_one(self, query, projection):
+            return {"saved_clans": ["ABC123"]}
+
+        def update_one(self, query, update, upsert=False):
+            self.update_called = True
+
+    user_collection = DummyUserCollection()
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: user_collection,
+    )
+
+    response = client.post("/saved-clans/ABC123")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": "Clan already saved.",
+        "clan_tag": "ABC123",
+        "count": 1,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.update_called is False
+
+
+def test_saved_clans_post_returns_conflict_at_limit(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def __init__(self):
+            self.update_called = False
+
+        def find_one(self, query, projection):
+            return {"saved_clans": [f"TAG{i}" for i in range(10)]}
+
+        def update_one(self, query, update, upsert=False):
+            self.update_called = True
+
+    user_collection = DummyUserCollection()
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: user_collection,
+    )
+
+    response = client.post("/saved-clans/ABC123")
+
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "message": (
+            "You can save up to 10 clans. Remove one before saving another."
+        ),
+        "count": 10,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.update_called is False
+
+
+def test_saved_clans_delete_removes_normalized_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def __init__(self):
+            self.update_call = None
+
+        def update_one(self, query, update):
+            self.update_call = (query, update)
+
+    user_collection = DummyUserCollection()
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: user_collection,
+    )
+
+    response = client.delete("/saved-clans/%23ABC123")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": "Saved clan removed.",
+        "clan_tag": "ABC123",
+    }
+    assert user_collection.update_call == (
+        {"player_tag": "PLAYER123"},
+        {"$pull": {"saved_clans": "ABC123"}},
+    )

--- a/tests/routes/test_saved_clans_unauthorized_route.py
+++ b/tests/routes/test_saved_clans_unauthorized_route.py
@@ -1,0 +1,61 @@
+def test_saved_clans_get_unauthorized_returns_401(client, monkeypatch):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        pass
+
+    def get_dummy_user_collection():
+        return DummyUserCollection()
+
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        get_dummy_user_collection,
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}
+
+
+def test_saved_clans_post_unauthorized_returns_401(client, monkeypatch):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        pass
+
+    def get_dummy_user_collection():
+        return DummyUserCollection()
+
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        get_dummy_user_collection,
+    )
+
+    response = client.post("/saved-clans/ABC123")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}
+
+
+def test_saved_clans_delete_unauthorized_returns_401(client, monkeypatch):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        pass
+
+    def get_dummy_user_collection():
+        return DummyUserCollection()
+
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        get_dummy_user_collection,
+    )
+
+    response = client.delete("/saved-clans/ABC123")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}

--- a/tests/routes/test_search_clans_route.py
+++ b/tests/routes/test_search_clans_route.py
@@ -1,0 +1,101 @@
+class DummyRecruitee:
+    instances = []
+    result = None
+
+    def __init__(self, player_tag, headers):
+        self.player_tag = player_tag
+        self.headers = headers
+        self.search_call = None
+        DummyRecruitee.instances.append(self)
+
+    def searchClan(self, filters, after=None):
+        self.search_call = (filters, after)
+        return DummyRecruitee.result
+
+
+def setup_search_route(monkeypatch, result):
+    import ClashRecruit.routes.search_clans_route as search_clans_route
+
+    DummyRecruitee.instances = []
+    DummyRecruitee.result = result
+    monkeypatch.setattr(search_clans_route, "Recruitee", DummyRecruitee)
+
+
+def test_search_clans_returns_success_payload(
+    client,
+    monkeypatch,
+    set_session,
+):
+    setup_search_route(
+        monkeypatch,
+        {
+            "items": [{"tag": "#TEST1", "name": "test_clan"}],
+            "after": "cursor-1",
+            "error": None,
+        },
+    )
+    set_session(player_tag="PLAYER123")
+
+    response = client.post(
+        "/search_clans",
+        json={"name": "test", "after": "cursor-0"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [{"tag": "#TEST1", "name": "test_clan"}],
+        "after": "cursor-1",
+        "error": None,
+    }
+    assert DummyRecruitee.instances[0].player_tag == "PLAYER123"
+    assert DummyRecruitee.instances[0].search_call == (
+        {"name": "test", "after": "cursor-0"},
+        "cursor-0",
+    )
+
+
+def test_search_clans_maps_empty_filter_error(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {
+            "items": [],
+            "after": None,
+            "error": {
+                "reason": "badRequest",
+                "message": "At least one filtering parameter must exist",
+                "status": 400,
+            },
+        },
+    )
+
+    response = client.post("/search_clans", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Add at least one random clan filter before searching.",
+        "reason": "badRequest",
+        "message": "At least one filtering parameter must exist",
+    }
+
+
+def test_search_clans_maps_generic_api_error(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {
+            "items": [],
+            "after": None,
+            "error": {
+                "reason": "accessDenied",
+                "message": "Invalid authorization",
+                "status": 403,
+            },
+        },
+    )
+
+    response = client.post("/search_clans", json={"name": "test"})
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "error": "Invalid authorization",
+        "reason": "accessDenied",
+    }

--- a/tests/routes/test_session_state_route.py
+++ b/tests/routes/test_session_state_route.py
@@ -1,0 +1,89 @@
+class DummyAPI:
+    instances = []
+
+    def __init__(self, player_tag, api_token, headers):
+        self.player_tag = player_tag
+        self.api_token = api_token
+        self.headers = headers
+        self.townhall = 14
+        self.townhallWeaponLevel = 3
+        self.clantag = "LIVECLAN"
+        self.check_called = False
+        DummyAPI.instances.append(self)
+
+    def check_player(self):
+        self.check_called = True
+        return True
+
+
+class DummyClanCollection:
+    def __init__(self, listing):
+        self.listing = listing
+        self.find_one_query = None
+        self.find_one_projection = None
+
+    def find_one(self, query, projection):
+        self.find_one_query = query
+        self.find_one_projection = projection
+        return self.listing
+
+
+def test_session_state_returns_guest_defaults(client, monkeypatch):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called for Guest")
+
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "Guest",
+        "recruit_status": False,
+        "has_active_listing": False,
+        "townhall": None,
+        "townhallWeaponLevel": None,
+    }
+
+
+def test_session_state_returns_logged_in_player_and_active_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing={"_id": "listing-id"})
+    DummyAPI.instances = []
+    set_session(
+        player_name="test_player",
+        player_tag="PLAYER123",
+        recruiter_status=True,
+        clan_tag="SESSIONCLAN",
+    )
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": True,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert DummyAPI.instances[0].player_tag == "PLAYER123"
+    assert DummyAPI.instances[0].api_token is None
+    assert DummyAPI.instances[0].check_called is True
+    assert collection.find_one_query["clan_tag"] == "LIVECLAN"
+    assert "$gt" in collection.find_one_query["expires"]
+    assert collection.find_one_projection == {"_id": 1}

--- a/tests/routes/test_session_state_route.py
+++ b/tests/routes/test_session_state_route.py
@@ -1,5 +1,6 @@
 class DummyAPI:
     instances = []
+    live_clan_tag = "LIVECLAN"
 
     def __init__(self, player_tag, api_token, headers):
         self.player_tag = player_tag
@@ -7,7 +8,7 @@ class DummyAPI:
         self.headers = headers
         self.townhall = 14
         self.townhallWeaponLevel = 3
-        self.clantag = "LIVECLAN"
+        self.clantag = self.live_clan_tag
         self.check_called = False
         DummyAPI.instances.append(self)
 
@@ -87,3 +88,76 @@ def test_session_state_returns_logged_in_player_and_active_listing(
     assert collection.find_one_query["clan_tag"] == "LIVECLAN"
     assert "$gt" in collection.find_one_query["expires"]
     assert collection.find_one_projection == {"_id": 1}
+
+
+def test_session_state_returns_logged_in_player_without_active_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing=None)
+    DummyAPI.instances = []
+    DummyAPI.live_clan_tag = "LIVECLAN"
+    set_session(
+        player_name="test_player",
+        player_tag="PLAYER123",
+        recruiter_status=True,
+        clan_tag="SESSIONCLAN",
+    )
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": False,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert collection.find_one_query["clan_tag"] == "LIVECLAN"
+
+
+def test_session_state_falls_back_to_session_clan_tag_when_api_has_none(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing={"_id": "listing-id"})
+    DummyAPI.instances = []
+    DummyAPI.live_clan_tag = None
+    set_session(
+        player_name="test_player",
+        player_tag="PLAYER123",
+        recruiter_status=True,
+        clan_tag="SESSIONCLAN",
+    )
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": True,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"
+    DummyAPI.live_clan_tag = "LIVECLAN"

--- a/tests/routes/test_session_state_user_info_route.py
+++ b/tests/routes/test_session_state_user_info_route.py
@@ -1,0 +1,15 @@
+def test_session_state_user_info_returns_empty_for_guest(client, monkeypatch):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class _FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "API should not be called for Guest user-info"
+                )
+
+    monkeypatch.setattr(session_state_route, "API", _FailIfCalledAPI)
+
+    response = client.get("/session-state/user-info")
+
+    assert response.status_code == 200
+    assert response.get_json() == {}

--- a/tests/routes/test_session_state_user_info_route.py
+++ b/tests/routes/test_session_state_user_info_route.py
@@ -13,3 +13,55 @@ def test_session_state_user_info_returns_empty_for_guest(client, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json() == {}
+
+
+def test_session_state_user_info_returns_player_stats(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class DummyAPI:
+        instances = []
+
+        def __init__(self, player_tag, api_token, headers):
+            self.player_tag = player_tag
+            self.api_token = api_token
+            self.headers = headers
+            self.requested_fields = None
+            DummyAPI.instances.append(self)
+
+        def check_player(self, fields):
+            self.requested_fields = fields
+            return {
+                "player_tag": self.player_tag,
+                "expLevel": 120,
+                "leagueTier": {"name": "Champion League"},
+                "builderBaseLeague": {"name": "Emerald League"},
+                "builderHallLevel": 10,
+                "clan": {"tag": "#TESTCLAN"},
+            }
+
+    set_session(player_tag="PLAYER123")
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+
+    response = client.get("/session-state/user-info")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "player_tag": "PLAYER123",
+        "expLevel": 120,
+        "leagueTier": {"name": "Champion League"},
+        "builderBaseLeague": {"name": "Emerald League"},
+        "builderHallLevel": 10,
+        "clan": {"tag": "#TESTCLAN"},
+    }
+    assert DummyAPI.instances[0].api_token is None
+    assert DummyAPI.instances[0].requested_fields == [
+        "expLevel",
+        "leagueTier",
+        "builderBaseLeague",
+        "builderHallLevel",
+        "clan",
+    ]

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -1,0 +1,59 @@
+from unittest.mock import Mock
+
+from ClashRecruit.api.clash_api import API
+from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
+
+
+def test_player_api_is_false(monkeypatch) -> None:
+    user = API(KNOWN_STABLE_TAG, api="invalid-token", headers=MOCK_HEADERS)
+    fake_response = Mock()
+    fake_response.json.return_value = {"status": "invalid"}
+    mock_post = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.post",
+        mock_post,
+    )
+
+    assert user.check_player_api() is False
+    assert user.reason == "API Token is incorrect"
+
+
+def test_player_is_guest() -> None:
+    guest_user = API("Guest", None, None)
+    guest_user.check_player()
+
+    assert guest_user.user_tag == "Guest"
+    assert guest_user.reason == "User is a Guest"
+
+
+def test_player_not_found(monkeypatch) -> None:
+    invalid_user = API("INVALID_TAG", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"reason" : "notFound"}
+    mock_post = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        mock_post,
+    )
+
+    assert not invalid_user.check_player()
+    assert invalid_user.reason == "Player tag is incorrect"
+
+
+def test_invalid_ip_address(monkeypatch) -> None:
+    user = API("invalid_ip_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"reason" : "accessDenied.invalidIp"}
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        mock_get,
+    )
+
+    assert not user.check_player()
+    assert user.reason == "Invalid IP"

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -101,13 +101,15 @@ def test_check_player_with_all_request_options(monkeypatch) -> None:
         mock_get,
     )
 
-    result = user.check_player([
-        "expLevel",
-        "leagueTier",
-        "builderBaseLeague",
-        "builderHallLevel",
-        "clan",
-    ])
+    result = user.check_player(
+        [
+            "expLevel",
+            "leagueTier",
+            "builderBaseLeague",
+            "builderHallLevel",
+            "clan",
+        ]
+    )
 
     assert result["player_tag"] == "valid_user"
     assert result["leagueTier"] == {"name": "Unranked"}
@@ -262,13 +264,15 @@ def test_check_player_request_subset_without_clan_num_items_5(
         Mock(return_value=fake_response),
     )
 
-    result = user.check_player([
-        "expLevel",
-        "leagueTier",
-        "builderBaseLeague",
-        "builderHallLevel",
-        "clan",
-    ])
+    result = user.check_player(
+        [
+            "expLevel",
+            "leagueTier",
+            "builderBaseLeague",
+            "builderHallLevel",
+            "clan",
+        ]
+    )
 
     assert result["player_tag"] == "valid_user"
     assert result["clan"] is None
@@ -288,4 +292,3 @@ def test_check_player_request_subset_without_clan_num_items_5(
 def test_recruiting_role_matrix(payload: dict, expected: bool) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
     assert user.recruiting(payload) is expected
-    

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -75,6 +75,20 @@ def test_player_api_is_true(monkeypatch) -> None:
     assert user.check_player_api()
 
 
+def test_player_api_unknown_status_sets_reason_payload(monkeypatch) -> None:
+    user = API("valid_user", api="token", headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"status": "maintenance"}
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.post",
+        Mock(return_value=fake_response),
+    )
+
+    assert user.check_player_api() is False
+    assert user.reason == {"status": "maintenance"}
+
+
 def test_check_player_with_all_request_options(monkeypatch) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
@@ -184,6 +198,31 @@ def test_check_player_double_digit_league_tier(monkeypatch) -> None:
 
     user.check_player()
     assert user.league == 27
+
+
+def test_check_player_townhall_above_17_leaves_weapon_level_unset(
+    monkeypatch,
+) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "leagueTier": {"name": "Titan League 27"},
+        "townHallLevel": 18,
+        "builderBaseTrophies": 2000,
+        "townHallWeaponLevel": 5,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "leader",
+        "name": "valid_user",
+    }
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        Mock(return_value=fake_response),
+    )
+
+    assert user.check_player() is True
+    assert user.townhall == 18
+    assert user.townhallWeaponLevel is None
 
 
 def test_check_player_with_token_verification_fails(monkeypatch) -> None:

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import pytest
 from ClashRecruit.api.clash_api import API
 from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
 
@@ -31,7 +32,7 @@ def test_player_not_found(monkeypatch) -> None:
     invalid_user = API("INVALID_TAG", api=None, headers=MOCK_HEADERS)
 
     fake_response = Mock()
-    fake_response.json.return_value = {"reason" : "notFound"}
+    fake_response.json.return_value = {"reason": "notFound"}
     mock_post = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
@@ -47,7 +48,7 @@ def test_invalid_ip_address(monkeypatch) -> None:
     user = API("invalid_ip_user", api=None, headers=MOCK_HEADERS)
 
     fake_response = Mock()
-    fake_response.json.return_value = {"reason" : "accessDenied.invalidIp"}
+    fake_response.json.return_value = {"reason": "accessDenied.invalidIp"}
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
@@ -57,3 +58,234 @@ def test_invalid_ip_address(monkeypatch) -> None:
 
     assert not user.check_player()
     assert user.reason == "Invalid IP"
+
+
+def test_player_api_is_true(monkeypatch) -> None:
+    user = API("valid_user", api="valid-token", headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"status": "ok"}
+    mock_post = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.post",
+        mock_post,
+    )
+
+    assert user.check_player_api()
+
+
+def test_check_player_with_all_request_options(monkeypatch) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "leagueTier": {"name": "Unranked"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "townHallWeaponLevel": 5,
+        "expLevel": 100,
+        "builderBaseLeague": {
+            "id": 44000033,
+            "name": "Platinum League II",
+        },
+        "builderHallLevel": 9,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "coLeader",
+        "name": "valid_user",
+    }
+    mock_post = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        mock_post,
+    )
+
+    result = user.check_player([
+        "expLevel",
+        "leagueTier",
+        "builderBaseLeague",
+        "builderHallLevel",
+        "clan",
+    ])
+
+    assert result["player_tag"] == "valid_user"
+    assert result["leagueTier"] == {"name": "Unranked"}
+    assert result["builderBaseLeague"] == {
+        "id": 44000033,
+        "name": "Platinum League II",
+    }
+    assert result["clan"] == {"tag": "#mock_clan_tag", "role": "coLeader"}
+    assert result["num_items"] == 6
+
+    assert user.clantag == "mock_clan_tag"
+    assert user.league == 0
+    assert user.recruiter_status
+    assert user.user_name == "valid_user"
+
+
+def test_check_player_single_digit_league_tier(monkeypatch) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "leagueTier": {"name": "Skeleton 1"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "townHallWeaponLevel": 5,
+        "expLevel": 100,
+        "builderBaseLeague": {
+            "id": 44000033,
+            "name": "Platinum League II",
+        },
+        "builderHallLevel": 9,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "coLeader",
+        "name": "valid_user",
+    }
+    mock_post = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        mock_post,
+    )
+
+    user.check_player()
+    assert user.league == 1
+
+
+def test_check_player_double_digit_league_tier(monkeypatch) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "leagueTier": {"name": "Titan League 27"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "townHallWeaponLevel": 5,
+        "expLevel": 100,
+        "builderBaseLeague": {
+            "id": 44000033,
+            "name": "Platinum League II",
+        },
+        "builderHallLevel": 9,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "coLeader",
+        "name": "valid_user",
+    }
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        mock_get,
+    )
+
+    user.check_player()
+    assert user.league == 27
+
+
+def test_check_player_with_token_verification_fails(monkeypatch) -> None:
+    user = API("valid_user", api="invalid-token", headers=MOCK_HEADERS)
+
+    fake_get_response = Mock()
+    fake_get_response.json.return_value = {
+        "leagueTier": {"name": "Unranked"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "leader",
+        "name": "valid_user",
+    }
+    fake_post_response = Mock()
+    fake_post_response.json.return_value = {"status": "invalid"}
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        Mock(return_value=fake_get_response),
+    )
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.post",
+        Mock(return_value=fake_post_response),
+    )
+
+    assert not user.check_player()
+    assert user.reason == "API Token is incorrect"
+
+
+def test_check_player_with_token_verification_succeeds(monkeypatch) -> None:
+    user = API("valid_user", api="valid-token", headers=MOCK_HEADERS)
+
+    fake_get_response = Mock()
+    fake_get_response.json.return_value = {
+        "leagueTier": {"name": "Titan League 27"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "clan": {"tag": "#mock_clan_tag"},
+        "role": "leader",
+        "name": "valid_user",
+    }
+    fake_post_response = Mock()
+    fake_post_response.json.return_value = {"status": "ok"}
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        Mock(return_value=fake_get_response),
+    )
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.post",
+        Mock(return_value=fake_post_response),
+    )
+
+    assert user.check_player()
+    assert user.token is True
+    assert user.user_name == "valid_user"
+
+
+def test_check_player_request_subset_without_clan_num_items_5(
+    monkeypatch,
+) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "leagueTier": {"name": "Unranked"},
+        "townHallLevel": 17,
+        "builderBaseTrophies": 2000,
+        "expLevel": 100,
+        "builderBaseLeague": {"id": 44000033, "name": "Platinum League II"},
+        "builderHallLevel": 9,
+        "name": "valid_user",
+    }
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.clash_api.requests.get",
+        Mock(return_value=fake_response),
+    )
+
+    result = user.check_player([
+        "expLevel",
+        "leagueTier",
+        "builderBaseLeague",
+        "builderHallLevel",
+        "clan",
+    ])
+
+    assert result["player_tag"] == "valid_user"
+    assert result["clan"] is None
+    assert result["num_items"] == 5
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"clan": {"tag": "#X"}, "role": "leader"}, True),
+        ({"clan": {"tag": "#X"}, "role": "coleader"}, True),
+        ({"clan": {"tag": "#X"}, "role": "admin"}, True),
+        ({"clan": {"tag": "#X"}, "role": "member"}, False),
+        ({"role": "leader", "clan": {}}, False),
+    ],
+)
+def test_recruiting_role_matrix(payload: dict, expected: bool) -> None:
+    user = API("valid_user", api=None, headers=MOCK_HEADERS)
+    assert user.recruiting(payload) is expected
+    

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -33,11 +33,11 @@ def test_player_not_found(monkeypatch) -> None:
 
     fake_response = Mock()
     fake_response.json.return_value = {"reason": "notFound"}
-    mock_post = Mock(return_value=fake_response)
+    mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
         "ClashRecruit.api.clash_api.requests.get",
-        mock_post,
+        mock_get,
     )
 
     assert not invalid_user.check_player()
@@ -94,11 +94,11 @@ def test_check_player_with_all_request_options(monkeypatch) -> None:
         "role": "coLeader",
         "name": "valid_user",
     }
-    mock_post = Mock(return_value=fake_response)
+    mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
         "ClashRecruit.api.clash_api.requests.get",
-        mock_post,
+        mock_get,
     )
 
     result = user.check_player([
@@ -143,11 +143,11 @@ def test_check_player_single_digit_league_tier(monkeypatch) -> None:
         "role": "coLeader",
         "name": "valid_user",
     }
-    mock_post = Mock(return_value=fake_response)
+    mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
         "ClashRecruit.api.clash_api.requests.get",
-        mock_post,
+        mock_get,
     )
 
     user.check_player()

--- a/tests/test_clash_api_preflight_service.py
+++ b/tests/test_clash_api_preflight_service.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+import ClashRecruit.services.clash_api_preflight as preflight
+import pytest
+
+
+def test_run_clash_api_preflight_returns_for_success(monkeypatch):
+    fake_response = Mock(status_code=200)
+    fake_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(preflight.requests, "get", fake_get)
+
+    result = preflight.run_clash_api_preflight({"Authorization": "token"})
+
+    assert result is None
+    fake_get.assert_called_once_with(
+        (
+            "https://api.clashofclans.com/v1/locations/32000249/"
+            "rankings/players?limit=1"
+        ),
+        headers={"Authorization": "token"},
+    )
+
+
+def test_run_clash_api_preflight_raises_for_api_error(monkeypatch):
+    fake_response = Mock(status_code=403)
+    fake_response.json.return_value = {"reason": "accessDenied.invalidIp"}
+    monkeypatch.setattr(
+        preflight.requests,
+        "get",
+        Mock(return_value=fake_response),
+    )
+
+    with pytest.raises(Exception, match="HTTP 403: accessDenied.invalidIp"):
+        preflight.run_clash_api_preflight({"Authorization": "token"})
+
+
+def test_run_clash_api_preflight_uses_unknown_reason_fallback(monkeypatch):
+    fake_response = Mock(status_code=500)
+    fake_response.json.return_value = {}
+    monkeypatch.setattr(
+        preflight.requests,
+        "get",
+        Mock(return_value=fake_response),
+    )
+
+    with pytest.raises(Exception, match="HTTP 500: unknown"):
+        preflight.run_clash_api_preflight({"Authorization": "token"})

--- a/tests/test_get_locations_service.py
+++ b/tests/test_get_locations_service.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock
+
+import ClashRecruit.services.get_locations as locations_service
+
+
+def test_get_locations_returns_items_from_api(monkeypatch):
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "items": [{"id": 32000007, "name": "International"}]
+    }
+    fake_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(locations_service.requests, "get", fake_get)
+
+    result = locations_service.get_locations({"Authorization": "Bearer token"})
+
+    assert result == [{"id": 32000007, "name": "International"}]
+    fake_get.assert_called_once_with(
+        "https://api.clashofclans.com/v1/locations",
+        headers={"Authorization": "Bearer token"},
+    )
+
+
+def test_update_location_collection_skips_blank_and_existing_locations(
+    monkeypatch,
+):
+    class DummyLocationCollection:
+        def __init__(self):
+            self.find_queries = []
+            self.inserted = []
+
+        def find_one(self, query):
+            self.find_queries.append(query)
+            if query == {"id": 32000007}:
+                return {"id": 32000007, "name": "Existing"}
+            return None
+
+        def insert_one(self, location):
+            self.inserted.append(location)
+
+    collection = DummyLocationCollection()
+    monkeypatch.setattr(
+        locations_service,
+        "get_location_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        locations_service,
+        "get_locations",
+        lambda headers: [
+            {"id": 1, "name": ""},
+            {"id": 32000007, "name": "Existing"},
+            {"id": 32000008, "name": "New"},
+        ],
+    )
+
+    locations_service.update_location_collection()
+
+    assert collection.find_queries == [
+        {"id": 32000007},
+        {"id": 32000008},
+    ]
+    assert collection.inserted == [{"id": 32000008, "name": "New"}]

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -1,0 +1,740 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import ClashRecruit.services.import_clash_api_clans as import_service
+import pytest
+import requests
+
+
+@pytest.mark.parametrize(
+    ("raw_tag", "expected"),
+    [
+        (" #test123 ", "TEST123"),
+        ("test123", "TEST123"),
+        ("", None),
+        (None, None),
+        ("  #  ", None),
+    ],
+)
+def test_clean_tag_normalizes_and_rejects_empty(raw_tag, expected):
+    assert import_service._clean_tag(raw_tag) == expected
+
+
+def test_extract_requirements_prefers_detail_values_over_search_values():
+    requirements = import_service._extract_requirements(
+        search_clan={
+            "requiredBuilderBaseTrophies": 1200,
+            "requiredTownhallLevel": 10,
+        },
+        detail_clan={
+            "requiredBuilderBaseTrophies": 2400,
+            "requiredTownhallLevel": 13,
+        },
+    )
+
+    assert requirements == [0, 2400, 13]
+
+
+def test_extract_requirements_uses_search_fallbacks_and_zero_defaults():
+    assert import_service._extract_requirements(
+        search_clan={
+            "requiredBuilderBaseTrophies": 1200,
+            "requiredTownhallLevel": 10,
+        }
+    ) == [0, 1200, 10]
+    assert import_service._extract_requirements() == [0, 0, 0]
+
+
+def test_build_seed_key_sorts_and_ignores_empty_values():
+    assert import_service._build_seed_key(
+        {"name": "test", "after": "", "limit": 10, "locationId": None}
+    ) == "limit:10|name:test"
+
+
+def test_seed_locations_returns_non_empty_ids(monkeypatch):
+    class DummyCursor:
+        def __init__(self):
+            self.limit_count = None
+
+        def limit(self, count):
+            self.limit_count = count
+            return [
+                {"id": 32000007},
+                {"name": "missing_id"},
+                {"id": 0},
+                {"id": 32000008},
+            ]
+
+    class DummyLocationCollection:
+        def __init__(self):
+            self.cursor = DummyCursor()
+            self.find_call = None
+
+        def find(self, query, projection):
+            self.find_call = (query, projection)
+            return self.cursor
+
+    collection = DummyLocationCollection()
+    monkeypatch.setattr(
+        import_service,
+        "_location_collection",
+        lambda: collection,
+    )
+
+    assert import_service._seed_locations(limit=3) == [32000007, 32000008]
+    assert collection.find_call == ({}, {"_id": 0, "id": 1})
+    assert collection.cursor.limit_count == 3
+
+
+def test_build_discovery_seeds_includes_prefix_war_and_location_seeds(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        import_service,
+        "_seed_locations",
+        lambda limit: [1, 2],
+    )
+
+    seeds = import_service._build_discovery_seeds()
+
+    assert seeds[0] == {"name": "a", "minMembers": 10, "limit": 10}
+    assert {
+        "warFrequency": "always",
+        "minMembers": 10,
+        "maxMembers": 50,
+        "limit": 10,
+    } in seeds
+    assert {
+        "locationId": 1,
+        "minClanLevel": 3,
+        "minMembers": 10,
+        "limit": 10,
+    } in seeds
+    assert len(seeds) == 31
+
+
+def test_normalize_discovery_item_builds_import_shell(monkeypatch):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+
+    document = import_service._normalize_discovery_item(
+        {
+            "tag": "#test123",
+            "name": "test_clan",
+            "location": {"id": 32000007, "name": "International"},
+            "badgeUrls": {"medium": "badge_url"},
+            "clanLevel": 10,
+            "members": 42,
+            "type": "open",
+            "warFrequency": "always",
+            "clanPoints": 36000,
+        },
+        "seed-key",
+    )
+
+    assert document == {
+        "clan_tag": "TEST123",
+        "name": "test_clan",
+        "source": "clash_api_import",
+        "seed_key": "seed-key",
+        "requirements": [0, 0, 0],
+        "requirements_source": "unsupported_by_api",
+        "last_discovered": frozen_now,
+        "clan_info": {
+            "description": None,
+            "location": {"id": 32000007, "name": "International"},
+            "badge": "badge_url",
+            "clan_level": 10,
+            "member_count": 42,
+            "type": "open",
+            "warFrequency": "always",
+            "clanPoints": 36000,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"members": 20, "clanLevel": 5}, True),
+        ({"members": 19, "clanLevel": 5}, False),
+        ({"members": 20, "clanLevel": 4}, False),
+        ({}, False),
+    ],
+)
+def test_passes_quality_gate(payload, expected):
+    assert import_service._passes_quality_gate(payload) is expected
+
+
+def test_build_enriched_import_document_uses_detail_with_search_fallbacks(
+    monkeypatch,
+):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+
+    document = import_service._build_enriched_import_document(
+        search_clan={
+            "tag": "#TEST123",
+            "name": "search_clan",
+            "location": {"id": 32000007, "name": "International"},
+            "badgeUrls": {"medium": "search_badge"},
+            "clanLevel": 9,
+            "members": 35,
+            "type": "open",
+            "warFrequency": "always",
+            "clanPoints": 35000,
+            "requiredBuilderBaseTrophies": 1600,
+            "requiredTownhallLevel": 11,
+        },
+        detail_clan={
+            "tag": "#TEST123",
+            "name": "test_clan",
+            "description": "  test description  ",
+            "badgeUrls": {},
+            "members": 40,
+            "requiredBuilderBaseTrophies": 2200,
+            "requiredTownhallLevel": 13,
+        },
+        seed_key="name:a|limit:10",
+    )
+
+    assert document == {
+        "clan_tag": "TEST123",
+        "name": "test_clan",
+        "source": "clash_api_import",
+        "seed_key": "name:a|limit:10",
+        "requirements": [0, 2200, 13],
+        "requirements_source": "clash_api",
+        "last_discovered": frozen_now,
+        "last_updated": frozen_now,
+        "clan_info": {
+            "description": "test description",
+            "location": {"id": 32000007, "name": "International"},
+            "badge": "search_badge",
+            "clan_level": 9,
+            "member_count": 40,
+            "type": "open",
+            "warFrequency": "always",
+            "clanPoints": 35000,
+        },
+    }
+
+
+def test_search_clans_calls_api_with_timeout_and_returns_cursor(monkeypatch):
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "items": [{"tag": "#TEST123"}],
+        "paging": {"cursors": {"after": "cursor-1"}},
+    }
+    fake_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(import_service.requests, "get", fake_get)
+
+    result = import_service._search_clans({"name": "test", "limit": 10})
+
+    assert result == {"items": [{"tag": "#TEST123"}], "after": "cursor-1"}
+    fake_response.raise_for_status.assert_called_once_with()
+    fake_get.assert_called_once_with(
+        "https://api.clashofclans.com/v1/clans",
+        params={"name": "test", "limit": 10},
+        headers=import_service.headers,
+        timeout=15,
+    )
+
+
+def test_fetch_clan_detail_returns_none_for_invalid_tag_without_network(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        import_service.requests,
+        "get",
+        lambda *args, **kwargs: pytest.fail("network should not be called"),
+    )
+
+    assert import_service._fetch_clan_detail("  #  ") is None
+
+
+def test_fetch_clan_detail_returns_none_for_404(monkeypatch):
+    fake_response = Mock(status_code=404)
+    fake_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(import_service.requests, "get", fake_get)
+
+    assert import_service._fetch_clan_detail("#missing") is None
+    fake_response.raise_for_status.assert_not_called()
+    fake_get.assert_called_once_with(
+        "https://api.clashofclans.com/v1/clans/%23MISSING",
+        headers=import_service.headers,
+        timeout=15,
+    )
+
+
+def test_fetch_clan_detail_raises_and_returns_json_for_success(monkeypatch):
+    fake_response = Mock(status_code=200)
+    fake_response.json.return_value = {"tag": "#TEST123", "name": "test_clan"}
+    fake_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(import_service.requests, "get", fake_get)
+
+    assert import_service._fetch_clan_detail("test123") == {
+        "tag": "#TEST123",
+        "name": "test_clan",
+    }
+    fake_response.raise_for_status.assert_called_once_with()
+
+
+def test_seed_state_helpers_read_update_and_reset(monkeypatch):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+
+    class DummyImportStateCollection:
+        def __init__(self):
+            self.find_one_call = None
+            self.update_calls = []
+
+        def find_one(self, query, projection):
+            self.find_one_call = (query, projection)
+            return {"after": "cursor-1"}
+
+        def update_one(self, query, update, upsert=False):
+            self.update_calls.append((query, update, upsert))
+
+    collection = DummyImportStateCollection()
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+    monkeypatch.setattr(
+        import_service,
+        "_import_state_collection",
+        lambda: collection,
+    )
+
+    assert import_service._get_seed_state("seed-key") == {"after": "cursor-1"}
+    import_service._set_seed_after("seed-key", "cursor-2")
+    import_service._reset_seed_after("seed-key")
+
+    assert collection.find_one_call == (
+        {"seed_key": "seed-key"},
+        {"_id": 0},
+    )
+    assert collection.update_calls == [
+        (
+            {"seed_key": "seed-key"},
+            {
+                "$set": {
+                    "seed_key": "seed-key",
+                    "after": "cursor-2",
+                    "last_run": frozen_now,
+                }
+            },
+            True,
+        ),
+        (
+            {"seed_key": "seed-key"},
+            {
+                "$set": {
+                    "seed_key": "seed-key",
+                    "after": None,
+                    "last_run": frozen_now,
+                }
+            },
+            True,
+        ),
+    ]
+
+
+def test_cleanup_old_imported_clans_deletes_past_retention(monkeypatch):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+
+    class DummyDeleteResult:
+        deleted_count = 4
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.delete_query = None
+
+        def delete_many(self, query):
+            self.delete_query = query
+            return DummyDeleteResult()
+
+    clan_collection = DummyClanCollection()
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+
+    assert import_service.cleanup_old_imported_clans() == 4
+    assert clan_collection.delete_query == {
+        "source": "clash_api_import",
+        "last_discovered": {
+            "$lt": frozen_now - import_service.IMPORTED_CLAN_RETENTION
+        },
+    }
+
+
+def test_discover_imported_clans_resumes_upserts_and_updates_cursor(
+    monkeypatch,
+):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    cleanup_calls = []
+    state_updates = []
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.update_calls = []
+
+        def update_one(self, query, update, upsert=False):
+            self.update_calls.append((query, update, upsert))
+
+    clan_collection = DummyClanCollection()
+    search_calls = []
+
+    def fake_search(seed):
+        search_calls.append(seed)
+        if len(search_calls) == 1:
+            return {
+                "items": [
+                    {
+                        "tag": "#TEST123",
+                        "name": "search_clan",
+                        "clanLevel": 10,
+                        "members": 40,
+                    }
+                ],
+                "after": "cursor-2",
+            }
+        return {"items": [], "after": None}
+
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+    monkeypatch.setattr(
+        import_service,
+        "cleanup_old_imported_clans",
+        lambda: cleanup_calls.append(True),
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_build_discovery_seeds",
+        lambda: [{"name": "test", "limit": 10}],
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_get_seed_state",
+        lambda seed_key: {"after": "cursor-1"},
+    )
+    monkeypatch.setattr(import_service, "_search_clans", fake_search)
+    monkeypatch.setattr(
+        import_service,
+        "_fetch_clan_detail",
+        lambda clan_tag: {
+            "tag": "#TEST123",
+            "name": "test_clan",
+            "clanLevel": 10,
+            "members": 40,
+            "requiredTownhallLevel": 13,
+        },
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_set_seed_after",
+        lambda seed_key, after: state_updates.append((seed_key, after)),
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+
+    assert import_service.discover_imported_clans(max_seeds=1) == 1
+
+    seed_key = "limit:10|name:test"
+    assert cleanup_calls == [True]
+    assert search_calls == [
+        {"name": "test", "limit": 10, "after": "cursor-1"},
+        {"name": "test", "limit": 10, "after": "cursor-2"},
+    ]
+    assert state_updates == [(seed_key, "cursor-2"), (seed_key, None)]
+    update_query, update_doc, upsert = clan_collection.update_calls[0]
+    assert update_query == {
+        "clan_tag": "TEST123",
+        "source": "clash_api_import",
+    }
+    assert upsert is True
+    assert update_doc["$set"]["name"] == "test_clan"
+    assert update_doc["$set"]["requirements"] == [0, 0, 13]
+    assert update_doc["$set"]["last_discovered"] == frozen_now
+
+
+def test_discover_imported_clans_skips_low_quality_bad_tags_and_bad_detail(
+    monkeypatch,
+):
+    class DummyClanCollection:
+        def __init__(self):
+            self.update_calls = []
+
+        def update_one(self, query, update, upsert=False):
+            self.update_calls.append((query, update, upsert))
+
+    clan_collection = DummyClanCollection()
+
+    def fake_fetch(clan_tag):
+        if clan_tag == "RAISES":
+            raise requests.RequestException("detail failed")
+        if clan_tag == "MISSING":
+            return None
+        if clan_tag == "LOWDETAIL":
+            return {"tag": "#LOWDETAIL", "clanLevel": 4, "members": 40}
+        return {"tag": f"#{clan_tag}", "clanLevel": 10, "members": 40}
+
+    monkeypatch.setattr(
+        import_service,
+        "cleanup_old_imported_clans",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_build_discovery_seeds",
+        lambda: [{"name": "test", "limit": 10}],
+    )
+    monkeypatch.setattr(import_service, "_get_seed_state", lambda seed_key: {})
+    monkeypatch.setattr(
+        import_service,
+        "_search_clans",
+        lambda seed: {
+            "items": [
+                {"tag": "#LOWSEARCH", "clanLevel": 4, "members": 40},
+                {"tag": "  #  ", "clanLevel": 10, "members": 40},
+                {"tag": "#RAISES", "clanLevel": 10, "members": 40},
+                {"tag": "#MISSING", "clanLevel": 10, "members": 40},
+                {"tag": "#LOWDETAIL", "clanLevel": 10, "members": 40},
+            ],
+            "after": None,
+        },
+    )
+    monkeypatch.setattr(import_service, "_fetch_clan_detail", fake_fetch)
+    monkeypatch.setattr(
+        import_service,
+        "_reset_seed_after",
+        lambda seed_key: None,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+
+    assert import_service.discover_imported_clans(max_seeds=1) == 0
+    assert clan_collection.update_calls == []
+
+
+def test_discover_imported_clans_breaks_seed_on_search_error(monkeypatch):
+    search_calls = []
+    reset_calls = []
+
+    def fake_search(seed):
+        search_calls.append(seed)
+        raise requests.RequestException("search failed")
+
+    monkeypatch.setattr(
+        import_service,
+        "cleanup_old_imported_clans",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_build_discovery_seeds",
+        lambda: [{"name": "test", "limit": 10}],
+    )
+    monkeypatch.setattr(import_service, "_get_seed_state", lambda seed_key: {})
+    monkeypatch.setattr(import_service, "_search_clans", fake_search)
+    monkeypatch.setattr(
+        import_service,
+        "_reset_seed_after",
+        lambda seed_key: reset_calls.append(seed_key),
+    )
+
+    assert import_service.discover_imported_clans(max_seeds=1) == 0
+    assert search_calls == [{"name": "test", "limit": 10}]
+    assert reset_calls == []
+
+
+def test_discover_imported_clans_task_delegates(monkeypatch):
+    monkeypatch.setattr(import_service, "discover_imported_clans", lambda: 7)
+
+    assert import_service.discover_imported_clans_task() == 7
+
+
+def test_run_import_refresh_on_worker_start_queues_task():
+    sender = Mock()
+
+    import_service.run_import_refresh_on_worker_start(sender=sender)
+    import_service.run_import_refresh_on_worker_start(sender=None)
+
+    sender.app.send_task.assert_called_once_with("discover_imported_clans_task")
+
+
+def test_ensure_imported_clan_inventory_skips_when_recent_count_is_enough(
+    monkeypatch,
+):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    discover_calls = []
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.count_query = None
+
+        def count_documents(self, query):
+            self.count_query = query
+            return 30
+
+    clan_collection = DummyClanCollection()
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "discover_imported_clans",
+        lambda: discover_calls.append(True),
+    )
+
+    import_service.ensure_imported_clan_inventory(min_complete=30)
+
+    assert discover_calls == []
+    assert clan_collection.count_query == {
+        "source": "clash_api_import",
+        "last_discovered": {
+            "$gte": frozen_now - import_service.DISCOVERY_STALE_AFTER
+        },
+    }
+
+
+def test_ensure_imported_clan_inventory_discovers_when_count_is_low(
+    monkeypatch,
+):
+    discover_calls = []
+
+    class DummyClanCollection:
+        def count_documents(self, query):
+            return 2
+
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: DummyClanCollection(),
+    )
+    monkeypatch.setattr(
+        import_service,
+        "discover_imported_clans",
+        lambda: discover_calls.append(True),
+    )
+
+    import_service.ensure_imported_clan_inventory(min_complete=30)
+
+    assert discover_calls == [True]
+
+
+def test_get_imported_clan_returns_cached_document_without_fetch(
+    monkeypatch,
+):
+    cached = {"clan_tag": "TEST123", "name": "test_clan"}
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.find_one_calls = []
+
+        def find_one(self, query, projection):
+            self.find_one_calls.append((query, projection))
+            return cached
+
+    clan_collection = DummyClanCollection()
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_fetch_clan_detail",
+        lambda clan_tag: pytest.fail("detail fetch should not be called"),
+    )
+
+    result = import_service.get_imported_clan(" #test123 ")
+
+    assert result == cached
+    assert clan_collection.find_one_calls == [
+        (
+            {"clan_tag": "TEST123", "source": "clash_api_import"},
+            {"_id": 0},
+        )
+    ]
+
+
+def test_get_imported_clan_fetches_caches_and_returns_imported_document(
+    monkeypatch,
+):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    imported = {"clan_tag": "TEST123", "name": "test_clan"}
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.find_one_calls = []
+            self.update_call = None
+
+        def find_one(self, query, projection):
+            self.find_one_calls.append((query, projection))
+            if len(self.find_one_calls) == 1:
+                return None
+            return imported
+
+        def update_one(self, query, update, upsert=False):
+            self.update_call = (query, update, upsert)
+
+    clan_collection = DummyClanCollection()
+    monkeypatch.setattr(import_service, "_now", lambda: frozen_now)
+    monkeypatch.setattr(
+        import_service,
+        "_clan_collection",
+        lambda: clan_collection,
+    )
+    monkeypatch.setattr(
+        import_service,
+        "_fetch_clan_detail",
+        lambda clan_tag: {
+            "tag": "#TEST123",
+            "name": "test_clan",
+            "description": "  cached description  ",
+            "location": {"id": 32000007, "name": "International"},
+            "badgeUrls": {"medium": "badge_url"},
+            "clanLevel": 10,
+            "members": 42,
+            "type": "inviteOnly",
+            "warFrequency": "always",
+            "clanPoints": 36000,
+            "requiredBuilderBaseTrophies": 2200,
+            "requiredTownhallLevel": 13,
+        },
+    )
+
+    result = import_service.get_imported_clan("TEST123")
+    update_query, update_doc, upsert = clan_collection.update_call
+    set_doc = update_doc["$set"]
+
+    assert result == imported
+    assert update_query == {
+        "clan_tag": "TEST123",
+        "source": "clash_api_import",
+    }
+    assert upsert is True
+    assert set_doc["clan_tag"] == "TEST123"
+    assert set_doc["name"] == "test_clan"
+    assert set_doc["requirements"] == [0, 2200, 13]
+    assert set_doc["last_discovered"] == frozen_now
+    assert set_doc["last_updated"] == frozen_now
+    assert set_doc["clan_info"] == {
+        "description": "cached description",
+        "location": {"id": 32000007, "name": "International"},
+        "badge": "badge_url",
+        "clan_level": 10,
+        "member_count": 42,
+        "type": "inviteOnly",
+        "warFrequency": "always",
+        "clanPoints": 36000,
+    }

--- a/tests/test_imported_clan_helpers.py
+++ b/tests/test_imported_clan_helpers.py
@@ -1,0 +1,76 @@
+import pytest
+from ClashRecruit.routes.imported_clans_route import (
+    _build_imported_query,
+    _get_requested_limit,
+    _get_requested_offset,
+)
+from flask import Flask
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/imported_clans", 10),
+        ("/imported_clans?limit=abc", 10),
+        ("/imported_clans?limit=0", 1),
+        ("/imported_clans?limit=500", 200),
+    ],
+)
+def test_get_requested_limit(app: Flask, path: str, expected: int) -> None:
+    with app.test_request_context(path):
+        assert _get_requested_limit(10) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/imported_clans", 0),
+        ("/imported_clans?offset=5", 5),
+        ("/imported_clans?offset=abc", 0),
+        ("/imported_clans?offset=-10", 0),
+    ],
+)
+def test_get_requested_offset(app: Flask, path: str, expected: int) -> None:
+    with app.test_request_context(path):
+        assert _get_requested_offset() == expected
+
+
+def test_build_imported_query_empty_filters_returns_source_only() -> None:
+    assert _build_imported_query({}) == {"source": "clash_api_import"}
+
+
+def test_build_imported_query_escapes_name_and_ignores_empty() -> None:
+    query = _build_imported_query(
+        {
+            "name": "  test.*(name)  ",
+            "warFrequency": "",
+            "location": "",
+        }
+    )
+
+    assert query == {
+        "source": "clash_api_import",
+        "name": {"$regex": "test\\.\\*\\(name\\)", "$options": "i"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("members", "expected"),
+    [
+        ({"min": 20}, {"$gte": 20}),
+        ({"max": 45}, {"$lte": 45}),
+        ({"min": 20, "max": 45}, {"$gte": 20, "$lte": 45}),
+    ],
+)
+def test_build_imported_query_member_ranges(
+    members: dict[str, int],
+    expected: dict[str, int],
+) -> None:
+    query = _build_imported_query(
+        {
+            "requirements": {"members": members},
+        }
+    )
+
+    assert query["source"] == "clash_api_import"
+    assert query["clan_info.member_count"] == expected

--- a/tests/test_imported_clan_helpers.py
+++ b/tests/test_imported_clan_helpers.py
@@ -74,3 +74,22 @@ def test_build_imported_query_member_ranges(
 
     assert query["source"] == "clash_api_import"
     assert query["clan_info.member_count"] == expected
+
+
+def test_build_imported_query_all_scalar_filters() -> None:
+    query = _build_imported_query(
+        {
+            "minClanLevel": 10,
+            "clanPoints": 35000,
+            "warFrequency": "always",
+            "location": "International",
+        }
+    )
+
+    assert query == {
+        "source": "clash_api_import",
+        "clan_info.clan_level": {"$gte": 10},
+        "clan_info.clanPoints": {"$gte": 35000},
+        "clan_info.warFrequency": "always",
+        "clan_info.location.name": "International",
+    }

--- a/tests/test_imports_side_effect_free.py
+++ b/tests/test_imports_side_effect_free.py
@@ -23,9 +23,8 @@ MODULES_TO_IMPORT = [
 class ImportSideEffectsTests(unittest.TestCase):
     def _clear_repo_modules(self):
         for module_name in list(sys.modules):
-            if (
-                module_name == "ClashRecruit"
-                or module_name.startswith("ClashRecruit.")
+            if module_name == "ClashRecruit" or module_name.startswith(
+                "ClashRecruit."
             ):
                 sys.modules.pop(module_name, None)
 

--- a/tests/test_imports_side_effect_free.py
+++ b/tests/test_imports_side_effect_free.py
@@ -7,7 +7,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_PARENT = PROJECT_ROOT.parent
 if str(PROJECT_PARENT) not in sys.path:
@@ -31,7 +30,10 @@ MODULES_TO_IMPORT = [
 class ImportSideEffectsTests(unittest.TestCase):
     def _clear_repo_modules(self):
         for module_name in list(sys.modules):
-            if module_name == "ClashRecruit" or module_name.startswith("ClashRecruit."):
+            if (
+                module_name == "ClashRecruit"
+                or module_name.startswith("ClashRecruit.")
+            ):
                 sys.modules.pop(module_name, None)
 
     def test_importing_backend_modules_does_not_create_mongo_client(self):

--- a/tests/test_imports_side_effect_free.py
+++ b/tests/test_imports_side_effect_free.py
@@ -4,14 +4,7 @@ import importlib
 import os
 import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PROJECT_PARENT = PROJECT_ROOT.parent
-if str(PROJECT_PARENT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_PARENT))
-
 
 MODULES_TO_IMPORT = [
     "ClashRecruit.app",

--- a/tests/test_maxtownhall_service.py
+++ b/tests/test_maxtownhall_service.py
@@ -1,0 +1,88 @@
+from unittest.mock import Mock
+
+import ClashRecruit.services.maxtownhall as maxtownhall
+import pytest
+
+
+class DummyCache:
+    def __init__(self, value=None):
+        self.value = value
+        self.set_calls = []
+
+    def get(self, key):
+        assert key == "MAXTOWNHALL"
+        return self.value
+
+    def set(self, key, value, expire):
+        self.set_calls.append((key, value, expire))
+        self.value = value
+
+
+def test_refresh_returns_cached_max_townhall(monkeypatch):
+    monkeypatch.setattr(maxtownhall, "get_cache", lambda: DummyCache("17"))
+    monkeypatch.setattr(
+        maxtownhall,
+        "get_max_townhall",
+        lambda headers: pytest.fail("API refresh should not be called"),
+    )
+
+    assert maxtownhall.refresh({"Authorization": "Bearer token"}) == 17
+
+
+def test_refresh_fetches_max_townhall_on_cache_miss(monkeypatch):
+    monkeypatch.setattr(maxtownhall, "get_cache", lambda: DummyCache(None))
+    monkeypatch.setattr(maxtownhall, "get_max_townhall", lambda headers: 18)
+
+    assert maxtownhall.refresh({"Authorization": "Bearer token"}) == 18
+
+
+def test_get_max_townhall_fetches_top_player_detail_and_caches(monkeypatch):
+    cache = DummyCache()
+    ranking_response = Mock()
+    ranking_response.json.return_value = {"items": [{"tag": "#PLAYER123"}]}
+    player_response = Mock()
+    player_response.json.return_value = {"townHallLevel": "17"}
+    fake_get = Mock(side_effect=[ranking_response, player_response])
+
+    monkeypatch.setattr(maxtownhall, "get_cache", lambda: cache)
+    monkeypatch.setattr(maxtownhall.requests, "get", fake_get)
+
+    result = maxtownhall.get_max_townhall(
+        {"Authorization": "Bearer token"}
+    )
+
+    assert result == 17
+    assert cache.set_calls == [("MAXTOWNHALL", 17, 86400)]
+    assert fake_get.call_args_list == [
+        (
+            (
+                "https://api.clashofclans.com/v1/locations/32000249/"
+                "rankings/players?limit=1",
+            ),
+            {"headers": {"Authorization": "Bearer token"}},
+        ),
+        (
+            ("https://api.clashofclans.com/v1/players/%23PLAYER123",),
+            {"headers": {"Authorization": "Bearer token"}},
+        ),
+    ]
+
+
+def test_get_max_townhall_raises_when_player_detail_has_no_townhall(
+    monkeypatch,
+):
+    ranking_response = Mock()
+    ranking_response.json.return_value = {"items": [{"tag": "#PLAYER123"}]}
+    player_response = Mock()
+    player_response.json.return_value = {}
+    monkeypatch.setattr(
+        maxtownhall.requests,
+        "get",
+        Mock(side_effect=[ranking_response, player_response]),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Missing 'townHallLevel' in Clash API response.",
+    ):
+        maxtownhall.get_max_townhall({"Authorization": "Bearer token"})

--- a/tests/test_recruitee_api.py
+++ b/tests/test_recruitee_api.py
@@ -1,0 +1,89 @@
+from unittest.mock import Mock
+
+from ClashRecruit.api.recruitee_api import Recruitee
+from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
+
+
+def test_search_clan_success_without_after(monkeypatch) -> None:
+    user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
+    filters = {"name": "test_filter"}
+
+    fake_response = Mock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "items": [{"tag": "#ABC"}],
+        "paging": {"cursors": {"after": "cursor-1"}},
+    }
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruitee_api.requests.get",
+        mock_get,
+    )
+
+    result = user.searchClan(filters)
+
+    assert result == {
+        "items": [{"tag": "#ABC"}],
+        "after": "cursor-1",
+        "error": None,
+    }
+    mock_get.assert_called_once_with(
+        "https://api.clashofclans.com/v1/clans",
+        params={"name": "test_filter"},
+        headers=MOCK_HEADERS,
+    )
+
+
+def test_search_clan_includes_after_cursor_in_params(monkeypatch) -> None:
+    user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
+    filters = {"name": "test_filter"}
+
+    fake_response = Mock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"items": []}
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruitee_api.requests.get",
+        mock_get,
+    )
+
+    result = user.searchClan(filters, after="next-cursor")
+
+    assert result["items"] == []
+    assert result["after"] is None
+    assert result["error"] is None
+    assert filters["after"] == "next-cursor"
+    mock_get.assert_called_once_with(
+        "https://api.clashofclans.com/v1/clans",
+        params={"name": "test_filter", "after": "next-cursor"},
+        headers=MOCK_HEADERS,
+    )
+
+
+def test_search_clan_maps_api_error_payload(monkeypatch) -> None:
+    user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.status_code = 400
+    fake_response.json.return_value = {
+        "reason": "badRequest",
+        "message": "At least one filtering parameter must exist",
+    }
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruitee_api.requests.get",
+        mock_get,
+    )
+
+    result = user.searchClan({})
+
+    assert result["items"] == []
+    assert result["after"] is None
+    assert result["error"] == {
+        "reason": "badRequest",
+        "message": "At least one filtering parameter must exist",
+        "status": 400,
+    }

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -32,6 +32,36 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
     )
 
 
+def test_pull_clan_requirements_defaults_when_api_returns_no_items(
+    monkeypatch,
+) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"items": []}
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        Mock(return_value=fake_response),
+    )
+
+    assert user.pull_clan_requirements() == [0, 0, 0]
+
+
+def test_pull_clan_requirements_defaults_when_items_missing(
+    monkeypatch,
+) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {}
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        Mock(return_value=fake_response),
+    )
+
+    assert user.pull_clan_requirements() == [0, 0, 0]
+
+
 def test_lookup_clan_full_payload(monkeypatch) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -1,0 +1,107 @@
+from unittest.mock import Mock
+
+from ClashRecruit.api.recruiter_api import Recruiter
+from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
+
+
+def test_pull_clan_requirements_success(monkeypatch) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "items": [
+            {
+                "requiredTownhallLevel": 12,
+                "requiredBuilderBaseTrophies": 2300,
+            }
+        ]
+    }
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        mock_get,
+    )
+
+    requirements = user.pull_clan_requirements()
+
+    assert requirements == [0, 2300, 12]
+    mock_get.assert_called_once_with(
+        f"https://api.clashofclans.com/v1/clans?name=%23{KNOWN_STABLE_TAG}",
+        headers=MOCK_HEADERS,
+    )
+
+
+def test_lookup_clan_full_payload(monkeypatch) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "name": "Test Clan",
+        "type": "inviteOnly",
+        "description": "Friendly and active",
+        "location": {"id": 32000007, "name": "Canada"},
+        "badgeUrls": {"medium": "badge-medium-url"},
+        "clanLevel": 14,
+        "members": 40,
+        "warFrequency": "always",
+        "clanPoints": 42000,
+    }
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        mock_get,
+    )
+
+    result = user.lookup_clan()
+
+    assert result == {
+        "name": "Test Clan",
+        "type": "inviteOnly",
+        "description": "Friendly and active",
+        "location": {"id": 32000007, "name": "Canada"},
+        "badge": "badge-medium-url",
+        "clan_level": 14,
+        "member_count": 40,
+        "warFrequency": "always",
+        "clanPoints": 42000,
+    }
+    mock_get.assert_called_once_with(
+        f"https://api.clashofclans.com/v1/clans/%23{KNOWN_STABLE_TAG}",
+        headers=MOCK_HEADERS,
+    )
+
+
+def test_lookup_clan_member_count_mode(monkeypatch) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"members": 48}
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        mock_get,
+    )
+
+    result = user.lookup_clan("member_count")
+
+    assert result == {"member_count": 48}
+
+
+def test_lookup_clan_description_mode(monkeypatch) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"description": "War focused clan"}
+    mock_get = Mock(return_value=fake_response)
+
+    monkeypatch.setattr(
+        "ClashRecruit.api.recruiter_api.requests.get",
+        mock_get,
+    )
+
+    result = user.lookup_clan("description")
+
+    assert result == {"description": "War focused clan"}

--- a/tests/test_refresh_db_service.py
+++ b/tests/test_refresh_db_service.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import ClashRecruit.services.refresh_db as refresh_db
+
+
+def test_refresh_membercount_updates_stale_entries(monkeypatch):
+    frozen_now = datetime(2026, 5, 4, tzinfo=timezone.utc)
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.find_query = None
+            self.update_calls = []
+
+        def find(self, query):
+            self.find_query = query
+            return [
+                {"clan_tag": "TEST123", "source": "live_listing"},
+                {"clan_tag": "TEST456", "source": "clash_api_import"},
+            ]
+
+        def update_one(self, query, update):
+            self.update_calls.append((query, update))
+
+    class DummyRecruiter:
+        instances = []
+
+        def __init__(self, clan_tag, headers):
+            self.clan_tag = clan_tag
+            self.headers = headers
+            DummyRecruiter.instances.append(self)
+
+        def lookup_clan(self, mode=None):
+            return {"member_count": 40 if self.clan_tag == "TEST123" else 35}
+
+    class FakeDatetime:
+        @staticmethod
+        def now(tz=None):
+            return frozen_now
+
+    clan_collection = DummyClanCollection()
+    monkeypatch.setattr(
+        refresh_db,
+        "get_clan_collection",
+        lambda: clan_collection,
+    )
+    monkeypatch.setattr(refresh_db, "Recruiter", DummyRecruiter)
+    monkeypatch.setattr(refresh_db, "datetime", FakeDatetime)
+
+    refresh_db.refresh_membercount()
+
+    assert clan_collection.find_query == {
+        "last_updated": {"$lte": frozen_now - refresh_db.THRESHOLD}
+    }
+    assert [instance.clan_tag for instance in DummyRecruiter.instances] == [
+        "TEST123",
+        "TEST456",
+    ]
+    assert clan_collection.update_calls == [
+        (
+            {"clan_tag": "TEST123", "source": "live_listing"},
+            {
+                "$set": {
+                    "last_updated": frozen_now,
+                    "clan_info.member_count": 40,
+                }
+            },
+        ),
+        (
+            {"clan_tag": "TEST456", "source": "clash_api_import"},
+            {
+                "$set": {
+                    "last_updated": frozen_now,
+                    "clan_info.member_count": 35,
+                }
+            },
+        ),
+    ]
+
+
+def test_refresh_task_and_worker_start_delegate(monkeypatch):
+    refresh_calls = []
+    sender = Mock()
+
+    monkeypatch.setattr(
+        refresh_db,
+        "refresh_membercount",
+        lambda: refresh_calls.append(True),
+    )
+
+    refresh_db.task()
+    refresh_db.run_refresh_on_worker_start(sender=sender)
+    refresh_db.run_refresh_on_worker_start(sender=None)
+
+    assert refresh_calls == [True]
+    sender.app.send_task.assert_called_once_with("refresh_membercount_task")


### PR DESCRIPTION
## Summary

- Expanded backend test coverage for Flask routes, API wrappers, and service modules.
- Added coverage for imported clan discovery, cache behavior, cursor state, cleanup, worker hooks, location refresh, max townhall caching, and API preflight checks.
- Added defensive handling for invalid recruiter status, invalid recruitee `location_id`, and empty recruiter API clan search results.

## Testing

- `./venv/bin/ruff check ...`
- `./venv/bin/python -m pytest .`

Result: `130 passed`
