### PR TITLE
fix: centralize clash api http calls

### DIFF
--- a/api/clash_api.py
+++ b/api/clash_api.py
@@ -2,12 +2,12 @@
 
 from typing import Literal
 
-import requests
+from ..clash_http_client import get as clash_get
+from ..clash_http_client import post as clash_post
 
 REQUESTOPTIONS = Literal[
     "expLevel", "leagueTier", "builderBaseLeague", "builderHallLevel", "clan"
 ]
-REQUEST_TIMEOUT_SECONDS = 10
 
 
 class API:
@@ -49,13 +49,12 @@ class API:
             f"%23{self.user_tag}/verifytoken"
         )
 
-        response = requests.post(
+        response = clash_post(
             url,
             headers=self.headers,
             json=self.json_data,
-            timeout=REQUEST_TIMEOUT_SECONDS,
         )
-        self.apistorage = response.json()
+        self.apistorage = response.payload
 
         status = self.apistorage.get("status")
 
@@ -89,12 +88,11 @@ class API:
             self.reason = "User is a Guest"
             return False
         url = f"https://api.clashofclans.com/v1/players/%23{self.user_tag}"
-        response = requests.get(
+        response = clash_get(
             url,
             headers=self.headers,
-            timeout=REQUEST_TIMEOUT_SECONDS,
         )
-        self.storage = response.json()
+        self.storage = response.payload
         reason = self.storage.get("reason")
 
         if reason == "notFound":

--- a/api/recruitee_api.py
+++ b/api/recruitee_api.py
@@ -1,8 +1,7 @@
 """API helpers for recruitee-facing clan search requests."""
 
-import requests
-
-REQUEST_TIMEOUT_SECONDS = 10
+from ..clash_http_client import ClashApiHTTPError
+from ..clash_http_client import get as clash_get
 
 
 class Recruitee:
@@ -37,21 +36,16 @@ class Recruitee:
         if after:
             filter["after"] = after
 
-        response = requests.get(
-            url,
-            params=filter,
-            headers=self.headers,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-
-        storage = response.json()
-
         error = None
-        if response.status_code >= 400:
+        try:
+            response = clash_get(url, params=filter, headers=self.headers)
+            storage = response.payload
+        except ClashApiHTTPError as exc:
+            storage = exc.payload
             error = {
                 "reason": storage.get("reason"),
                 "message": storage.get("message"),
-                "status": response.status_code,
+                "status": exc.status_code,
             }
 
         return {

--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -1,8 +1,6 @@
 """API helpers for recruiter workflows and clan listing metadata."""
 
-import requests
-
-REQUEST_TIMEOUT_SECONDS = 10
+from ..clash_http_client import get as clash_get
 
 
 class Recruiter:
@@ -25,12 +23,11 @@ class Recruiter:
         Returns:
             list: Clan requirements in order `[league, builder, townhall]`.
         """
-        response = requests.get(
+        response = clash_get(
             f"https://api.clashofclans.com/v1/clans?name=%23{self.clan_tag}",
             headers=self.headers,
-            timeout=REQUEST_TIMEOUT_SECONDS,
         )
-        self.storage = response.json()
+        self.storage = response.payload
         long_list = self.storage.get("items") or []
         required_townhall = 0
         required_builder_trophies = 0
@@ -60,12 +57,11 @@ class Recruiter:
         Returns:
             dict: Clan metadata payload for the selected request mode.
         """
-        response = requests.get(
+        response = clash_get(
             f"https://api.clashofclans.com/v1/clans/%23{self.clan_tag}",
             headers=self.headers,
-            timeout=REQUEST_TIMEOUT_SECONDS,
         )
-        response = response.json()
+        response = response.payload
         rsp: dict[str, object] = {}
 
         if request is None:

--- a/clash_http_client.py
+++ b/clash_http_client.py
@@ -1,0 +1,130 @@
+"""Shared HTTP client helpers for the Clash of Clans API."""
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+
+BASE_URL = "https://api.clashofclans.com/v1/"
+DEFAULT_TIMEOUT_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class ClashApiResponse:
+    """Parsed Clash API response metadata."""
+
+    status_code: int
+    payload: dict[str, Any]
+
+
+class ClashApiError(Exception):
+    """Base error raised for Clash API request failures."""
+
+
+class ClashApiNetworkError(ClashApiError):
+    """Raised when the request fails before a response is available."""
+
+
+class ClashApiJSONError(ClashApiError):
+    """Raised when the Clash API response body is not valid JSON."""
+
+
+class ClashApiHTTPError(ClashApiError):
+    """Raised when the Clash API returns an unexpected HTTP status."""
+
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any],
+    ) -> None:
+        self.status_code = status_code
+        self.payload = payload
+        self.reason = payload.get("reason", "unknown")
+        self.message = payload.get("message")
+        super().__init__(f"HTTP {status_code}: {self.reason}")
+
+
+def get(
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    allowed_statuses: set[int] | None = None,
+) -> ClashApiResponse:
+    """Send a GET request to the Clash API and return parsed JSON."""
+    return _request(
+        "GET",
+        path,
+        headers=headers,
+        params=params,
+        timeout=timeout,
+        allowed_statuses=allowed_statuses,
+    )
+
+
+def post(
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    allowed_statuses: set[int] | None = None,
+) -> ClashApiResponse:
+    """Send a POST request to the Clash API and return parsed JSON."""
+    return _request(
+        "POST",
+        path,
+        headers=headers,
+        json=json,
+        timeout=timeout,
+        allowed_statuses=allowed_statuses,
+    )
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    allowed_statuses: set[int] | None = None,
+) -> ClashApiResponse:
+    """Send an HTTP request with shared Clash API handling."""
+    allowed_statuses = allowed_statuses or set()
+    try:
+        response = requests.request(
+            method,
+            _build_url(path),
+            headers=headers,
+            params=params,
+            json=json,
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise ClashApiNetworkError(str(exc)) from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ClashApiJSONError(
+            "Clash API response was not valid JSON"
+        ) from exc
+
+    if (
+        response.status_code >= 400
+        and response.status_code not in allowed_statuses
+    ):
+        raise ClashApiHTTPError(response.status_code, payload)
+
+    return ClashApiResponse(status_code=response.status_code, payload=payload)
+
+
+def _build_url(path: str) -> str:
+    """Return an absolute Clash API URL for relative endpoint paths."""
+    if path.startswith(("http://", "https://")):
+        return path
+    return urljoin(BASE_URL, path.lstrip("/"))

--- a/services/clash_api_preflight.py
+++ b/services/clash_api_preflight.py
@@ -1,7 +1,7 @@
 """Development preflight check for Clash API reachability."""
 
-import requests
-
+from ..clash_http_client import ClashApiHTTPError
+from ..clash_http_client import get as clash_get
 from ..config import headers
 
 
@@ -19,18 +19,16 @@ def run_clash_api_preflight(headers=headers) -> None:
         Exception: Raised when the Clash API responds with an HTTP error
             status.
     """
-    response = requests.get(
-        (
-            "https://api.clashofclans.com/v1/locations/32000249/"
-            "rankings/players?limit=1"
-        ),
-        headers=headers,
-    )
-    status_code = response.status_code
-
-    if status_code >= 400:
-        reason = response.json().get("reason", "unknown")
-        raise Exception(f"HTTP {status_code}: {reason}")
+    try:
+        clash_get(
+            (
+                "https://api.clashofclans.com/v1/locations/32000249/"
+                "rankings/players?limit=1"
+            ),
+            headers=headers,
+        )
+    except ClashApiHTTPError as exc:
+        raise Exception(f"HTTP {exc.status_code}: {exc.reason}") from exc
 
     return
 

--- a/services/get_locations.py
+++ b/services/get_locations.py
@@ -1,7 +1,6 @@
 """Service for fetching and updating Clash of Clans location data."""
 
-import requests
-
+from ..clash_http_client import get as clash_get
 from ..config import headers
 from ..services.mongo_db_client import get_location_collection
 
@@ -18,11 +17,11 @@ def get_locations(headers) -> list:
     Returns:
         list: The list of all locations returned from the Clash of Clans API.
     """
-    response = requests.get(
+    response = clash_get(
         "https://api.clashofclans.com/v1/locations",
         headers=headers,
     )
-    list_of_locations = response.json().get("items", None)
+    list_of_locations = response.payload.get("items", None)
 
     return list_of_locations
 

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -3,9 +3,10 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-import requests
 from celery.signals import worker_ready
 
+from ..clash_http_client import ClashApiError
+from ..clash_http_client import get as clash_get
 from ..config import headers
 from .celery_app import app
 from .mongo_db_client import (
@@ -110,14 +111,13 @@ def _build_discovery_seeds() -> list[dict[str, Any]]:
 
 def _search_clans(filters: dict[str, Any]) -> dict[str, Any]:
     """Search clans from Clash API and return items with cursor metadata."""
-    response = requests.get(
+    response = clash_get(
         "https://api.clashofclans.com/v1/clans",
         params=filters,
         headers=headers,
         timeout=15,
     )
-    response.raise_for_status()
-    payload = response.json()
+    payload = response.payload
     return {
         "items": payload.get("items", []),
         "after": payload.get("paging", {}).get("cursors", {}).get("after"),
@@ -159,17 +159,17 @@ def _fetch_clan_detail(clan_tag: str | None) -> dict[str, Any] | None:
         return None
 
     encoded_tag = f"%23{clean_tag}"
-    response = requests.get(
+    response = clash_get(
         f"https://api.clashofclans.com/v1/clans/{encoded_tag}",
         headers=headers,
         timeout=15,
+        allowed_statuses={404},
     )
 
     if response.status_code == 404:
         return None
 
-    response.raise_for_status()
-    return response.json()
+    return response.payload
 
 
 def _normalize_discovery_item(
@@ -336,7 +336,7 @@ def discover_imported_clans(max_seeds: int = 12) -> int:
 
             try:
                 search_result = _search_clans(request_seed)
-            except requests.RequestException:
+            except ClashApiError:
                 break
 
             clans = search_result.get("items", [])
@@ -360,7 +360,7 @@ def discover_imported_clans(max_seeds: int = 12) -> int:
 
                 try:
                     detail = _fetch_clan_detail(clan_tag)
-                except requests.RequestException:
+                except ClashApiError:
                     continue
 
                 if detail is None or not _passes_quality_gate(detail):

--- a/services/maxtownhall.py
+++ b/services/maxtownhall.py
@@ -2,10 +2,9 @@
 
 from functools import lru_cache
 
-import requests
 from diskcache import Cache
 
-REQUEST_TIMEOUT_SECONDS = 10
+from ..clash_http_client import get as clash_get
 
 
 @lru_cache(maxsize=1)
@@ -28,21 +27,19 @@ def get_max_townhall(headers) -> int:
         ValueError: If the API response does not include a valid
             ``townHallLevel`` value.
     """
-    response = requests.get(
+    response = clash_get(
         "https://api.clashofclans.com/v1/locations/32000249/"
         "rankings/players?limit=1",
         headers=headers,
-        timeout=REQUEST_TIMEOUT_SECONDS,
     )
-    response = response.json()
+    response = response.payload
     tag = response["items"][0]["tag"]
     tag = tag[1:]
-    response = requests.get(
+    response = clash_get(
         f"https://api.clashofclans.com/v1/players/%23{tag}",
         headers=headers,
-        timeout=REQUEST_TIMEOUT_SECONDS,
     )
-    response = response.json()
+    response = response.payload
     max_townhall = response.get("townHallLevel")
     if max_townhall is None:
         raise ValueError("Missing 'townHallLevel' in Clash API response.")

--- a/tests/test_clash_api.py
+++ b/tests/test_clash_api.py
@@ -2,17 +2,17 @@ from unittest.mock import Mock
 
 import pytest
 from ClashRecruit.api.clash_api import API
+from ClashRecruit.clash_http_client import ClashApiResponse
 from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
 
 
 def test_player_api_is_false(monkeypatch) -> None:
     user = API(KNOWN_STABLE_TAG, api="invalid-token", headers=MOCK_HEADERS)
-    fake_response = Mock()
-    fake_response.json.return_value = {"status": "invalid"}
+    fake_response = ClashApiResponse(200, {"status": "invalid"})
     mock_post = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.post",
+        "ClashRecruit.api.clash_api.clash_post",
         mock_post,
     )
 
@@ -31,12 +31,11 @@ def test_player_is_guest() -> None:
 def test_player_not_found(monkeypatch) -> None:
     invalid_user = API("INVALID_TAG", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"reason": "notFound"}
+    fake_response = ClashApiResponse(200, {"reason": "notFound"})
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         mock_get,
     )
 
@@ -47,12 +46,11 @@ def test_player_not_found(monkeypatch) -> None:
 def test_invalid_ip_address(monkeypatch) -> None:
     user = API("invalid_ip_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"reason": "accessDenied.invalidIp"}
+    fake_response = ClashApiResponse(200, {"reason": "accessDenied.invalidIp"})
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         mock_get,
     )
 
@@ -63,12 +61,11 @@ def test_invalid_ip_address(monkeypatch) -> None:
 def test_player_api_is_true(monkeypatch) -> None:
     user = API("valid_user", api="valid-token", headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"status": "ok"}
+    fake_response = ClashApiResponse(200, {"status": "ok"})
     mock_post = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.post",
+        "ClashRecruit.api.clash_api.clash_post",
         mock_post,
     )
 
@@ -78,11 +75,9 @@ def test_player_api_is_true(monkeypatch) -> None:
 def test_player_api_unknown_status_sets_reason_payload(monkeypatch) -> None:
     user = API("valid_user", api="token", headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"status": "maintenance"}
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.post",
-        Mock(return_value=fake_response),
+        "ClashRecruit.api.clash_api.clash_post",
+        Mock(return_value=ClashApiResponse(200, {"status": "maintenance"})),
     )
 
     assert user.check_player_api() is False
@@ -92,8 +87,7 @@ def test_player_api_unknown_status_sets_reason_payload(monkeypatch) -> None:
 def test_check_player_with_all_request_options(monkeypatch) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
+    fake_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Unranked"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
@@ -107,11 +101,11 @@ def test_check_player_with_all_request_options(monkeypatch) -> None:
         "clan": {"tag": "#mock_clan_tag"},
         "role": "coLeader",
         "name": "valid_user",
-    }
+    })
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         mock_get,
     )
 
@@ -143,8 +137,7 @@ def test_check_player_with_all_request_options(monkeypatch) -> None:
 def test_check_player_single_digit_league_tier(monkeypatch) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
+    fake_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Skeleton 1"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
@@ -158,11 +151,11 @@ def test_check_player_single_digit_league_tier(monkeypatch) -> None:
         "clan": {"tag": "#mock_clan_tag"},
         "role": "coLeader",
         "name": "valid_user",
-    }
+    })
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         mock_get,
     )
 
@@ -173,8 +166,7 @@ def test_check_player_single_digit_league_tier(monkeypatch) -> None:
 def test_check_player_double_digit_league_tier(monkeypatch) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
+    fake_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Titan League 27"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
@@ -188,11 +180,11 @@ def test_check_player_double_digit_league_tier(monkeypatch) -> None:
         "clan": {"tag": "#mock_clan_tag"},
         "role": "coLeader",
         "name": "valid_user",
-    }
+    })
     mock_get = Mock(return_value=fake_response)
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         mock_get,
     )
 
@@ -205,8 +197,7 @@ def test_check_player_townhall_above_17_leaves_weapon_level_unset(
 ) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
+    fake_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Titan League 27"},
         "townHallLevel": 18,
         "builderBaseTrophies": 2000,
@@ -214,9 +205,9 @@ def test_check_player_townhall_above_17_leaves_weapon_level_unset(
         "clan": {"tag": "#mock_clan_tag"},
         "role": "leader",
         "name": "valid_user",
-    }
+    })
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         Mock(return_value=fake_response),
     )
 
@@ -228,24 +219,22 @@ def test_check_player_townhall_above_17_leaves_weapon_level_unset(
 def test_check_player_with_token_verification_fails(monkeypatch) -> None:
     user = API("valid_user", api="invalid-token", headers=MOCK_HEADERS)
 
-    fake_get_response = Mock()
-    fake_get_response.json.return_value = {
+    fake_get_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Unranked"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
         "clan": {"tag": "#mock_clan_tag"},
         "role": "leader",
         "name": "valid_user",
-    }
-    fake_post_response = Mock()
-    fake_post_response.json.return_value = {"status": "invalid"}
+    })
+    fake_post_response = ClashApiResponse(200, {"status": "invalid"})
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         Mock(return_value=fake_get_response),
     )
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.post",
+        "ClashRecruit.api.clash_api.clash_post",
         Mock(return_value=fake_post_response),
     )
 
@@ -256,24 +245,22 @@ def test_check_player_with_token_verification_fails(monkeypatch) -> None:
 def test_check_player_with_token_verification_succeeds(monkeypatch) -> None:
     user = API("valid_user", api="valid-token", headers=MOCK_HEADERS)
 
-    fake_get_response = Mock()
-    fake_get_response.json.return_value = {
+    fake_get_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Titan League 27"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
         "clan": {"tag": "#mock_clan_tag"},
         "role": "leader",
         "name": "valid_user",
-    }
-    fake_post_response = Mock()
-    fake_post_response.json.return_value = {"status": "ok"}
+    })
+    fake_post_response = ClashApiResponse(200, {"status": "ok"})
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         Mock(return_value=fake_get_response),
     )
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.post",
+        "ClashRecruit.api.clash_api.clash_post",
         Mock(return_value=fake_post_response),
     )
 
@@ -287,8 +274,7 @@ def test_check_player_request_subset_without_clan_num_items_5(
 ) -> None:
     user = API("valid_user", api=None, headers=MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
+    fake_response = ClashApiResponse(200, {
         "leagueTier": {"name": "Unranked"},
         "townHallLevel": 17,
         "builderBaseTrophies": 2000,
@@ -296,10 +282,10 @@ def test_check_player_request_subset_without_clan_num_items_5(
         "builderBaseLeague": {"id": 44000033, "name": "Platinum League II"},
         "builderHallLevel": 9,
         "name": "valid_user",
-    }
+    })
 
     monkeypatch.setattr(
-        "ClashRecruit.api.clash_api.requests.get",
+        "ClashRecruit.api.clash_api.clash_get",
         Mock(return_value=fake_response),
     )
 

--- a/tests/test_clash_api_preflight_service.py
+++ b/tests/test_clash_api_preflight_service.py
@@ -2,12 +2,12 @@ from unittest.mock import Mock
 
 import ClashRecruit.services.clash_api_preflight as preflight
 import pytest
+from ClashRecruit.clash_http_client import ClashApiHTTPError, ClashApiResponse
 
 
 def test_run_clash_api_preflight_returns_for_success(monkeypatch):
-    fake_response = Mock(status_code=200)
-    fake_get = Mock(return_value=fake_response)
-    monkeypatch.setattr(preflight.requests, "get", fake_get)
+    fake_get = Mock(return_value=ClashApiResponse(200, {"items": []}))
+    monkeypatch.setattr(preflight, "clash_get", fake_get)
 
     result = preflight.run_clash_api_preflight({"Authorization": "token"})
 
@@ -22,12 +22,15 @@ def test_run_clash_api_preflight_returns_for_success(monkeypatch):
 
 
 def test_run_clash_api_preflight_raises_for_api_error(monkeypatch):
-    fake_response = Mock(status_code=403)
-    fake_response.json.return_value = {"reason": "accessDenied.invalidIp"}
     monkeypatch.setattr(
-        preflight.requests,
-        "get",
-        Mock(return_value=fake_response),
+        preflight,
+        "clash_get",
+        Mock(
+            side_effect=ClashApiHTTPError(
+                403,
+                {"reason": "accessDenied.invalidIp"},
+            )
+        ),
     )
 
     with pytest.raises(Exception, match="HTTP 403: accessDenied.invalidIp"):
@@ -35,12 +38,10 @@ def test_run_clash_api_preflight_raises_for_api_error(monkeypatch):
 
 
 def test_run_clash_api_preflight_uses_unknown_reason_fallback(monkeypatch):
-    fake_response = Mock(status_code=500)
-    fake_response.json.return_value = {}
     monkeypatch.setattr(
-        preflight.requests,
-        "get",
-        Mock(return_value=fake_response),
+        preflight,
+        "clash_get",
+        Mock(side_effect=ClashApiHTTPError(500, {})),
     )
 
     with pytest.raises(Exception, match="HTTP 500: unknown"):

--- a/tests/test_clash_http_client.py
+++ b/tests/test_clash_http_client.py
@@ -1,0 +1,116 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+from ClashRecruit import clash_http_client
+from ClashRecruit.clash_http_client import (
+    ClashApiHTTPError,
+    ClashApiJSONError,
+    ClashApiNetworkError,
+)
+
+
+def test_get_uses_base_url_headers_params_and_default_timeout(monkeypatch):
+    fake_response = Mock(status_code=200)
+    fake_response.json.return_value = {"items": []}
+    fake_request = Mock(return_value=fake_response)
+    monkeypatch.setattr(clash_http_client.requests, "request", fake_request)
+
+    result = clash_http_client.get(
+        "/clans",
+        headers={"Authorization": "Bearer token"},
+        params={"name": "test"},
+    )
+
+    assert result.payload == {"items": []}
+    fake_request.assert_called_once_with(
+        "GET",
+        "https://api.clashofclans.com/v1/clans",
+        headers={"Authorization": "Bearer token"},
+        params={"name": "test"},
+        json=None,
+        timeout=10,
+    )
+
+
+def test_post_sends_json_body(monkeypatch):
+    fake_response = Mock(status_code=200)
+    fake_response.json.return_value = {"status": "ok"}
+    fake_request = Mock(return_value=fake_response)
+    monkeypatch.setattr(clash_http_client.requests, "request", fake_request)
+
+    result = clash_http_client.post(
+        "players/%23PLAYER/verifytoken",
+        headers={"Authorization": "Bearer token"},
+        json={"token": "abc"},
+    )
+
+    assert result.payload == {"status": "ok"}
+    fake_request.assert_called_once_with(
+        "POST",
+        "https://api.clashofclans.com/v1/players/%23PLAYER/verifytoken",
+        headers={"Authorization": "Bearer token"},
+        params=None,
+        json={"token": "abc"},
+        timeout=10,
+    )
+
+
+def test_http_error_includes_status_and_payload(monkeypatch):
+    fake_response = Mock(status_code=403)
+    fake_response.json.return_value = {
+        "reason": "accessDenied.invalidIp",
+        "message": "Invalid IP",
+    }
+    monkeypatch.setattr(
+        clash_http_client.requests,
+        "request",
+        Mock(return_value=fake_response),
+    )
+
+    with pytest.raises(ClashApiHTTPError) as error:
+        clash_http_client.get("locations")
+
+    assert error.value.status_code == 403
+    assert error.value.reason == "accessDenied.invalidIp"
+    assert error.value.message == "Invalid IP"
+    assert error.value.payload == fake_response.json.return_value
+
+
+def test_allowed_http_status_returns_response(monkeypatch):
+    fake_response = Mock(status_code=404)
+    fake_response.json.return_value = {"reason": "notFound"}
+    monkeypatch.setattr(
+        clash_http_client.requests,
+        "request",
+        Mock(return_value=fake_response),
+    )
+
+    result = clash_http_client.get("clans/%23MISSING", allowed_statuses={404})
+
+    assert result.status_code == 404
+    assert result.payload == {"reason": "notFound"}
+
+
+def test_invalid_json_raises_normalized_error(monkeypatch):
+    fake_response = Mock(status_code=200)
+    fake_response.json.side_effect = ValueError("no json")
+    monkeypatch.setattr(
+        clash_http_client.requests,
+        "request",
+        Mock(return_value=fake_response),
+    )
+
+    with pytest.raises(ClashApiJSONError):
+        clash_http_client.get("locations")
+
+
+def test_request_exception_raises_normalized_network_error(monkeypatch):
+    monkeypatch.setattr(
+        clash_http_client.requests,
+        "request",
+        Mock(side_effect=requests.Timeout("timed out")),
+    )
+
+    with pytest.raises(ClashApiNetworkError):
+        clash_http_client.get("locations")

--- a/tests/test_get_locations_service.py
+++ b/tests/test_get_locations_service.py
@@ -1,15 +1,16 @@
 from unittest.mock import Mock
 
 import ClashRecruit.services.get_locations as locations_service
+from ClashRecruit.clash_http_client import ClashApiResponse
 
 
 def test_get_locations_returns_items_from_api(monkeypatch):
-    fake_response = Mock()
-    fake_response.json.return_value = {
-        "items": [{"id": 32000007, "name": "International"}]
-    }
+    fake_response = ClashApiResponse(
+        200,
+        {"items": [{"id": 32000007, "name": "International"}]},
+    )
     fake_get = Mock(return_value=fake_response)
-    monkeypatch.setattr(locations_service.requests, "get", fake_get)
+    monkeypatch.setattr(locations_service, "clash_get", fake_get)
 
     result = locations_service.get_locations({"Authorization": "Bearer token"})
 

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import ClashRecruit.services.import_clash_api_clans as import_service
 import pytest
-import requests
+from ClashRecruit.clash_http_client import ClashApiError, ClashApiResponse
 
 
 @pytest.mark.parametrize(
@@ -221,18 +221,19 @@ def test_build_enriched_import_document_uses_detail_with_search_fallbacks(
 
 
 def test_search_clans_calls_api_with_timeout_and_returns_cursor(monkeypatch):
-    fake_response = Mock()
-    fake_response.json.return_value = {
-        "items": [{"tag": "#TEST123"}],
-        "paging": {"cursors": {"after": "cursor-1"}},
-    }
+    fake_response = ClashApiResponse(
+        200,
+        {
+            "items": [{"tag": "#TEST123"}],
+            "paging": {"cursors": {"after": "cursor-1"}},
+        },
+    )
     fake_get = Mock(return_value=fake_response)
-    monkeypatch.setattr(import_service.requests, "get", fake_get)
+    monkeypatch.setattr(import_service, "clash_get", fake_get)
 
     result = import_service._search_clans({"name": "test", "limit": 10})
 
     assert result == {"items": [{"tag": "#TEST123"}], "after": "cursor-1"}
-    fake_response.raise_for_status.assert_called_once_with()
     fake_get.assert_called_once_with(
         "https://api.clashofclans.com/v1/clans",
         params={"name": "test", "limit": 10},
@@ -245,8 +246,8 @@ def test_fetch_clan_detail_returns_none_for_invalid_tag_without_network(
     monkeypatch,
 ):
     monkeypatch.setattr(
-        import_service.requests,
-        "get",
+        import_service,
+        "clash_get",
         lambda *args, **kwargs: pytest.fail("network should not be called"),
     )
 
@@ -254,30 +255,31 @@ def test_fetch_clan_detail_returns_none_for_invalid_tag_without_network(
 
 
 def test_fetch_clan_detail_returns_none_for_404(monkeypatch):
-    fake_response = Mock(status_code=404)
+    fake_response = ClashApiResponse(404, {"reason": "notFound"})
     fake_get = Mock(return_value=fake_response)
-    monkeypatch.setattr(import_service.requests, "get", fake_get)
+    monkeypatch.setattr(import_service, "clash_get", fake_get)
 
     assert import_service._fetch_clan_detail("#missing") is None
-    fake_response.raise_for_status.assert_not_called()
     fake_get.assert_called_once_with(
         "https://api.clashofclans.com/v1/clans/%23MISSING",
         headers=import_service.headers,
         timeout=15,
+        allowed_statuses={404},
     )
 
 
 def test_fetch_clan_detail_raises_and_returns_json_for_success(monkeypatch):
-    fake_response = Mock(status_code=200)
-    fake_response.json.return_value = {"tag": "#TEST123", "name": "test_clan"}
+    fake_response = ClashApiResponse(
+        200,
+        {"tag": "#TEST123", "name": "test_clan"},
+    )
     fake_get = Mock(return_value=fake_response)
-    monkeypatch.setattr(import_service.requests, "get", fake_get)
+    monkeypatch.setattr(import_service, "clash_get", fake_get)
 
     assert import_service._fetch_clan_detail("test123") == {
         "tag": "#TEST123",
         "name": "test_clan",
     }
-    fake_response.raise_for_status.assert_called_once_with()
 
 
 def test_seed_state_helpers_read_update_and_reset(monkeypatch):
@@ -474,7 +476,7 @@ def test_discover_imported_clans_skips_low_quality_bad_tags_and_bad_detail(
 
     def fake_fetch(clan_tag):
         if clan_tag == "RAISES":
-            raise requests.RequestException("detail failed")
+            raise ClashApiError("detail failed")
         if clan_tag == "MISSING":
             return None
         if clan_tag == "LOWDETAIL":
@@ -528,7 +530,7 @@ def test_discover_imported_clans_breaks_seed_on_search_error(monkeypatch):
 
     def fake_search(seed):
         search_calls.append(seed)
-        raise requests.RequestException("search failed")
+        raise ClashApiError("search failed")
 
     monkeypatch.setattr(
         import_service,

--- a/tests/test_maxtownhall_service.py
+++ b/tests/test_maxtownhall_service.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import ClashRecruit.services.maxtownhall as maxtownhall
 import pytest
+from ClashRecruit.clash_http_client import ClashApiResponse
 
 
 class DummyCache:
@@ -38,14 +39,15 @@ def test_refresh_fetches_max_townhall_on_cache_miss(monkeypatch):
 
 def test_get_max_townhall_fetches_top_player_detail_and_caches(monkeypatch):
     cache = DummyCache()
-    ranking_response = Mock()
-    ranking_response.json.return_value = {"items": [{"tag": "#PLAYER123"}]}
-    player_response = Mock()
-    player_response.json.return_value = {"townHallLevel": "17"}
+    ranking_response = ClashApiResponse(
+        200,
+        {"items": [{"tag": "#PLAYER123"}]},
+    )
+    player_response = ClashApiResponse(200, {"townHallLevel": "17"})
     fake_get = Mock(side_effect=[ranking_response, player_response])
 
     monkeypatch.setattr(maxtownhall, "get_cache", lambda: cache)
-    monkeypatch.setattr(maxtownhall.requests, "get", fake_get)
+    monkeypatch.setattr(maxtownhall, "clash_get", fake_get)
 
     result = maxtownhall.get_max_townhall(
         {"Authorization": "Bearer token"}
@@ -61,14 +63,12 @@ def test_get_max_townhall_fetches_top_player_detail_and_caches(monkeypatch):
             ),
             {
                 "headers": {"Authorization": "Bearer token"},
-                "timeout": 10,
             },
         ),
         (
             ("https://api.clashofclans.com/v1/players/%23PLAYER123",),
             {
                 "headers": {"Authorization": "Bearer token"},
-                "timeout": 10,
             },
         ),
     ]
@@ -77,13 +77,14 @@ def test_get_max_townhall_fetches_top_player_detail_and_caches(monkeypatch):
 def test_get_max_townhall_raises_when_player_detail_has_no_townhall(
     monkeypatch,
 ):
-    ranking_response = Mock()
-    ranking_response.json.return_value = {"items": [{"tag": "#PLAYER123"}]}
-    player_response = Mock()
-    player_response.json.return_value = {}
+    ranking_response = ClashApiResponse(
+        200,
+        {"items": [{"tag": "#PLAYER123"}]},
+    )
+    player_response = ClashApiResponse(200, {})
     monkeypatch.setattr(
-        maxtownhall.requests,
-        "get",
+        maxtownhall,
+        "clash_get",
         Mock(side_effect=[ranking_response, player_response]),
     )
 

--- a/tests/test_no_raw_clash_requests.py
+++ b/tests/test_no_raw_clash_requests.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def test_backend_modules_do_not_make_raw_clash_requests():
+    project_root = Path(__file__).resolve().parents[1]
+    allowed = {
+        project_root / "clash_http_client.py",
+    }
+    offenders = []
+
+    for directory_name in ("api", "services"):
+        for path in (project_root / directory_name).glob("*.py"):
+            if path in allowed:
+                continue
+            content = path.read_text()
+            if "requests.get(" in content or "requests.post(" in content:
+                offenders.append(path.relative_to(project_root).as_posix())
+
+    assert offenders == []

--- a/tests/test_recruitee_api.py
+++ b/tests/test_recruitee_api.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock
 
+import ClashRecruit.api.recruitee_api as recruitee_api
 from ClashRecruit.api.recruitee_api import Recruitee
+from ClashRecruit.clash_http_client import ClashApiHTTPError, ClashApiResponse
 from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
 
 
@@ -8,18 +10,16 @@ def test_search_clan_success_without_after(monkeypatch) -> None:
     user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
     filters = {"name": "test_filter"}
 
-    fake_response = Mock()
-    fake_response.status_code = 200
-    fake_response.json.return_value = {
-        "items": [{"tag": "#ABC"}],
-        "paging": {"cursors": {"after": "cursor-1"}},
-    }
+    fake_response = ClashApiResponse(
+        200,
+        {
+            "items": [{"tag": "#ABC"}],
+            "paging": {"cursors": {"after": "cursor-1"}},
+        },
+    )
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruitee_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruitee_api, "clash_get", mock_get)
 
     result = user.searchClan(filters)
 
@@ -32,7 +32,6 @@ def test_search_clan_success_without_after(monkeypatch) -> None:
         "https://api.clashofclans.com/v1/clans",
         params={"name": "test_filter"},
         headers=MOCK_HEADERS,
-        timeout=10,
     )
 
 
@@ -40,15 +39,10 @@ def test_search_clan_includes_after_cursor_in_params(monkeypatch) -> None:
     user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
     filters = {"name": "test_filter"}
 
-    fake_response = Mock()
-    fake_response.status_code = 200
-    fake_response.json.return_value = {"items": []}
+    fake_response = ClashApiResponse(200, {"items": []})
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruitee_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruitee_api, "clash_get", mock_get)
 
     result = user.searchClan(filters, after="next-cursor")
 
@@ -60,25 +54,23 @@ def test_search_clan_includes_after_cursor_in_params(monkeypatch) -> None:
         "https://api.clashofclans.com/v1/clans",
         params={"name": "test_filter", "after": "next-cursor"},
         headers=MOCK_HEADERS,
-        timeout=10,
     )
 
 
 def test_search_clan_maps_api_error_payload(monkeypatch) -> None:
     user = Recruitee(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.status_code = 400
-    fake_response.json.return_value = {
-        "reason": "badRequest",
-        "message": "At least one filtering parameter must exist",
-    }
-    mock_get = Mock(return_value=fake_response)
-
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruitee_api.requests.get",
-        mock_get,
+    mock_get = Mock(
+        side_effect=ClashApiHTTPError(
+            400,
+            {
+                "reason": "badRequest",
+                "message": "At least one filtering parameter must exist",
+            },
+        )
     )
+
+    monkeypatch.setattr(recruitee_api, "clash_get", mock_get)
 
     result = user.searchClan({})
 

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -1,27 +1,28 @@
 from unittest.mock import Mock
 
+import ClashRecruit.api.recruiter_api as recruiter_api
 from ClashRecruit.api.recruiter_api import Recruiter
+from ClashRecruit.clash_http_client import ClashApiResponse
 from constants import KNOWN_STABLE_TAG, MOCK_HEADERS
 
 
 def test_pull_clan_requirements_success(monkeypatch) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
-        "items": [
-            {
-                "requiredTownhallLevel": 12,
-                "requiredBuilderBaseTrophies": 2300,
-            }
-        ]
-    }
+    fake_response = ClashApiResponse(
+        200,
+        {
+            "items": [
+                {
+                    "requiredTownhallLevel": 12,
+                    "requiredBuilderBaseTrophies": 2300,
+                }
+            ]
+        },
+    )
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruiter_api, "clash_get", mock_get)
 
     requirements = user.pull_clan_requirements()
 
@@ -29,7 +30,6 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
     mock_get.assert_called_once_with(
         f"https://api.clashofclans.com/v1/clans?name=%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,
-        timeout=10,
     )
 
 
@@ -38,11 +38,10 @@ def test_pull_clan_requirements_defaults_when_api_returns_no_items(
 ) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"items": []}
     monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        Mock(return_value=fake_response),
+        recruiter_api,
+        "clash_get",
+        Mock(return_value=ClashApiResponse(200, {"items": []})),
     )
 
     assert user.pull_clan_requirements() == [0, 0, 0]
@@ -53,11 +52,10 @@ def test_pull_clan_requirements_defaults_when_items_missing(
 ) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {}
     monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        Mock(return_value=fake_response),
+        recruiter_api,
+        "clash_get",
+        Mock(return_value=ClashApiResponse(200, {})),
     )
 
     assert user.pull_clan_requirements() == [0, 0, 0]
@@ -66,24 +64,23 @@ def test_pull_clan_requirements_defaults_when_items_missing(
 def test_lookup_clan_full_payload(monkeypatch) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {
-        "name": "Test Clan",
-        "type": "inviteOnly",
-        "description": "Friendly and active",
-        "location": {"id": 32000007, "name": "Canada"},
-        "badgeUrls": {"medium": "badge-medium-url"},
-        "clanLevel": 14,
-        "members": 40,
-        "warFrequency": "always",
-        "clanPoints": 42000,
-    }
+    fake_response = ClashApiResponse(
+        200,
+        {
+            "name": "Test Clan",
+            "type": "inviteOnly",
+            "description": "Friendly and active",
+            "location": {"id": 32000007, "name": "Canada"},
+            "badgeUrls": {"medium": "badge-medium-url"},
+            "clanLevel": 14,
+            "members": 40,
+            "warFrequency": "always",
+            "clanPoints": 42000,
+        },
+    )
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruiter_api, "clash_get", mock_get)
 
     result = user.lookup_clan()
 
@@ -101,21 +98,16 @@ def test_lookup_clan_full_payload(monkeypatch) -> None:
     mock_get.assert_called_once_with(
         f"https://api.clashofclans.com/v1/clans/%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,
-        timeout=10,
     )
 
 
 def test_lookup_clan_member_count_mode(monkeypatch) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"members": 48}
+    fake_response = ClashApiResponse(200, {"members": 48})
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruiter_api, "clash_get", mock_get)
 
     result = user.lookup_clan("member_count")
 
@@ -125,14 +117,10 @@ def test_lookup_clan_member_count_mode(monkeypatch) -> None:
 def test_lookup_clan_description_mode(monkeypatch) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
 
-    fake_response = Mock()
-    fake_response.json.return_value = {"description": "War focused clan"}
+    fake_response = ClashApiResponse(200, {"description": "War focused clan"})
     mock_get = Mock(return_value=fake_response)
 
-    monkeypatch.setattr(
-        "ClashRecruit.api.recruiter_api.requests.get",
-        mock_get,
-    )
+    monkeypatch.setattr(recruiter_api, "clash_get", mock_get)
 
     result = user.lookup_clan("description")
 


### PR DESCRIPTION
## Summary
- Add shared Clash API HTTP client wrapper
- Migrate Clash API call sites to use the wrapper
- Add tests for timeout, JSON, status, and network error handling
- Add guard coverage against future raw requests usage

## Why
Clash API calls were inconsistent across modules. Centralizing them ensures all calls use timeouts, consistent JSON parsing, normalized errors, and predictable status handling.