### PR TITLE
Fix Celery import paths and move inventory ensure off request path

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ flask run
 
 In separate terminals, start Celery:
 ```
-celery -A ClashRecruiter.services.celery_app:app worker --loglevel=info
-celery -A ClashRecruiter.services.celery_app:app beat --loglevel=info
+celery -A ClashRecruit.services.celery_app:app worker --loglevel=info
+celery -A ClashRecruit.services.celery_app:app beat --loglevel=info
 ```
 
 Backend runs at `http://127.0.0.1:5000`.

--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -7,6 +7,7 @@ import requests
 REQUESTOPTIONS = Literal[
     "expLevel", "leagueTier", "builderBaseLeague", "builderHallLevel", "clan"
 ]
+REQUEST_TIMEOUT_SECONDS = 10
 
 
 class API:
@@ -52,6 +53,7 @@ class API:
             url,
             headers=self.headers,
             json=self.json_data,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         self.apistorage = response.json()
 
@@ -87,7 +89,11 @@ class API:
             self.reason = "User is a Guest"
             return False
         url = f"https://api.clashofclans.com/v1/players/%23{self.user_tag}"
-        response = requests.get(url, headers=self.headers)
+        response = requests.get(
+            url,
+            headers=self.headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
         self.storage = response.json()
         reason = self.storage.get("reason")
 

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -2,6 +2,8 @@
 
 import requests
 
+REQUEST_TIMEOUT_SECONDS = 10
+
 
 class Recruitee:
     """Wrap Clash API calls used by recruitee search routes."""
@@ -35,7 +37,12 @@ class Recruitee:
         if after:
             filter["after"] = after
 
-        response = requests.get(url, params=filter, headers=self.headers)
+        response = requests.get(
+            url,
+            params=filter,
+            headers=self.headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
 
         storage = response.json()
 

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -2,6 +2,8 @@
 
 import requests
 
+REQUEST_TIMEOUT_SECONDS = 10
+
 
 class Recruiter:
     """Wrap Clash API calls used by recruiter-facing routes."""
@@ -26,6 +28,7 @@ class Recruiter:
         response = requests.get(
             f"https://api.clashofclans.com/v1/clans?name=%23{self.clan_tag}",
             headers=self.headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         self.storage = response.json()
         long_list = self.storage.get("items") or []
@@ -60,6 +63,7 @@ class Recruiter:
         response = requests.get(
             f"https://api.clashofclans.com/v1/clans/%23{self.clan_tag}",
             headers=self.headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         response = response.json()
         rsp: dict[str, object] = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,47 +3,58 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   web:
     build: .
     working_dir: /app
-    command: flask --app ClashRecruiter.app run --host=0.0.0.0 --port=5000
+    command: flask --app ClashRecruit.app run --host=0.0.0.0 --port=5000
     env_file:
       - .env
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
     volumes:
-      - .:/app/ClashRecruiter
+      - .:/app/ClashRecruit
     ports:
       - "5000:5000"
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
 
   worker:
     build: .
     working_dir: /app
-    command: celery -A ClashRecruiter.services.celery_app:app worker --loglevel=info
+    command: celery -A ClashRecruit.services.celery_app:app worker --loglevel=info
     env_file:
       - .env
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
     volumes:
-      - .:/app/ClashRecruiter
+      - .:/app/ClashRecruit
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
 
   beat:
     build: .
     working_dir: /app
-    command: celery -A ClashRecruiter.services.celery_app:app beat --loglevel=info
+    command: celery -A ClashRecruit.services.celery_app:app beat --loglevel=info
     env_file:
       - .env
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
     volumes:
-      - .:/app/ClashRecruiter
+      - .:/app/ClashRecruit
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
+    restart: unless-stopped

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -5,7 +5,6 @@ import re
 from flask import Blueprint, jsonify, request
 
 from ..services.import_clash_api_clans import (
-    ensure_imported_clan_inventory,
     get_imported_clan,
 )
 from ..services.mongo_db_client import get_clan_collection
@@ -100,7 +99,6 @@ def imported_clans_post():
             return jsonify({"error": "Imported clan not found"}), 404
         return jsonify(clan)
 
-    ensure_imported_clan_inventory()
 
     filters = raw_form.get("filters", {})
     query = _build_imported_query(filters)

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -4,7 +4,6 @@ import re
 
 from flask import Blueprint, jsonify, request, session
 
-from ..services.import_clash_api_clans import ensure_imported_clan_inventory
 from ..services.mongo_db_client import get_clan_collection
 
 recruitee_bp = Blueprint("recruitee", __name__)
@@ -40,10 +39,6 @@ def _get_requested_offset():
     return max(0, parsed_offset)
 
 
-def _should_refresh_imported_inventory():
-    """Return whether imported inventory should refresh for this request."""
-    return _get_requested_offset() == 0
-
 
 def _should_include_total():
     """Return whether the response should include paginated total metadata."""
@@ -59,8 +54,6 @@ def recruitee_get():
     requested_limit = _get_requested_limit(default_limit)
     requested_offset = _get_requested_offset()
 
-    if _should_refresh_imported_inventory():
-        ensure_imported_clan_inventory()
 
     if not player_name or player_name == "Guest":
         base_query = {}
@@ -111,8 +104,6 @@ def recruitee_post():
             return jsonify({"error": "Clan not found"}), 404
         return jsonify(data)
 
-    if _should_refresh_imported_inventory():
-        ensure_imported_clan_inventory()
 
     filters = raw_form.get("filters", {})
     query = {}

--- a/services/celery_app.py
+++ b/services/celery_app.py
@@ -19,6 +19,10 @@ app.conf.beat_schedule = {
         "task": "refresh_membercount_task",
         "schedule": timedelta(minutes=5),
     },
+    "ensure_imported_clan_inventory_every_30_minutes": {
+        "task": "ensure_imported_clan_inventory_task",
+        "schedule": timedelta(minutes=30),
+    },
     "discover_imported_clans_daily": {
         "task": "discover_imported_clans_task",
         "schedule": timedelta(days=1),

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -292,6 +292,12 @@ def discover_imported_clans_task() -> int:
     return discover_imported_clans()
 
 
+@app.task(name="ensure_imported_clan_inventory_task")
+def ensure_imported_clan_inventory_task(min_complete: int = 30) -> None:
+    """Run imported clan inventory top-up checks as a Celery task."""
+    ensure_imported_clan_inventory(min_complete=min_complete)
+
+
 def cleanup_old_imported_clans() -> int:
     """Delete stale imported clans past retention and return delete count."""
     cutoff = _now() - IMPORTED_CLAN_RETENTION
@@ -418,9 +424,9 @@ def run_import_refresh_on_worker_start(
     sender: Any = None,
     **kwargs: Any,
 ) -> None:
-    """Queue an import discovery task when a Celery worker starts."""
+    """Queue an import inventory ensure task when a Celery worker starts."""
     if sender is not None:
-        sender.app.send_task("discover_imported_clans_task")
+        sender.app.send_task("ensure_imported_clan_inventory_task")
 
 
 def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -5,6 +5,8 @@ from functools import lru_cache
 import requests
 from diskcache import Cache
 
+REQUEST_TIMEOUT_SECONDS = 10
+
 
 @lru_cache(maxsize=1)
 def get_cache() -> Cache:
@@ -30,6 +32,7 @@ def get_max_townhall(headers) -> int:
         "https://api.clashofclans.com/v1/locations/32000249/"
         "rankings/players?limit=1",
         headers=headers,
+        timeout=REQUEST_TIMEOUT_SECONDS,
     )
     response = response.json()
     tag = response["items"][0]["tag"]
@@ -37,6 +40,7 @@ def get_max_townhall(headers) -> int:
     response = requests.get(
         f"https://api.clashofclans.com/v1/players/%23{tag}",
         headers=headers,
+        timeout=REQUEST_TIMEOUT_SECONDS,
     )
     response = response.json()
     max_townhall = response.get("townHallLevel")

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -4,8 +4,6 @@ def test_imported_clans_post_filters_and_paginates(
 ):
     import ClashRecruit.routes.imported_clans_route as imported_clans_route
 
-    refresh_calls = []
-
     class DummyCursor:
         def __init__(self, docs):
             self.docs = docs
@@ -54,14 +52,6 @@ def test_imported_clans_post_filters_and_paginates(
 
     collection = DummyClanCollection()
 
-    def fake_refresh():
-        refresh_calls.append(True)
-
-    monkeypatch.setattr(
-        imported_clans_route,
-        "ensure_imported_clan_inventory",
-        fake_refresh,
-    )
     monkeypatch.setattr(
         imported_clans_route,
         "get_clan_collection",
@@ -99,7 +89,6 @@ def test_imported_clans_post_filters_and_paginates(
         "limit": 1,
         "offset": 1,
     }
-    assert refresh_calls == [True]
     assert collection.count_query == expected_query
     assert collection.find_query == expected_query
     assert collection.find_projection == {"_id": 0}

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -55,7 +55,6 @@ def test_recruitee_get_filters_logged_in_player_with_total(
 ):
     import ClashRecruit.routes.recruitee_route as recruitee_route
 
-    refresh_calls = []
     collection = DummyClanCollection(
         [
             {"clan_tag": "TEST1", "name": "test_clan_1"},
@@ -69,11 +68,6 @@ def test_recruitee_get_filters_logged_in_player_with_total(
         player_league=5,
         player_builderbase_trophies=2200,
         player_townhall=13,
-    )
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: refresh_calls.append(True),
     )
     monkeypatch.setattr(
         recruitee_route,
@@ -96,7 +90,6 @@ def test_recruitee_get_filters_logged_in_player_with_total(
         "limit": 1,
         "offset": 1,
     }
-    assert refresh_calls == []
     assert collection.find_query == expected_query
     assert collection.count_query == expected_query
     assert collection.find_projection == {"_id": 0}
@@ -115,7 +108,6 @@ def test_recruitee_get_returns_guest_default_raw_list(
 ):
     import ClashRecruit.routes.recruitee_route as recruitee_route
 
-    refresh_calls = []
     collection = DummyClanCollection(
         [
             {"clan_tag": "TEST1", "name": "test_clan_1"},
@@ -124,11 +116,6 @@ def test_recruitee_get_returns_guest_default_raw_list(
     )
 
     set_session(player_name="Guest")
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: refresh_calls.append(True),
-    )
     monkeypatch.setattr(
         recruitee_route,
         "get_clan_collection",
@@ -142,7 +129,6 @@ def test_recruitee_get_returns_guest_default_raw_list(
         {"clan_tag": "TEST1", "name": "test_clan_1"},
         {"clan_tag": "TEST2", "name": "test_clan_2"},
     ]
-    assert refresh_calls == [True]
     assert collection.find_query == {}
     assert collection.count_query is None
     assert collection.cursor.skip_count == 0
@@ -155,7 +141,6 @@ def test_recruitee_post_filters_and_paginates_with_total(
 ):
     import ClashRecruit.routes.recruitee_route as recruitee_route
 
-    refresh_calls = []
     collection = DummyClanCollection(
         [
             {"clan_tag": "TEST1", "name": "test_clan_1"},
@@ -164,11 +149,6 @@ def test_recruitee_post_filters_and_paginates_with_total(
         ]
     )
 
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: refresh_calls.append(True),
-    )
     monkeypatch.setattr(
         recruitee_route,
         "get_clan_collection",
@@ -214,7 +194,6 @@ def test_recruitee_post_filters_and_paginates_with_total(
         "limit": 2,
         "offset": 0,
     }
-    assert refresh_calls == [True]
     assert collection.find_query == expected_query
     assert collection.count_query == expected_query
     assert collection.find_projection == {"_id": 0}
@@ -256,14 +235,8 @@ def test_recruitee_post_filters_by_location_name_without_location_id(
 ):
     import ClashRecruit.routes.recruitee_route as recruitee_route
 
-    refresh_calls = []
     collection = DummyClanCollection(
         [{"clan_tag": "TEST123", "name": "test_clan"}]
-    )
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: refresh_calls.append(True),
     )
     monkeypatch.setattr(
         recruitee_route,
@@ -280,7 +253,6 @@ def test_recruitee_post_filters_by_location_name_without_location_id(
     assert response.get_json() == [
         {"clan_tag": "TEST123", "name": "test_clan"}
     ]
-    assert refresh_calls == [True]
     assert collection.find_query == {
         "clan_info.location.name": "International",
     }
@@ -295,11 +267,6 @@ def test_recruitee_uses_defaults_for_invalid_limit_and_offset(
 
     collection = DummyClanCollection(
         [{"clan_tag": "TEST123", "name": "test_clan"}]
-    )
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: None,
     )
     monkeypatch.setattr(
         recruitee_route,
@@ -329,11 +296,6 @@ def test_recruitee_post_returns_400_for_invalid_location_id(
     import ClashRecruit.routes.recruitee_route as recruitee_route
 
     collection = DummyClanCollection()
-    monkeypatch.setattr(
-        recruitee_route,
-        "ensure_imported_clan_inventory",
-        lambda: None,
-    )
     monkeypatch.setattr(
         recruitee_route,
         "get_clan_collection",

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -559,13 +559,30 @@ def test_discover_imported_clans_task_delegates(monkeypatch):
     assert import_service.discover_imported_clans_task() == 7
 
 
+def test_ensure_imported_clan_inventory_task_delegates(monkeypatch):
+    ensure_calls = []
+
+    monkeypatch.setattr(
+        import_service,
+        "ensure_imported_clan_inventory",
+        lambda min_complete=30: ensure_calls.append(min_complete),
+    )
+
+    import_service.ensure_imported_clan_inventory_task()
+    import_service.ensure_imported_clan_inventory_task(min_complete=42)
+
+    assert ensure_calls == [30, 42]
+
+
 def test_run_import_refresh_on_worker_start_queues_task():
     sender = Mock()
 
     import_service.run_import_refresh_on_worker_start(sender=sender)
     import_service.run_import_refresh_on_worker_start(sender=None)
 
-    sender.app.send_task.assert_called_once_with("discover_imported_clans_task")
+    sender.app.send_task.assert_called_once_with(
+        "ensure_imported_clan_inventory_task"
+    )
 
 
 def test_ensure_imported_clan_inventory_skips_when_recent_count_is_enough(

--- a/tests/test_maxtownhall_service.py
+++ b/tests/test_maxtownhall_service.py
@@ -59,11 +59,17 @@ def test_get_max_townhall_fetches_top_player_detail_and_caches(monkeypatch):
                 "https://api.clashofclans.com/v1/locations/32000249/"
                 "rankings/players?limit=1",
             ),
-            {"headers": {"Authorization": "Bearer token"}},
+            {
+                "headers": {"Authorization": "Bearer token"},
+                "timeout": 10,
+            },
         ),
         (
             ("https://api.clashofclans.com/v1/players/%23PLAYER123",),
-            {"headers": {"Authorization": "Bearer token"}},
+            {
+                "headers": {"Authorization": "Bearer token"},
+                "timeout": 10,
+            },
         ),
     ]
 

--- a/tests/test_recruitee_api.py
+++ b/tests/test_recruitee_api.py
@@ -32,6 +32,7 @@ def test_search_clan_success_without_after(monkeypatch) -> None:
         "https://api.clashofclans.com/v1/clans",
         params={"name": "test_filter"},
         headers=MOCK_HEADERS,
+        timeout=10,
     )
 
 
@@ -59,6 +60,7 @@ def test_search_clan_includes_after_cursor_in_params(monkeypatch) -> None:
         "https://api.clashofclans.com/v1/clans",
         params={"name": "test_filter", "after": "next-cursor"},
         headers=MOCK_HEADERS,
+        timeout=10,
     )
 
 

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -29,6 +29,7 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
     mock_get.assert_called_once_with(
         f"https://api.clashofclans.com/v1/clans?name=%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,
+        timeout=10,
     )
 
 
@@ -100,6 +101,7 @@ def test_lookup_clan_full_payload(monkeypatch) -> None:
     mock_get.assert_called_once_with(
         f"https://api.clashofclans.com/v1/clans/%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,
+        timeout=10,
     )
 
 


### PR DESCRIPTION
## Summary

- Fix Celery and Docker Compose import paths to use the current `ClashRecruit` package name.
- Move imported clan inventory refresh work out of request handlers and into Celery background tasks.
- Add 10-second timeouts to Clash API requests so external API calls cannot hang indefinitely.
- Add Redis health checks and restart policies for the Docker Compose web, worker, and beat services.
- Update route/service/API tests for the new background refresh behavior and request timeout arguments.

## Why

Imported clan inventory checks were previously triggered during recruitee and imported-clan requests, which could add avoidable latency to user-facing routes. This branch shifts that work to Celery startup and scheduled jobs, keeping request handling focused on reading existing clan data.

## Testing

- `venv/bin/python -m pytest`
- 131 passed in 0.47s

