### PR TITLE
ci: run backend tests and lint

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,30 @@
+name: Backend CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run Ruff
+        run: python -m ruff check .
+
+      - name: Run pytest
+        run: python -m pytest .

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ diskcache==5.6.3
 celery==5.6.2
 redis==7.2.0
 ruff==0.15.9
+pytest==7.4.4


### PR DESCRIPTION
## Summary

- Add a Backend CI GitHub Actions workflow for pull requests and pushes to main.
- Set up Python 3.12 with pip caching, install `requirements.txt`, then run Ruff and pytest.

## Validation

- `./venv/bin/ruff check .`
- `./venv/bin/python -m pytest .` (`130 passed`)