### PR TITLE
refactor: extract recruiter listing service

### DIFF
--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -1,13 +1,11 @@
 """Register routes for handling recruiter requests."""
 
-from datetime import datetime, timedelta, timezone
-
 from flask import Blueprint, jsonify, request, session
 
-from ..api.recruiter_api import Recruiter
-from ..config import headers
-from ..services.maxtownhall import refresh
-from ..services.mongo_db_client import get_clan_collection
+from ..services.recruiter_listing import (
+    get_recruiter_listing_page,
+    handle_recruiter_listing_action,
+)
 
 recruiter_bp = Blueprint("recruiter", __name__)
 
@@ -18,114 +16,16 @@ def recruit():
     if not session.get("recruiter_status"):
         return jsonify({"message": "Forbidden"}), 403
 
-    clan_collection = get_clan_collection()
-
-    existing = clan_collection.find_one(
-        {
-            "clan_tag": session.get("clan_tag"),
-            "source": {"$ne": "clash_api_import"},
-        }
-    )
-
-    user = Recruiter(session.get("clan_tag"), headers)
-    user.pull_clan_requirements()
     if request.method == "GET":
-        if existing:
-            required_league = existing["requirements"][0]
-            required_builder_league = existing["requirements"][1]
-            required_townhall = existing["requirements"][2]
-            clan_description = existing.get("clan_info", {}).get(
-                "description", ""
-            )
-            status = existing["expires"]
-        else:
-            required_league = user.requirements[0]
-            required_builder_league = user.requirements[1]
-            required_townhall = user.requirements[2]
-            clan_description = user.lookup_clan("description")["description"]
-            status = None
-
-        MAXTOWNHALL = refresh(headers)
-        return jsonify(
-            {
-                "oldRequiredLeague": required_league,
-                "oldRequiredBuilderLeague": required_builder_league,
-                "oldRequiredTownhall": required_townhall,
-                "MAXTOWNHALL": MAXTOWNHALL,
-                "clanDescription": clan_description,
-                "status": status,
-            }
+        payload, status_code = get_recruiter_listing_page(
+            session.get("clan_tag")
         )
+        return jsonify(payload), status_code
 
     data = request.get_json(silent=True) or {}
-    listing_status = data.get("status")
-    if listing_status not in {"new", "update", "removeListing"}:
-        return jsonify({"message": "Invalid listing status."}), 400
-
-    if listing_status == "removeListing":
-        deleted = clan_collection.delete_one(
-            {
-                "clan_tag": session.get("clan_tag"),
-                "source": {"$ne": "clash_api_import"},
-            }
-        )
-        if deleted.deleted_count:
-            message = "Successfully deleted entry."
-            return jsonify({"message": message}), 200
-
-        return jsonify({"message": "Failed to delete."}), 404
-
-    new_required_league = data.get("requiredLeague", None)
-    new_required_builder_league = data.get("requiredBuilderLeague", None)
-    new_required_townhall = data.get("requiredTownhall", None)
-    user.requirements[0] = new_required_league
-    user.requirements[1] = new_required_builder_league
-    user.requirements[2] = new_required_townhall
-    clan_info = user.lookup_clan()
-
-    if listing_status == "new":
-        expiry = datetime.now(timezone.utc) + timedelta(days=7)
-        clan_info["description"] = data.get("description")
-        data = {
-            "source": "live_listing",
-            "requirements": user.requirements,
-            "name": clan_info.get("name"),
-            "clan_tag": session.get("clan_tag"),
-            "player_tag": session.get("player_tag"),
-            "clan_info": clan_info,
-            "last_updated": datetime.now(timezone.utc),
-            "expires": expiry,
-        }
-        render_data = data.copy()
-        clan_collection.insert_one(data)
-        render_data["status"] = expiry
-        render_data["message"] = "Listing created successfully."
-
-    elif listing_status == "update":
-        query = {
-            "source": "live_listing",
-            "requirements": user.requirements,
-            "clan_info.description": data.get("description"),
-            "last_updated": datetime.now(timezone.utc),
-        }
-
-        if data.get("updateExpiry") is True:
-            expiry = datetime.now(timezone.utc) + timedelta(days=7)
-            query["expires"] = expiry
-            status = expiry
-        else:
-            status = data.get("expiry")
-
-        clan_collection.update_one(
-            {
-                "clan_tag": session.get("clan_tag"),
-                "source": {"$ne": "clash_api_import"},
-            },
-            {"$set": query},
-        )
-        render_data = {
-            "status": status,
-            "message": "Listing updated successfully.",
-        }
-
-    return jsonify(render_data), 200
+    payload, status_code = handle_recruiter_listing_action(
+        session.get("clan_tag"),
+        session.get("player_tag"),
+        data,
+    )
+    return jsonify(payload), status_code

--- a/services/recruiter_listing.py
+++ b/services/recruiter_listing.py
@@ -1,0 +1,167 @@
+"""Service functions for recruiter listing lifecycle operations."""
+
+from datetime import datetime, timedelta, timezone
+
+from ..api.recruiter_api import Recruiter
+from ..config import headers
+from .maxtownhall import refresh
+from .mongo_db_client import get_clan_collection
+
+LISTING_DURATION = timedelta(days=7)
+VALID_LISTING_STATUSES = {"new", "update", "removeListing"}
+
+
+def get_recruiter_listing_page(
+    clan_tag: str | None,
+) -> tuple[dict[str, object], int]:
+    """Return recruiter listing form data for a clan."""
+    clan_collection = get_clan_collection()
+    existing = clan_collection.find_one(_listing_query(clan_tag))
+
+    recruiter = _recruiter_with_requirements(clan_tag)
+    if existing:
+        required_league = existing["requirements"][0]
+        required_builder_league = existing["requirements"][1]
+        required_townhall = existing["requirements"][2]
+        clan_description = existing.get("clan_info", {}).get(
+            "description",
+            "",
+        )
+        status = existing["expires"]
+    else:
+        required_league = recruiter.requirements[0]
+        required_builder_league = recruiter.requirements[1]
+        required_townhall = recruiter.requirements[2]
+        clan_description = recruiter.lookup_clan("description")[
+            "description"
+        ]
+        status = None
+
+    return (
+        {
+            "oldRequiredLeague": required_league,
+            "oldRequiredBuilderLeague": required_builder_league,
+            "oldRequiredTownhall": required_townhall,
+            "MAXTOWNHALL": refresh(headers),
+            "clanDescription": clan_description,
+            "status": status,
+        },
+        200,
+    )
+
+
+def handle_recruiter_listing_action(
+    clan_tag: str | None,
+    player_tag: str | None,
+    data: dict[str, object],
+) -> tuple[dict[str, object], int]:
+    """Create, update, or remove a recruiter listing from request data."""
+    listing_status = data.get("status")
+    if listing_status not in VALID_LISTING_STATUSES:
+        return {"message": "Invalid listing status."}, 400
+
+    if listing_status == "removeListing":
+        return remove_recruiter_listing(clan_tag)
+
+    if listing_status == "new":
+        return create_recruiter_listing(clan_tag, player_tag, data)
+
+    return update_recruiter_listing(clan_tag, data)
+
+
+def create_recruiter_listing(
+    clan_tag: str | None,
+    player_tag: str | None,
+    data: dict[str, object],
+) -> tuple[dict[str, object], int]:
+    """Create a live recruiter listing for a clan."""
+    clan_collection = get_clan_collection()
+    recruiter = _recruiter_with_requirements(clan_tag)
+    _set_requirements_from_data(recruiter, data)
+
+    clan_info = recruiter.lookup_clan()
+    clan_info["description"] = data.get("description")
+
+    now = datetime.now(timezone.utc)
+    expiry = now + LISTING_DURATION
+    document = {
+        "source": "live_listing",
+        "requirements": recruiter.requirements,
+        "name": clan_info.get("name"),
+        "clan_tag": clan_tag,
+        "player_tag": player_tag,
+        "clan_info": clan_info,
+        "last_updated": now,
+        "expires": expiry,
+    }
+    render_data = document.copy()
+    clan_collection.insert_one(document)
+    render_data["status"] = expiry
+    render_data["message"] = "Listing created successfully."
+
+    return render_data, 200
+
+
+def update_recruiter_listing(
+    clan_tag: str | None,
+    data: dict[str, object],
+) -> tuple[dict[str, object], int]:
+    """Update a live recruiter listing for a clan."""
+    clan_collection = get_clan_collection()
+    recruiter = _recruiter_with_requirements(clan_tag)
+    _set_requirements_from_data(recruiter, data)
+
+    update_doc = {
+        "source": "live_listing",
+        "requirements": recruiter.requirements,
+        "clan_info.description": data.get("description"),
+        "last_updated": datetime.now(timezone.utc),
+    }
+
+    if data.get("updateExpiry") is True:
+        expiry = datetime.now(timezone.utc) + LISTING_DURATION
+        update_doc["expires"] = expiry
+        status = expiry
+    else:
+        status = data.get("expiry")
+
+    clan_collection.update_one(
+        _listing_query(clan_tag),
+        {"$set": update_doc},
+    )
+
+    return {"status": status, "message": "Listing updated successfully."}, 200
+
+
+def remove_recruiter_listing(
+    clan_tag: str | None,
+) -> tuple[dict[str, object], int]:
+    """Remove a live recruiter listing for a clan."""
+    clan_collection = get_clan_collection()
+    deleted = clan_collection.delete_one(_listing_query(clan_tag))
+    if deleted.deleted_count:
+        return {"message": "Successfully deleted entry."}, 200
+
+    return {"message": "Failed to delete."}, 404
+
+
+def _listing_query(clan_tag: str | None) -> dict[str, object]:
+    return {
+        "clan_tag": clan_tag,
+        "source": {"$ne": "clash_api_import"},
+    }
+
+
+def _recruiter_with_requirements(clan_tag: str | None) -> Recruiter:
+    recruiter = Recruiter(clan_tag, headers)
+    recruiter.pull_clan_requirements()
+    return recruiter
+
+
+def _set_requirements_from_data(
+    recruiter: Recruiter,
+    data: dict[str, object],
+) -> None:
+    recruiter.requirements[0] = data.get("requiredLeague")
+    recruiter.requirements[1] = data.get("requiredBuilderLeague")
+    recruiter.requirements[2] = data.get("requiredTownhall")

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -58,17 +58,17 @@ class DummyRecruiter:
 
 
 def setup_recruiter_route(monkeypatch, collection):
-    import ClashRecruit.routes.recruiter_route as recruiter_route
+    import ClashRecruit.services.recruiter_listing as recruiter_listing
 
     DummyRecruiter.instances = []
-    monkeypatch.setattr(recruiter_route, "Recruiter", DummyRecruiter)
+    monkeypatch.setattr(recruiter_listing, "Recruiter", DummyRecruiter)
     monkeypatch.setattr(
-        recruiter_route,
+        recruiter_listing,
         "get_clan_collection",
         lambda: collection,
     )
-    monkeypatch.setattr(recruiter_route, "refresh", lambda headers: 17)
-    return recruiter_route
+    monkeypatch.setattr(recruiter_listing, "refresh", lambda headers: 17)
+    return recruiter_listing
 
 
 def test_recruiter_get_forbidden_without_recruiter_status(client):

--- a/tests/test_recruiter_listing_service.py
+++ b/tests/test_recruiter_listing_service.py
@@ -1,0 +1,268 @@
+from datetime import datetime, timedelta, timezone
+
+import ClashRecruit.services.recruiter_listing as recruiter_listing
+
+FROZEN_NOW = datetime(2026, 5, 12, 12, 30, tzinfo=timezone.utc)
+
+
+class DummyDeleteResult:
+    def __init__(self, deleted_count):
+        self.deleted_count = deleted_count
+
+
+class DummyClanCollection:
+    def __init__(self, existing=None, deleted_count=1):
+        self.existing = existing
+        self.deleted_count = deleted_count
+        self.find_one_query = None
+        self.inserted_doc = None
+        self.update_call = None
+        self.delete_query = None
+
+    def find_one(self, query):
+        self.find_one_query = query
+        return self.existing
+
+    def insert_one(self, doc):
+        self.inserted_doc = doc
+
+    def update_one(self, query, update):
+        self.update_call = (query, update)
+
+    def delete_one(self, query):
+        self.delete_query = query
+        return DummyDeleteResult(self.deleted_count)
+
+
+class DummyRecruiter:
+    instances = []
+
+    def __init__(self, clan_tag, headers):
+        self.clan_tag = clan_tag
+        self.headers = headers
+        self.requirements = [1, 2, 3]
+        self.pull_called = False
+        self.lookup_modes = []
+        DummyRecruiter.instances.append(self)
+
+    def pull_clan_requirements(self):
+        self.pull_called = True
+        return self.requirements
+
+    def lookup_clan(self, mode=None):
+        self.lookup_modes.append(mode)
+        if mode == "description":
+            return {"description": "test_clan_description"}
+
+        return {
+            "name": "test_clan",
+            "description": "original_description",
+            "member_count": 40,
+        }
+
+
+class FakeDatetime:
+    @staticmethod
+    def now(tz=None):
+        return FROZEN_NOW
+
+
+def setup_recruiter_listing(monkeypatch, collection):
+    DummyRecruiter.instances = []
+    monkeypatch.setattr(recruiter_listing, "Recruiter", DummyRecruiter)
+    monkeypatch.setattr(
+        recruiter_listing,
+        "get_clan_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(recruiter_listing, "refresh", lambda headers: 17)
+    monkeypatch.setattr(recruiter_listing, "datetime", FakeDatetime)
+
+
+def test_get_recruiter_listing_page_returns_existing_listing(monkeypatch):
+    existing = {
+        "requirements": [4, 1800, 12],
+        "clan_info": {"description": "existing_description"},
+        "expires": "existing_expiry",
+    }
+    collection = DummyClanCollection(existing=existing)
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.get_recruiter_listing_page(
+        "TEST123"
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "oldRequiredLeague": 4,
+        "oldRequiredBuilderLeague": 1800,
+        "oldRequiredTownhall": 12,
+        "MAXTOWNHALL": 17,
+        "clanDescription": "existing_description",
+        "status": "existing_expiry",
+    }
+    assert collection.find_one_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert DummyRecruiter.instances[0].pull_called is True
+    assert DummyRecruiter.instances[0].lookup_modes == []
+
+
+def test_get_recruiter_listing_page_uses_clash_defaults(monkeypatch):
+    collection = DummyClanCollection(existing=None)
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.get_recruiter_listing_page(
+        "TEST123"
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "oldRequiredLeague": 1,
+        "oldRequiredBuilderLeague": 2,
+        "oldRequiredTownhall": 3,
+        "MAXTOWNHALL": 17,
+        "clanDescription": "test_clan_description",
+        "status": None,
+    }
+    assert DummyRecruiter.instances[0].lookup_modes == ["description"]
+
+
+def test_create_recruiter_listing_inserts_live_listing(monkeypatch):
+    collection = DummyClanCollection()
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.create_recruiter_listing(
+        "TEST123",
+        "PLAYER123",
+        {
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 2400,
+            "requiredTownhall": 13,
+            "description": "new_description",
+        },
+    )
+
+    expiry = FROZEN_NOW + timedelta(days=7)
+    assert status_code == 200
+    assert payload["message"] == "Listing created successfully."
+    assert payload["source"] == "live_listing"
+    assert payload["requirements"] == [5, 2400, 13]
+    assert payload["name"] == "test_clan"
+    assert payload["clan_tag"] == "TEST123"
+    assert payload["player_tag"] == "PLAYER123"
+    assert payload["clan_info"]["description"] == "new_description"
+    assert payload["last_updated"] == FROZEN_NOW
+    assert payload["expires"] == expiry
+    assert payload["status"] == expiry
+    assert collection.inserted_doc["last_updated"] == FROZEN_NOW
+    assert collection.inserted_doc["expires"] == expiry
+
+
+def test_update_recruiter_listing_refreshes_expiry(monkeypatch):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.update_recruiter_listing(
+        "TEST123",
+        {
+            "requiredLeague": 6,
+            "requiredBuilderLeague": 2600,
+            "requiredTownhall": 14,
+            "description": "updated_description",
+            "updateExpiry": True,
+        },
+    )
+    update_query, update_doc = collection.update_call
+    set_doc = update_doc["$set"]
+    expiry = FROZEN_NOW + timedelta(days=7)
+
+    assert status_code == 200
+    assert payload == {
+        "status": expiry,
+        "message": "Listing updated successfully.",
+    }
+    assert update_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+    assert set_doc == {
+        "source": "live_listing",
+        "requirements": [6, 2600, 14],
+        "clan_info.description": "updated_description",
+        "last_updated": FROZEN_NOW,
+        "expires": expiry,
+    }
+
+
+def test_update_recruiter_listing_preserves_provided_expiry(monkeypatch):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.update_recruiter_listing(
+        "TEST123",
+        {
+            "requiredLeague": 6,
+            "requiredBuilderLeague": 2600,
+            "requiredTownhall": 14,
+            "description": "updated_description",
+            "updateExpiry": False,
+            "expiry": "provided_expiry",
+        },
+    )
+    _, update_doc = collection.update_call
+    set_doc = update_doc["$set"]
+
+    assert status_code == 200
+    assert payload == {
+        "status": "provided_expiry",
+        "message": "Listing updated successfully.",
+    }
+    assert "expires" not in set_doc
+
+
+def test_remove_recruiter_listing_returns_delete_result(monkeypatch):
+    collection = DummyClanCollection(deleted_count=1)
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.remove_recruiter_listing(
+        "TEST123"
+    )
+
+    assert status_code == 200
+    assert payload == {"message": "Successfully deleted entry."}
+    assert collection.delete_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+
+
+def test_remove_recruiter_listing_returns_404_when_not_deleted(monkeypatch):
+    collection = DummyClanCollection(deleted_count=0)
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.remove_recruiter_listing(
+        "TEST123"
+    )
+
+    assert status_code == 404
+    assert payload == {"message": "Failed to delete."}
+
+
+def test_handle_recruiter_listing_action_rejects_unknown_status(monkeypatch):
+    collection = DummyClanCollection()
+    setup_recruiter_listing(monkeypatch, collection)
+
+    payload, status_code = recruiter_listing.handle_recruiter_listing_action(
+        "TEST123",
+        "PLAYER123",
+        {"status": "unexpected"},
+    )
+
+    assert status_code == 400
+    assert payload == {"message": "Invalid listing status."}
+    assert DummyRecruiter.instances == []
+    assert collection.inserted_doc is None
+    assert collection.update_call is None
+    assert collection.delete_query is None


### PR DESCRIPTION
## Summary

- Move recruiter listing page data and create/update/remove lifecycle logic into `services/recruiter_listing.py`
- Keep `/recruiter` focused on session authorization, request parsing, service dispatch, and JSON responses
- Add direct service coverage for listing lifecycle behavior while preserving route coverage

## Validation

- `./venv/bin/python -m ruff check .`
- `./venv/bin/python -m pytest .` (`139 passed`)