### PR TITLE
Add API rate limits

### DIFF
--- a/frontend/src/Recruiter.jsx
+++ b/frontend/src/Recruiter.jsx
@@ -135,7 +135,9 @@ function Recruiter() {
       })
     });    
     const data = await response.json();
-    setStatus(data.status);
+    if (response.ok && data.status !== undefined) {
+      setStatus(data.status);
+    }
     setSuccessMessage(data.message ?? "");
   };
 

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -5,13 +5,35 @@ from flask import Blueprint, jsonify, request, session
 from ..api.clash_api import API
 from ..config import headers
 from ..services.mongo_db_client import get_clan_collection
+from ..services.rate_limiter import is_rate_limited
+from .rate_limit import rate_limit
 
 home_bp = Blueprint("home", __name__)
+LOGIN_RATE_LIMIT = 5
+LOGIN_RATE_WINDOW_SECONDS = 5
 
 
 @home_bp.post("/")
 def home():
     """Validate a player, store session data, and return login details."""
+    limiter_key = f"login:{request.remote_addr or 'unknown'}"
+    limited, retry_after = is_rate_limited(
+        limiter_key,
+        limit=LOGIN_RATE_LIMIT,
+        window_seconds=LOGIN_RATE_WINDOW_SECONDS,
+    )
+    if limited:
+        response = jsonify(
+            {
+                "message": False,
+                "receivedPlayerTag": (
+                    "Too many login attempts. Please try again shortly."
+                ),
+            }
+        )
+        response.headers["Retry-After"] = str(retry_after)
+        return response, 429
+
     data = request.get_json()
 
     received_tag = data.get("playerTag")
@@ -51,6 +73,7 @@ def home():
 
 
 @home_bp.get("/database_count")
+@rate_limit("database_count", limit=30, window_seconds=60)
 def database_count():
     """Return the current number of stored clans in the database."""
     clan_collection = get_clan_collection()
@@ -58,6 +81,7 @@ def database_count():
 
 
 @home_bp.post("/logout")
+@rate_limit("logout", limit=10, window_seconds=60)
 def logout():
     """Clear the current session and confirm logout."""
     session.clear()

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -8,6 +8,7 @@ from ..services.import_clash_api_clans import (
     get_imported_clan,
 )
 from ..services.mongo_db_client import get_clan_collection
+from .rate_limit import rate_limit
 
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
@@ -84,6 +85,7 @@ def _build_imported_query(filters):
 
 
 @imported_clans_bp.post("/imported_clans")
+@rate_limit("imported_clans", limit=20, window_seconds=60)
 def imported_clans_post():
     """Return clan details for a tag or a filtered imported clan list."""
     clan_collection = get_clan_collection()

--- a/routes/locations_route.py
+++ b/routes/locations_route.py
@@ -3,11 +3,13 @@
 from flask import Blueprint, jsonify
 
 from ..services.mongo_db_client import get_location_collection
+from .rate_limit import rate_limit
 
 locations_bp = Blueprint("locations", __name__)
 
 
 @locations_bp.route("/clash_locations", methods=["GET"])
+@rate_limit("clash_locations", limit=20, window_seconds=60)
 def clash_locations():
     """Return all stored Clash of Clans locations as a JSON array."""
     location_collection = get_location_collection()

--- a/routes/rate_limit.py
+++ b/routes/rate_limit.py
@@ -1,0 +1,42 @@
+"""Flask route helpers for endpoint rate limiting."""
+
+from functools import wraps
+
+from flask import jsonify, request
+
+from ..services.rate_limiter import is_rate_limited
+
+
+def rate_limit(
+    bucket: str,
+    *,
+    limit: int,
+    window_seconds: int,
+):
+    """Return a decorator that rate limits requests by client IP."""
+
+    def decorate(route_handler):
+        @wraps(route_handler)
+        def wrapper(*args, **kwargs):
+            limiter_key = f"{bucket}:{request.remote_addr or 'unknown'}"
+            limited, retry_after = is_rate_limited(
+                limiter_key,
+                limit=limit,
+                window_seconds=window_seconds,
+            )
+            if limited:
+                response = jsonify(
+                    {
+                        "message": (
+                            "Too many requests. Please try again shortly."
+                        )
+                    }
+                )
+                response.headers["Retry-After"] = str(retry_after)
+                return response, 429
+
+            return route_handler(*args, **kwargs)
+
+        return wrapper
+
+    return decorate

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -5,6 +5,7 @@ import re
 from flask import Blueprint, jsonify, request, session
 
 from ..services.mongo_db_client import get_clan_collection
+from .rate_limit import rate_limit
 
 recruitee_bp = Blueprint("recruitee", __name__)
 
@@ -46,6 +47,7 @@ def _should_include_total():
 
 
 @recruitee_bp.get("/recruitee")
+@rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
     """Return clans for the current session with optional total metadata."""
     clan_collection = get_clan_collection()
@@ -88,6 +90,7 @@ def recruitee_get():
 
 
 @recruitee_bp.post("/recruitee")
+@rate_limit("recruitee_post", limit=30, window_seconds=60)
 def recruitee_post():
     """Return clan details by tag or a filtered clan list for recruitees."""
     clan_collection = get_clan_collection()

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -6,8 +6,16 @@ from ..services.recruiter_listing import (
     get_recruiter_listing_page,
     handle_recruiter_listing_action,
 )
+from ..services.rate_limiter import is_rate_limited
 
 recruiter_bp = Blueprint("recruiter", __name__)
+RECRUITER_GET_RATE_LIMIT = 10
+RECRUITER_GET_RATE_WINDOW_SECONDS = 60
+RECRUITER_ACTION_RATE_WINDOW_SECONDS = 60
+RECRUITER_ACTION_RATE_LIMITS = {
+    "new": 1,
+    "update": 2,
+}
 
 
 @recruiter_bp.route("/recruiter", methods=["GET", "POST"])
@@ -17,15 +25,67 @@ def recruit():
         return jsonify({"message": "Forbidden"}), 403
 
     if request.method == "GET":
+        limited_response = _rate_limit_recruiter_get()
+        if limited_response:
+            return limited_response
+
         payload, status_code = get_recruiter_listing_page(
             session.get("clan_tag")
         )
         return jsonify(payload), status_code
 
     data = request.get_json(silent=True) or {}
+    limited_response = _rate_limit_recruiter_action(data)
+    if limited_response:
+        return limited_response
+
     payload, status_code = handle_recruiter_listing_action(
         session.get("clan_tag"),
         session.get("player_tag"),
         data,
     )
     return jsonify(payload), status_code
+
+
+def _rate_limit_recruiter_get():
+    """Return a 429 response when recruiter page loads are being spammed."""
+    limited, retry_after = is_rate_limited(
+        f"recruiter_get:{request.remote_addr or 'unknown'}",
+        limit=RECRUITER_GET_RATE_LIMIT,
+        window_seconds=RECRUITER_GET_RATE_WINDOW_SECONDS,
+    )
+    if not limited:
+        return None
+
+    response = jsonify(
+        {"message": "Too many requests. Please try again shortly."}
+    )
+    response.headers["Retry-After"] = str(retry_after)
+    return response, 429
+
+
+def _rate_limit_recruiter_action(data):
+    """Return a 429 response when a listing mutation is being spammed."""
+    action = data.get("status")
+    limit = RECRUITER_ACTION_RATE_LIMITS.get(action)
+    if limit is None:
+        return None
+
+    clan_tag = session.get("clan_tag") or "unknown"
+    limited, retry_after = is_rate_limited(
+        f"recruiter_action:{action}:{clan_tag}",
+        limit=limit,
+        window_seconds=RECRUITER_ACTION_RATE_WINDOW_SECONDS,
+    )
+    if not limited:
+        return None
+
+    response = jsonify(
+        {
+            "message": (
+                "Please wait before changing your listing again."
+            )
+        }
+    )
+    response.headers["Retry-After"] = str(retry_after)
+    return response, 429

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -2,11 +2,11 @@
 
 from flask import Blueprint, jsonify, request, session
 
+from ..services.rate_limiter import is_rate_limited
 from ..services.recruiter_listing import (
     get_recruiter_listing_page,
     handle_recruiter_listing_action,
 )
-from ..services.rate_limiter import is_rate_limited
 
 recruiter_bp = Blueprint("recruiter", __name__)
 RECRUITER_GET_RATE_LIMIT = 10
@@ -81,11 +81,7 @@ def _rate_limit_recruiter_action(data):
         return None
 
     response = jsonify(
-        {
-            "message": (
-                "Please wait before changing your listing again."
-            )
-        }
+        {"message": ("Please wait before changing your listing again.")}
     )
     response.headers["Retry-After"] = str(retry_after)
     return response, 429

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -3,6 +3,7 @@
 from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import get_clan_collection, get_user_collection
+from .rate_limit import rate_limit
 
 saved_clans_bp = Blueprint("saved_clans", __name__)
 
@@ -68,6 +69,7 @@ def _hydrate_saved_clans(saved_clan_tags):
 
 
 @saved_clans_bp.get("/saved-clans")
+@rate_limit("saved_clans_get", limit=30, window_seconds=60)
 def get_saved_clans():
     """Return the current user's saved clans and limits as JSON."""
     user_collection = get_user_collection()
@@ -95,6 +97,7 @@ def get_saved_clans():
 
 
 @saved_clans_bp.post("/saved-clans/<clan_tag>")
+@rate_limit("saved_clans_post", limit=20, window_seconds=60)
 def add_saved_clan(clan_tag):
     """Return a JSON response after saving a clan tag for the current user.
 
@@ -158,6 +161,7 @@ def add_saved_clan(clan_tag):
 
 
 @saved_clans_bp.delete("/saved-clans/<clan_tag>")
+@rate_limit("saved_clans_delete", limit=20, window_seconds=60)
 def delete_saved_clan(clan_tag):
     """Return a JSON response after removing a saved clan tag for the user.
 

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -4,11 +4,13 @@ from flask import Blueprint, jsonify, request, session
 
 from ..api.recruitee_api import Recruitee
 from ..config import headers
+from .rate_limit import rate_limit
 
 search_clans_bp = Blueprint("search_clans", __name__)
 
 
 @search_clans_bp.post("/search_clans")
+@rate_limit("search_clans", limit=10, window_seconds=60)
 def search_clans():
     """Search clans using provided filters and return matching results."""
     filters = request.get_json() or {}

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -7,11 +7,13 @@ from flask import Blueprint, jsonify, session
 from ..api.clash_api import API
 from ..config import headers
 from ..services.mongo_db_client import get_clan_collection
+from .rate_limit import rate_limit
 
 session_state_bp = Blueprint("session_state", __name__)
 
 
 @session_state_bp.route("/session-state")
+@rate_limit("session_state", limit=20, window_seconds=60)
 def session_state():
     """Return current session status, player state, and active listing info."""
     username = session.get("player_name", "Guest")
@@ -47,6 +49,7 @@ def session_state():
 
 
 @session_state_bp.route("/session-state/user-info")
+@rate_limit("session_state_user_info", limit=10, window_seconds=60)
 def session_state_user_info():
     """Return extended player info for the current session when available."""
     player_tag = session.get("player_tag", "Guest")

--- a/services/rate_limiter.py
+++ b/services/rate_limiter.py
@@ -1,0 +1,44 @@
+"""Small in-memory sliding-window rate limiter helpers."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from collections.abc import Callable
+
+_Clock = Callable[[], float]
+
+_attempts: dict[str, deque[float]] = defaultdict(deque)
+
+
+def is_rate_limited(
+    key: str,
+    *,
+    limit: int,
+    window_seconds: int,
+    clock: _Clock = time.monotonic,
+) -> tuple[bool, int]:
+    """Return whether a key has exceeded its request budget.
+
+    The current attempt is counted when the key is still under the limit.
+    When the key is already limited, the returned retry value is the number
+    of whole seconds until the oldest attempt leaves the window.
+    """
+    now = clock()
+    cutoff = now - window_seconds
+    attempts = _attempts[key]
+
+    while attempts and attempts[0] <= cutoff:
+        attempts.popleft()
+
+    if len(attempts) >= limit:
+        retry_after = max(1, int(attempts[0] + window_seconds - now))
+        return True, retry_after
+
+    attempts.append(now)
+    return False, 0
+
+
+def reset_rate_limits() -> None:
+    """Clear rate-limit state, primarily for tests."""
+    _attempts.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,13 @@ def client(app: Flask):
     return app.test_client()
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    from ClashRecruit.services.rate_limiter import reset_rate_limits
+
+    reset_rate_limits()
+
+
 @pytest.fixture
 def set_session(client):
     def _set_session(**values):

--- a/tests/routes/test_home_login_route.py
+++ b/tests/routes/test_home_login_route.py
@@ -95,3 +95,32 @@ def test_home_login_invalid_player_sets_failure_session(
         assert "player_league" not in session
         assert "player_townhall" not in session
         assert "player_builderbase_trophies" not in session
+
+
+def test_home_login_rate_limits_repeated_attempts(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    for _ in range(home_route.LOGIN_RATE_LIMIT):
+        response = client.post(
+            "/",
+            json={"playerTag": "PLAYER123", "apiToken": "token-123"},
+        )
+        assert response.status_code == 200
+
+    response = client.post(
+        "/",
+        json={"playerTag": "PLAYER123", "apiToken": "token-123"},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert response.get_json() == {
+        "message": False,
+        "receivedPlayerTag": (
+            "Too many login attempts. Please try again shortly."
+        ),
+    }
+    assert len(DummyAPI.instances) == home_route.LOGIN_RATE_LIMIT

--- a/tests/routes/test_rate_limit_route.py
+++ b/tests/routes/test_rate_limit_route.py
@@ -1,0 +1,68 @@
+def test_database_count_rate_limit_skips_collection(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    calls = 0
+
+    class DummyCollection:
+        def count_documents(self, query):
+            nonlocal calls
+            calls += 1
+            return 12
+
+    monkeypatch.setattr(
+        home_route,
+        "get_clan_collection",
+        lambda: DummyCollection(),
+    )
+
+    for _ in range(30):
+        response = client.get("/database_count")
+        assert response.status_code == 200
+
+    response = client.get("/database_count")
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert response.get_json() == {
+        "message": "Too many requests. Please try again shortly."
+    }
+    assert calls == 30
+
+
+def test_session_state_rate_limit_skips_clash_api(client, set_session, monkeypatch):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    calls = 0
+
+    class DummyAPI:
+        def __init__(self, player_tag, api_token, headers):
+            self.townhall = 13
+            self.townhallWeaponLevel = 4
+            self.clantag = "TESTCLAN"
+
+        def check_player(self):
+            nonlocal calls
+            calls += 1
+            return True
+
+    class DummyCollection:
+        def find_one(self, query, projection=None):
+            return None
+
+    set_session(player_name="Player", player_tag="PLAYER123", clan_tag="TESTCLAN")
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: DummyCollection(),
+    )
+
+    for _ in range(20):
+        response = client.get("/session-state")
+        assert response.status_code == 200
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert calls == 20

--- a/tests/routes/test_rate_limit_route.py
+++ b/tests/routes/test_rate_limit_route.py
@@ -29,7 +29,9 @@ def test_database_count_rate_limit_skips_collection(client, monkeypatch):
     assert calls == 30
 
 
-def test_session_state_rate_limit_skips_clash_api(client, set_session, monkeypatch):
+def test_session_state_rate_limit_skips_clash_api(
+    client, set_session, monkeypatch
+):
     import ClashRecruit.routes.session_state_route as session_state_route
 
     calls = 0
@@ -49,7 +51,9 @@ def test_session_state_rate_limit_skips_clash_api(client, set_session, monkeypat
         def find_one(self, query, projection=None):
             return None
 
-    set_session(player_name="Player", player_tag="PLAYER123", clan_tag="TESTCLAN")
+    set_session(
+        player_name="Player", player_tag="PLAYER123", clan_tag="TESTCLAN"
+    )
     monkeypatch.setattr(session_state_route, "API", DummyAPI)
     monkeypatch.setattr(
         session_state_route,

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -339,3 +339,160 @@ def test_recruiter_post_returns_400_for_missing_json_status(
 
     assert response.status_code == 400
     assert response.get_json() == {"message": "Invalid listing status."}
+
+
+def test_recruiter_update_allows_two_actions_per_minute(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    payload = {
+        "status": "update",
+        "requiredLeague": 6,
+        "requiredBuilderLeague": 2600,
+        "requiredTownhall": 14,
+        "description": "updated_description",
+        "updateExpiry": False,
+        "expiry": "provided_expiry",
+    }
+
+    first_response = client.post("/recruiter", json=payload)
+    second_response = client.post("/recruiter", json=payload)
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+
+
+def test_recruiter_update_rate_limit_blocks_third_action_before_service(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    payload = {
+        "status": "update",
+        "requiredLeague": 6,
+        "requiredBuilderLeague": 2600,
+        "requiredTownhall": 14,
+        "description": "updated_description",
+        "updateExpiry": False,
+        "expiry": "provided_expiry",
+    }
+
+    for _ in range(2):
+        response = client.post("/recruiter", json=payload)
+        assert response.status_code == 200
+
+    collection.update_call = None
+    response = client.post("/recruiter", json=payload)
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert response.get_json() == {
+        "message": "Please wait before changing your listing again."
+    }
+    assert collection.update_call is None
+
+
+def test_recruiter_create_rate_limit_blocks_second_action_before_service(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(
+        recruiter_status=True,
+        clan_tag="TEST123",
+        player_tag="PLAYER123",
+    )
+
+    payload = {
+        "status": "new",
+        "requiredLeague": 5,
+        "requiredBuilderLeague": 2400,
+        "requiredTownhall": 13,
+        "description": "new_description",
+    }
+
+    response = client.post("/recruiter", json=payload)
+    assert response.status_code == 200
+
+    collection.inserted_doc = None
+    response = client.post("/recruiter", json=payload)
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert response.get_json() == {
+        "message": "Please wait before changing your listing again."
+    }
+    assert collection.inserted_doc is None
+
+
+def test_recruiter_delete_is_not_action_rate_limited(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(
+        existing={"requirements": [1, 2, 3]},
+        deleted_count=1,
+    )
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post("/recruiter", json={"status": "removeListing"})
+    assert response.status_code == 200
+
+    collection.delete_query = None
+    response = client.post("/recruiter", json={"status": "removeListing"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Successfully deleted entry."}
+    assert collection.delete_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }
+
+
+def test_recruiter_delete_still_runs_after_limited_updates(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(
+        existing={"requirements": [1, 2, 3]},
+        deleted_count=1,
+    )
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    update_payload = {
+        "status": "update",
+        "requiredLeague": 6,
+        "requiredBuilderLeague": 2600,
+        "requiredTownhall": 14,
+        "description": "updated_description",
+        "updateExpiry": False,
+        "expiry": "provided_expiry",
+    }
+
+    for _ in range(3):
+        client.post("/recruiter", json=update_payload)
+
+    collection.delete_query = None
+    response = client.post("/recruiter", json={"status": "removeListing"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Successfully deleted entry."}
+    assert collection.delete_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
+    }


### PR DESCRIPTION
## Summary
- add in-memory sliding-window rate limits for user-triggered API entrypoints
- add recruiter-specific create/update throttles while leaving delete unblocked
- preserve listing expiry in the UI when an update request is rate-limited
- add route coverage for login, generic API limits, and recruiter limit behavior

## Validation
- `venv/bin/python -m pytest -q` (`147 passed`)

## Notes
- Rate-limit state is in-memory per Flask process. A multi-worker or multi-instance deployment would need shared storage such as Redis.
- Frontend build was not run because `npm` is unavailable in this environment.