### PR TITLE
chore: add request payload validation

### DIFF
--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -7,6 +7,12 @@ from ..config import headers
 from ..services.mongo_db_client import get_clan_collection
 from ..services.rate_limiter import is_rate_limited
 from .rate_limit import rate_limit
+from .validation import (
+    RequestValidationError,
+    get_json_object,
+    normalize_tag,
+    optional_string,
+)
 
 home_bp = Blueprint("home", __name__)
 LOGIN_RATE_LIMIT = 5
@@ -34,10 +40,13 @@ def home():
         response.headers["Retry-After"] = str(retry_after)
         return response, 429
 
-    data = request.get_json()
+    try:
+        data = get_json_object(request)
+        received_tag = normalize_tag(data.get("playerTag"), "playerTag")
+        received_token = optional_string(data, "apiToken", max_length=128)
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
 
-    received_tag = data.get("playerTag")
-    received_token = data.get("apiToken")
     session["player_tag"] = received_tag
     user = API(received_tag, received_token, headers)
     check_player_team = user.check_player()

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -9,6 +9,15 @@ from ..services.import_clash_api_clans import (
 )
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
+from .validation import (
+    RequestValidationError,
+    ensure_object,
+    get_json_object,
+    normalize_tag,
+    optional_int,
+    optional_string,
+    query_int,
+)
 
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
@@ -17,30 +26,18 @@ MAX_LIMIT = 200
 
 def _get_requested_limit(default_limit):
     """Return the validated `limit` query param capped to allowed bounds."""
-    raw_limit = request.args.get("limit")
-    if raw_limit is None:
-        return default_limit
-
-    try:
-        parsed_limit = int(raw_limit)
-    except (TypeError, ValueError):
-        return default_limit
-
-    return max(1, min(parsed_limit, MAX_LIMIT))
+    return query_int(
+        request,
+        "limit",
+        default=default_limit,
+        min_value=1,
+        max_value=MAX_LIMIT,
+    )
 
 
 def _get_requested_offset():
     """Return the validated `offset` query param with a minimum of zero."""
-    raw_offset = request.args.get("offset")
-    if raw_offset is None:
-        return 0
-
-    try:
-        parsed_offset = int(raw_offset)
-    except (TypeError, ValueError):
-        return 0
-
-    return max(0, parsed_offset)
+    return query_int(request, "offset", default=0, min_value=0)
 
 
 def _build_imported_query(filters):
@@ -88,11 +85,15 @@ def _build_imported_query(filters):
 @rate_limit("imported_clans", limit=20, window_seconds=60)
 def imported_clans_post():
     """Return clan details for a tag or a filtered imported clan list."""
+    try:
+        default_limit = 10
+        requested_limit = _get_requested_limit(default_limit)
+        requested_offset = _get_requested_offset()
+        raw_form = _validate_imported_payload(get_json_object(request))
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
     clan_collection = get_clan_collection()
-    default_limit = 10
-    requested_limit = _get_requested_limit(default_limit)
-    requested_offset = _get_requested_offset()
-    raw_form = request.get_json() or {}
 
     clan_tag = raw_form.get("clanTag") or raw_form.get("clan_tag")
     if clan_tag:
@@ -128,3 +129,73 @@ def imported_clans_post():
             "offset": requested_offset,
         }
     )
+
+
+def _validate_imported_payload(payload):
+    """Return normalized imported-clans POST payload."""
+    normalized = {}
+    raw_tag = payload.get("clanTag") or payload.get("clan_tag")
+    if raw_tag is not None:
+        normalized["clanTag"] = normalize_tag(raw_tag, "clanTag")
+        return normalized
+
+    filters = ensure_object(payload.get("filters"), "filters")
+    normalized["filters"] = _validate_imported_filters(filters)
+    return normalized
+
+
+def _validate_imported_filters(filters):
+    normalized = {}
+
+    name = optional_string(filters, "name", max_length=120)
+    if name:
+        normalized["name"] = name
+
+    min_clan_level = optional_int(filters, "minClanLevel", min_value=0)
+    if min_clan_level is not None:
+        normalized["minClanLevel"] = min_clan_level
+    clan_points = optional_int(filters, "clanPoints", min_value=0)
+    if clan_points is not None:
+        normalized["clanPoints"] = clan_points
+
+    requirements = ensure_object(
+        filters.get("requirements"),
+        "filters.requirements",
+    )
+    members = ensure_object(
+        requirements.get("members"),
+        "filters.requirements.members",
+    )
+    normalized_members = _validate_members_filter(members)
+    if normalized_members:
+        normalized["requirements"] = {"members": normalized_members}
+
+    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    if war_frequency:
+        normalized["warFrequency"] = war_frequency
+
+    location = optional_string(filters, "location", max_length=120)
+    if location:
+        normalized["location"] = location
+
+    return normalized
+
+
+def _validate_members_filter(members):
+    normalized = {}
+    min_members = optional_int(members, "min", min_value=0, max_value=50)
+    max_members = optional_int(members, "max", min_value=0, max_value=50)
+    if (
+        min_members is not None
+        and max_members is not None
+        and min_members > max_members
+    ):
+        raise RequestValidationError(
+            "filters.requirements.members.min must be less than or equal "
+            "to max."
+        )
+    if min_members is not None:
+        normalized["min"] = min_members
+    if max_members is not None:
+        normalized["max"] = max_members
+    return normalized

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -6,6 +6,15 @@ from flask import Blueprint, jsonify, request, session
 
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
+from .validation import (
+    RequestValidationError,
+    ensure_object,
+    get_json_object,
+    normalize_tag,
+    optional_int,
+    optional_string,
+    query_int,
+)
 
 recruitee_bp = Blueprint("recruitee", __name__)
 
@@ -14,30 +23,18 @@ MAX_LIMIT = 200
 
 def _get_requested_limit(default_limit):
     """Return the validated `limit` query param capped to allowed bounds."""
-    raw_limit = request.args.get("limit")
-    if raw_limit is None:
-        return default_limit
-
-    try:
-        parsed_limit = int(raw_limit)
-    except (TypeError, ValueError):
-        return default_limit
-
-    return max(1, min(parsed_limit, MAX_LIMIT))
+    return query_int(
+        request,
+        "limit",
+        default=default_limit,
+        min_value=1,
+        max_value=MAX_LIMIT,
+    )
 
 
 def _get_requested_offset():
     """Return the validated `offset` query param with a minimum of zero."""
-    raw_offset = request.args.get("offset")
-    if raw_offset is None:
-        return 0
-
-    try:
-        parsed_offset = int(raw_offset)
-    except (TypeError, ValueError):
-        return 0
-
-    return max(0, parsed_offset)
+    return query_int(request, "offset", default=0, min_value=0)
 
 
 
@@ -50,12 +47,15 @@ def _should_include_total():
 @rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
     """Return clans for the current session with optional total metadata."""
+    try:
+        default_limit = 10
+        requested_limit = _get_requested_limit(default_limit)
+        requested_offset = _get_requested_offset()
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
     clan_collection = get_clan_collection()
     player_name = session.get("player_name", None)
-    default_limit = 10
-    requested_limit = _get_requested_limit(default_limit)
-    requested_offset = _get_requested_offset()
-
 
     if not player_name or player_name == "Guest":
         base_query = {}
@@ -93,14 +93,17 @@ def recruitee_get():
 @rate_limit("recruitee_post", limit=30, window_seconds=60)
 def recruitee_post():
     """Return clan details by tag or a filtered clan list for recruitees."""
+    try:
+        default_limit = 10
+        requested_limit = _get_requested_limit(default_limit)
+        requested_offset = _get_requested_offset()
+        raw_form = _validate_recruitee_payload(get_json_object(request))
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
     clan_collection = get_clan_collection()
-    DEFAULT_LIMIT = 10
-    requested_limit = _get_requested_limit(DEFAULT_LIMIT)
-    requested_offset = _get_requested_offset()
 
-    raw_form = request.get_json() or {}
-
-    clan_tag = raw_form.get("clanTag", None) or raw_form.get("clan_tag", None)
+    clan_tag = raw_form.get("clanTag") or raw_form.get("clan_tag")
     if clan_tag:
         data = clan_collection.find_one({"clan_tag": clan_tag}, {"_id": 0})
         if data is None:
@@ -174,3 +177,92 @@ def recruitee_post():
             "offset": requested_offset,
         }
     )
+
+
+def _validate_recruitee_payload(payload):
+    """Return normalized recruitee POST payload."""
+    normalized = {}
+    raw_tag = payload.get("clanTag") or payload.get("clan_tag")
+    if raw_tag is not None:
+        normalized["clanTag"] = normalize_tag(raw_tag, "clanTag")
+        return normalized
+
+    filters = ensure_object(payload.get("filters"), "filters")
+    normalized["filters"] = _validate_filter_payload(filters)
+    return normalized
+
+
+def _validate_filter_payload(filters):
+    normalized = {}
+
+    name = optional_string(filters, "name", max_length=120)
+    if name:
+        normalized["name"] = name
+
+    requirements = ensure_object(
+        filters.get("requirements"),
+        "filters.requirements",
+    )
+    normalized_requirements = {}
+    townhall = optional_int(
+        requirements,
+        "townhall",
+        min_value=0,
+        max_value=25,
+    )
+    if townhall is not None:
+        normalized_requirements["townhall"] = townhall
+    league = optional_int(requirements, "league", min_value=0, max_value=34)
+    if league is not None:
+        normalized_requirements["league"] = league
+
+    members = ensure_object(
+        requirements.get("members"),
+        "filters.requirements.members",
+    )
+    normalized_members = _validate_members_filter(members)
+    if normalized_members:
+        normalized_requirements["members"] = normalized_members
+    if normalized_requirements:
+        normalized["requirements"] = normalized_requirements
+
+    min_clan_level = optional_int(filters, "minClanLevel", min_value=0)
+    if min_clan_level is not None:
+        normalized["minClanLevel"] = min_clan_level
+    clan_points = optional_int(filters, "clanPoints", min_value=0)
+    if clan_points is not None:
+        normalized["clanPoints"] = clan_points
+
+    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    if war_frequency:
+        normalized["warFrequency"] = war_frequency
+
+    location_id = optional_int(filters, "location_id", min_value=1)
+    if location_id is not None:
+        normalized["location_id"] = location_id
+    else:
+        location = optional_string(filters, "location", max_length=120)
+        if location:
+            normalized["location"] = location
+
+    return normalized
+
+
+def _validate_members_filter(members):
+    normalized = {}
+    min_members = optional_int(members, "min", min_value=0, max_value=50)
+    max_members = optional_int(members, "max", min_value=0, max_value=50)
+    if (
+        min_members is not None
+        and max_members is not None
+        and min_members > max_members
+    ):
+        raise RequestValidationError(
+            "filters.requirements.members.min must be less than or equal "
+            "to max."
+        )
+    if min_members is not None:
+        normalized["min"] = min_members
+    if max_members is not None:
+        normalized["max"] = max_members
+    return normalized

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -7,6 +7,13 @@ from ..services.recruiter_listing import (
     get_recruiter_listing_page,
     handle_recruiter_listing_action,
 )
+from .validation import (
+    RequestValidationError,
+    get_json_object,
+    optional_bool,
+    optional_string,
+    required_int,
+)
 
 recruiter_bp = Blueprint("recruiter", __name__)
 RECRUITER_GET_RATE_LIMIT = 10
@@ -34,7 +41,11 @@ def recruit():
         )
         return jsonify(payload), status_code
 
-    data = request.get_json(silent=True) or {}
+    try:
+        data = _validate_recruiter_payload(get_json_object(request))
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
     limited_response = _rate_limit_recruiter_action(data)
     if limited_response:
         return limited_response
@@ -85,3 +96,50 @@ def _rate_limit_recruiter_action(data):
     )
     response.headers["Retry-After"] = str(retry_after)
     return response, 429
+
+
+def _validate_recruiter_payload(data):
+    """Return normalized recruiter action data."""
+    status = optional_string(data, "status")
+    if status not in {"new", "update", "removeListing"}:
+        raise RequestValidationError("Invalid listing status.")
+
+    normalized = {"status": status}
+    if status == "removeListing":
+        return normalized
+
+    normalized["requiredLeague"] = required_int(
+        data,
+        "requiredLeague",
+        min_value=0,
+        max_value=34,
+    )
+    normalized["requiredBuilderLeague"] = required_int(
+        data,
+        "requiredBuilderLeague",
+        min_value=0,
+    )
+    normalized["requiredTownhall"] = required_int(
+        data,
+        "requiredTownhall",
+        min_value=0,
+        max_value=25,
+    )
+    normalized["description"] = optional_string(
+        data,
+        "description",
+        max_length=5000,
+    )
+
+    if status == "update":
+        update_expiry = optional_bool(data, "updateExpiry")
+        if update_expiry is None:
+            raise RequestValidationError("updateExpiry is required.")
+        normalized["updateExpiry"] = update_expiry
+        if not update_expiry:
+            expiry = optional_string(data, "expiry", max_length=128)
+            if not expiry:
+                raise RequestValidationError("expiry is required.")
+            normalized["expiry"] = expiry
+
+    return normalized

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -4,6 +4,7 @@ from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import get_clan_collection, get_user_collection
 from .rate_limit import rate_limit
+from .validation import RequestValidationError, normalize_tag
 
 saved_clans_bp = Blueprint("saved_clans", __name__)
 
@@ -109,7 +110,10 @@ def add_saved_clan(clan_tag):
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
 
-    normalized_tag = clan_tag.lstrip("#")
+    try:
+        normalized_tag = normalize_tag(clan_tag, "clan_tag")
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
 
     current_doc = (
         user_collection.find_one(
@@ -174,7 +178,10 @@ def delete_saved_clan(clan_tag):
     if not player_tag:
         return jsonify({"message": "Unauthorized"}), 401
 
-    normalized_tag = clan_tag.lstrip("#")
+    try:
+        normalized_tag = normalize_tag(clan_tag, "clan_tag")
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
 
     user_collection.update_one(
         {"player_tag": player_tag},

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -5,6 +5,7 @@ from flask import Blueprint, jsonify, request, session
 from ..api.recruitee_api import Recruitee
 from ..config import headers
 from .rate_limit import rate_limit
+from .validation import RequestValidationError, get_json_object
 
 search_clans_bp = Blueprint("search_clans", __name__)
 
@@ -13,7 +14,11 @@ search_clans_bp = Blueprint("search_clans", __name__)
 @rate_limit("search_clans", limit=10, window_seconds=60)
 def search_clans():
     """Search clans using provided filters and return matching results."""
-    filters = request.get_json() or {}
+    try:
+        filters = _validate_search_filters(get_json_object(request))
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
     user = Recruitee(
         session.get("player_tag"),
         headers,
@@ -45,3 +50,21 @@ def search_clans():
         ), error.get("status") or 400
 
     return jsonify(clans)
+
+
+def _validate_search_filters(filters):
+    """Return a shallow-normalized Clash clan search filter dict."""
+    normalized = {}
+    for key, value in filters.items():
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (str, int)):
+            raise RequestValidationError(
+                f"{key} must be a string or integer."
+            )
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                continue
+        normalized[key] = value
+    return normalized

--- a/routes/validation.py
+++ b/routes/validation.py
@@ -1,0 +1,159 @@
+"""Request validation helpers shared by Flask routes."""
+
+import re
+from typing import Any
+
+from flask import Request
+
+TAG_PATTERN = re.compile(r"^[A-Z0-9]+$")
+
+
+class RequestValidationError(ValueError):
+    """Raised when client supplied request data is invalid."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def get_json_object(request: Request) -> dict[str, Any]:
+    """Return the request JSON body as an object."""
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        raise RequestValidationError("Request body must be a JSON object.")
+    return payload
+
+
+def query_int(
+    request: Request,
+    field_name: str,
+    *,
+    default: int,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int:
+    """Return a validated integer query parameter."""
+    value = request.args.get(field_name)
+    if value is None:
+        return default
+
+    parsed = _parse_int(value, field_name)
+    _validate_int_bounds(parsed, field_name, min_value, max_value)
+    return parsed
+
+
+def ensure_object(value: Any, field_name: str) -> dict[str, Any]:
+    """Return a dict value or raise a validation error for bad shape."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise RequestValidationError(f"{field_name} must be an object.")
+    return value
+
+
+def optional_string(
+    payload: dict[str, Any],
+    field_name: str,
+    *,
+    max_length: int | None = None,
+) -> str | None:
+    """Return an optional trimmed string field."""
+    value = payload.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RequestValidationError(f"{field_name} must be a string.")
+
+    normalized = value.strip()
+    if max_length is not None and len(normalized) > max_length:
+        raise RequestValidationError(
+            f"{field_name} must be {max_length} characters or fewer."
+        )
+    return normalized
+
+
+def optional_bool(payload: dict[str, Any], field_name: str) -> bool | None:
+    """Return an optional boolean field."""
+    value = payload.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise RequestValidationError(f"{field_name} must be a boolean.")
+    return value
+
+
+def optional_int(
+    payload: dict[str, Any],
+    field_name: str,
+    *,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int | None:
+    """Return an optional integer, accepting integer-looking strings."""
+    value = payload.get(field_name)
+    if value is None:
+        return None
+
+    parsed = _parse_int(value, field_name)
+    _validate_int_bounds(parsed, field_name, min_value, max_value)
+    return parsed
+
+
+def required_int(
+    payload: dict[str, Any],
+    field_name: str,
+    *,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int:
+    """Return a required integer, accepting integer-looking strings."""
+    value = payload.get(field_name)
+    if value is None:
+        raise RequestValidationError(f"{field_name} is required.")
+
+    parsed = _parse_int(value, field_name)
+    _validate_int_bounds(parsed, field_name, min_value, max_value)
+    return parsed
+
+
+def normalize_tag(value: Any, field_name: str) -> str:
+    """Normalize a Clash-style tag used as an application identity key."""
+    if not isinstance(value, str):
+        raise RequestValidationError(f"{field_name} must be a string.")
+
+    normalized = value.strip().lstrip("#").upper()
+    if not normalized:
+        raise RequestValidationError(f"{field_name} is required.")
+    if not TAG_PATTERN.fullmatch(normalized):
+        raise RequestValidationError(
+            f"{field_name} must contain only letters and numbers."
+        )
+    return normalized
+
+
+def _parse_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise RequestValidationError(f"{field_name} must be an integer.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped.isdecimal():
+            return int(stripped)
+    raise RequestValidationError(f"{field_name} must be an integer.")
+
+
+def _validate_int_bounds(
+    value: int,
+    field_name: str,
+    min_value: int | None,
+    max_value: int | None,
+) -> None:
+    if min_value is not None and value < min_value:
+        raise RequestValidationError(
+            f"{field_name} must be at least {min_value}."
+        )
+    if max_value is not None and value > max_value:
+        raise RequestValidationError(
+            f"{field_name} must be at most {max_value}."
+        )

--- a/tests/routes/test_home_login_route.py
+++ b/tests/routes/test_home_login_route.py
@@ -97,6 +97,49 @@ def test_home_login_invalid_player_sets_failure_session(
         assert "player_builderbase_trophies" not in session
 
 
+def test_home_login_normalizes_player_tag(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post(
+        "/",
+        json={"playerTag": "  #player123  ", "apiToken": "token-123"},
+    )
+
+    assert response.status_code == 200
+    assert DummyAPI.instances[0].player_tag == "PLAYER123"
+
+
+def test_home_login_returns_400_for_missing_json_object(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post("/")
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Request body must be a JSON object."
+    }
+    assert DummyAPI.instances == []
+
+
+def test_home_login_returns_400_for_invalid_player_tag(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post("/", json={"playerTag": "   "})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "playerTag is required."}
+    assert DummyAPI.instances == []
+
+
 def test_home_login_rate_limits_repeated_attempts(client, monkeypatch):
     import ClashRecruit.routes.home_route as home_route
 

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -154,3 +154,67 @@ def test_imported_clans_post_returns_404_for_missing_tag(
 
     assert response.status_code == 404
     assert response.get_json() == {"error": "Imported clan not found"}
+
+
+def test_imported_clans_post_returns_400_for_bad_filter_shape(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"requirements": {"members": []}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "filters.requirements.members must be an object."
+    }
+
+
+def test_imported_clans_post_returns_400_for_invalid_numeric_filter(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"clanPoints": "many"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "clanPoints must be an integer."
+    }
+
+
+def test_imported_clans_post_returns_400_for_invalid_limit(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post("/imported_clans?limit=bad", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer."}

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -259,7 +259,7 @@ def test_recruitee_post_filters_by_location_name_without_location_id(
     assert collection.count_query is None
 
 
-def test_recruitee_uses_defaults_for_invalid_limit_and_offset(
+def test_recruitee_returns_400_for_invalid_limit_and_offset(
     client,
     monkeypatch,
 ):
@@ -276,17 +276,9 @@ def test_recruitee_uses_defaults_for_invalid_limit_and_offset(
 
     response = client.get("/recruitee?includeTotal=1&limit=bad&offset=bad")
 
-    assert response.status_code == 200
-    assert response.get_json() == {
-        "items": [{"clan_tag": "TEST123", "name": "test_clan"}],
-        "total": 1,
-        "limit": 10,
-        "offset": 0,
-    }
-    assert collection.find_query == {}
-    assert collection.count_query == {}
-    assert collection.cursor.skip_count == 0
-    assert collection.cursor.limit_count == 10
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer."}
+    assert collection.find_query is None
 
 
 def test_recruitee_post_returns_400_for_invalid_location_id(
@@ -308,7 +300,9 @@ def test_recruitee_post_returns_400_for_invalid_location_id(
     )
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "Invalid location_id"}
+    assert response.get_json() == {
+        "error": "location_id must be an integer."
+    }
     assert collection.find_query is None
 
 
@@ -331,3 +325,88 @@ def test_recruitee_post_returns_404_for_missing_clan_tag(
     assert response.get_json() == {"error": "Clan not found"}
     assert collection.find_one_query == {"clan_tag": "MISSING"}
     assert collection.find_one_projection == {"_id": 0}
+
+
+def test_recruitee_post_returns_400_for_list_payload(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json=[])
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Request body must be a JSON object."
+    }
+    assert collection.find_query is None
+
+
+def test_recruitee_post_returns_400_for_bad_nested_filter_shape(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"requirements": []}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "filters.requirements must be an object."
+    }
+    assert collection.find_query is None
+
+
+def test_recruitee_post_normalizes_numeric_string_filters(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={
+            "filters": {
+                "requirements": {
+                    "townhall": "12",
+                    "league": "4",
+                    "members": {"min": "30", "max": "45"},
+                },
+                "minClanLevel": "10",
+                "clanPoints": "35000",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert collection.find_query == {
+        "requirements.2": {"$gte": 12},
+        "requirements.0": {"$gte": 4},
+        "clan_info.clan_level": {"$gte": 10},
+        "clan_info.clanPoints": {"$gte": 35000},
+        "clan_info.member_count": {"$gte": 30, "$lte": 45},
+    }

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -320,7 +320,7 @@ def test_recruiter_post_returns_400_for_unknown_status(
     response = client.post("/recruiter", json={"status": "unexpected"})
 
     assert response.status_code == 400
-    assert response.get_json() == {"message": "Invalid listing status."}
+    assert response.get_json() == {"error": "Invalid listing status."}
     assert collection.inserted_doc is None
     assert collection.update_call is None
     assert collection.delete_query is None
@@ -338,7 +338,52 @@ def test_recruiter_post_returns_400_for_missing_json_status(
     response = client.post("/recruiter")
 
     assert response.status_code == 400
-    assert response.get_json() == {"message": "Invalid listing status."}
+    assert response.get_json() == {
+        "error": "Request body must be a JSON object."
+    }
+
+
+def test_recruiter_post_returns_400_for_list_payload(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post("/recruiter", json=[])
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Request body must be a JSON object."
+    }
+
+
+def test_recruiter_post_returns_400_for_bad_requirement_type(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": "high",
+            "requiredBuilderLeague": 2400,
+            "requiredTownhall": 13,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "requiredLeague must be an integer."
+    }
+    assert collection.inserted_doc is None
 
 
 def test_recruiter_update_allows_two_actions_per_minute(

--- a/tests/routes/test_saved_clans_authorized_route.py
+++ b/tests/routes/test_saved_clans_authorized_route.py
@@ -212,6 +212,26 @@ def test_saved_clans_post_adds_normalized_tag(
     )
 
 
+def test_saved_clans_post_returns_400_for_empty_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: object(),
+    )
+    set_session(player_tag="PLAYER123")
+
+    response = client.post("/saved-clans/%20%20")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "clan_tag is required."}
+
+
 def test_saved_clans_post_returns_existing_without_update(
     client,
     monkeypatch,

--- a/tests/routes/test_search_clans_route.py
+++ b/tests/routes/test_search_clans_route.py
@@ -99,3 +99,33 @@ def test_search_clans_maps_generic_api_error(client, monkeypatch):
         "error": "Invalid authorization",
         "reason": "accessDenied",
     }
+
+
+def test_search_clans_returns_400_for_list_payload(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post("/search_clans", json=[])
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Request body must be a JSON object."
+    }
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_nested_filter_value(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post("/search_clans", json={"name": {"bad": "shape"}})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "name must be a string or integer."
+    }
+    assert DummyRecruitee.instances == []

--- a/tests/test_imported_clan_helpers.py
+++ b/tests/test_imported_clan_helpers.py
@@ -4,6 +4,7 @@ from ClashRecruit.routes.imported_clans_route import (
     _get_requested_limit,
     _get_requested_offset,
 )
+from ClashRecruit.routes.validation import RequestValidationError
 from flask import Flask
 
 
@@ -11,9 +12,8 @@ from flask import Flask
     ("path", "expected"),
     [
         ("/imported_clans", 10),
-        ("/imported_clans?limit=abc", 10),
-        ("/imported_clans?limit=0", 1),
-        ("/imported_clans?limit=500", 200),
+        ("/imported_clans?limit=1", 1),
+        ("/imported_clans?limit=200", 200),
     ],
 )
 def test_get_requested_limit(app: Flask, path: str, expected: int) -> None:
@@ -26,13 +26,34 @@ def test_get_requested_limit(app: Flask, path: str, expected: int) -> None:
     [
         ("/imported_clans", 0),
         ("/imported_clans?offset=5", 5),
-        ("/imported_clans?offset=abc", 0),
-        ("/imported_clans?offset=-10", 0),
     ],
 )
 def test_get_requested_offset(app: Flask, path: str, expected: int) -> None:
     with app.test_request_context(path):
         assert _get_requested_offset() == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("/imported_clans?limit=abc", "limit must be an integer."),
+        ("/imported_clans?limit=0", "limit must be at least 1."),
+        ("/imported_clans?limit=500", "limit must be at most 200."),
+        ("/imported_clans?offset=abc", "offset must be an integer."),
+        ("/imported_clans?offset=-10", "offset must be an integer."),
+    ],
+)
+def test_invalid_pagination_raises_validation_error(
+    app: Flask,
+    path: str,
+    message: str,
+) -> None:
+    with app.test_request_context(path):
+        with pytest.raises(RequestValidationError, match=message):
+            if "limit" in path:
+                _get_requested_limit(10)
+            else:
+                _get_requested_offset()
 
 
 def test_build_imported_query_empty_filters_returns_source_only() -> None:


### PR DESCRIPTION
## Summary

- Add shared request validation helpers for JSON bodies, tags, strings, booleans, integers, and query params
- Validate and normalize inputs across login, recruiter actions, saved clans, recruitee filters, imported clan filters, and clan search
- Add route coverage for malformed payloads, invalid nested shapes, invalid numeric fields, numeric string normalization, invalid pagination, and empty tags

## Testing

- `venv/bin/python -m ruff check .`
- `venv/bin/python -m pytest .`