### PR TITLE
Fix API-imported clan attribution and expiry metadata

### DIFF
--- a/frontend/src/ClanDetails.jsx
+++ b/frontend/src/ClanDetails.jsx
@@ -10,6 +10,29 @@ function normalizeLocation(rawLocation) {
     return "";
 }
 
+function parseDate(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDate(value) {
+    const date = parseDate(value);
+    return date ? date.toLocaleDateString() : "Not available";
+}
+
+function getImportedClanExpiry(clanInfo) {
+    const explicitExpiry = parseDate(clanInfo.expires);
+    if (explicitExpiry) return explicitExpiry;
+
+    const discoveredAt = parseDate(clanInfo.last_discovered);
+    if (!discoveredAt) return null;
+
+    const expiry = new Date(discoveredAt);
+    expiry.setDate(expiry.getDate() + 3);
+    return expiry;
+}
+
 function ClanDetails() {
     const { clanTag } = useParams();
     const [clanInfo, setClanInfo] = useState(null);
@@ -51,6 +74,13 @@ function ClanDetails() {
 
     const requirements = clanInfo.requirements || [];
     const details = clanInfo.clan_info || {};
+    const isApiImported = clanInfo.source === "clash_api_import";
+    const attributionLabel = isApiImported
+        ? "Imported from Clash API"
+        : clanInfo.player_tag || "Unknown player";
+    const expiryDate = isApiImported
+        ? getImportedClanExpiry(clanInfo)
+        : parseDate(clanInfo.expires);
 
     return (
         <section className="clan-details-page">
@@ -82,9 +112,9 @@ function ClanDetails() {
 
                 <div className="clan-meta">
                     <p><strong>Clan Tag:</strong> {clanInfo.clan_tag}</p>
-                    <p><strong>Posted by:</strong> {clanInfo.player_tag}</p>
-                    <p><strong>Last updated:</strong> {new Date(clanInfo.last_updated).toLocaleDateString()}</p>
-                    <p><strong>Expires:</strong> {new Date(clanInfo.expires).toLocaleDateString()}</p>
+                    <p><strong>{isApiImported ? "Source:" : "Posted by:"}</strong> {attributionLabel}</p>
+                    <p><strong>Last updated:</strong> {formatDate(clanInfo.last_updated || clanInfo.last_discovered)}</p>
+                    <p><strong>Expires:</strong> {expiryDate ? expiryDate.toLocaleDateString() : "Not available"}</p>
                 </div>
             </div>
         </section>

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -23,6 +23,11 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _import_expiry(reference_time: datetime | None = None) -> datetime:
+    """Return when an imported clan should expire from the cache."""
+    return (reference_time or _now()) + IMPORTED_CLAN_RETENTION
+
+
 def _clan_collection():
     """Return the clans collection lazily."""
     return get_clan_collection()
@@ -177,6 +182,7 @@ def _normalize_discovery_item(
     seed_key: str,
 ) -> dict[str, Any]:
     """Normalize a search result clan into the imported clan document shape."""
+    discovered_at = _now()
     return {
         "clan_tag": _clean_tag(clan.get("tag")),
         "name": clan.get("name"),
@@ -184,7 +190,8 @@ def _normalize_discovery_item(
         "seed_key": seed_key,
         "requirements": [0, 0, 0],
         "requirements_source": "unsupported_by_api",
-        "last_discovered": _now(),
+        "last_discovered": discovered_at,
+        "expires": _import_expiry(discovered_at),
         "clan_info": {
             "description": None,
             "location": clan.get("location") or {},
@@ -230,6 +237,7 @@ def _build_enriched_import_document(
 ) -> dict[str, Any]:
     """Build an imported clan document enriched with detail endpoint data."""
     description = (detail_clan.get("description") or "").strip()
+    discovered_at = _now()
     return {
         "clan_tag": _clean_tag(
             search_clan.get("tag") or detail_clan.get("tag")
@@ -242,8 +250,9 @@ def _build_enriched_import_document(
             detail_clan=detail_clan,
         ),
         "requirements_source": "clash_api",
-        "last_discovered": _now(),
-        "last_updated": _now(),
+        "last_discovered": discovered_at,
+        "last_updated": discovered_at,
+        "expires": _import_expiry(discovered_at),
         "clan_info": {
             "description": description or None,
             "location": (
@@ -386,6 +395,7 @@ def discover_imported_clans(max_seeds: int = 12) -> int:
                                 "last_discovered"
                             ],
                             "last_updated": enriched_document["last_updated"],
+                            "expires": enriched_document["expires"],
                             "clan_info": enriched_document["clan_info"],
                         },
                     },
@@ -446,6 +456,7 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
     if detail is None:
         return None
 
+    discovered_at = _now()
     _clan_collection().update_one(
         {"clan_tag": clean_tag, "source": "clash_api_import"},
         {
@@ -455,8 +466,9 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
                 "source": "clash_api_import",
                 "requirements": _extract_requirements(detail_clan=detail),
                 "requirements_source": "clash_api",
-                "last_discovered": _now(),
-                "last_updated": _now(),
+                "last_discovered": discovered_at,
+                "last_updated": discovered_at,
+                "expires": _import_expiry(discovered_at),
                 "clan_info": {
                     "description": (
                         (detail.get("description") or "").strip() or None

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -140,6 +140,7 @@ def test_normalize_discovery_item_builds_import_shell(monkeypatch):
         "requirements": [0, 0, 0],
         "requirements_source": "unsupported_by_api",
         "last_discovered": frozen_now,
+        "expires": frozen_now + import_service.IMPORTED_CLAN_RETENTION,
         "clan_info": {
             "description": None,
             "location": {"id": 32000007, "name": "International"},
@@ -207,6 +208,7 @@ def test_build_enriched_import_document_uses_detail_with_search_fallbacks(
         "requirements_source": "clash_api",
         "last_discovered": frozen_now,
         "last_updated": frozen_now,
+        "expires": frozen_now + import_service.IMPORTED_CLAN_RETENTION,
         "clan_info": {
             "description": "test description",
             "location": {"id": 32000007, "name": "International"},
@@ -458,6 +460,10 @@ def test_discover_imported_clans_resumes_upserts_and_updates_cursor(
     assert update_doc["$set"]["name"] == "test_clan"
     assert update_doc["$set"]["requirements"] == [0, 0, 13]
     assert update_doc["$set"]["last_discovered"] == frozen_now
+    assert (
+        update_doc["$set"]["expires"]
+        == frozen_now + import_service.IMPORTED_CLAN_RETENTION
+    )
 
 
 def test_discover_imported_clans_skips_low_quality_bad_tags_and_bad_detail(
@@ -745,6 +751,9 @@ def test_get_imported_clan_fetches_caches_and_returns_imported_document(
     assert set_doc["requirements"] == [0, 2200, 13]
     assert set_doc["last_discovered"] == frozen_now
     assert set_doc["last_updated"] == frozen_now
+    assert set_doc["expires"] == (
+        frozen_now + import_service.IMPORTED_CLAN_RETENTION
+    )
     assert set_doc["clan_info"] == {
         "description": "cached description",
         "location": {"id": 32000007, "name": "International"},


### PR DESCRIPTION
## Summary
- Add explicit expiry timestamps for clans imported from the Clash API using the existing imported-clan retention window.
- Show API-imported clans as `Source: Imported from Clash API` instead of rendering an empty `Posted by` value.
- Guard clan detail date rendering so missing or old cached date fields do not show `Invalid Date`.
- Add tests covering imported clan expiry metadata.

## Testing
- `venv/bin/python -m pytest`
- `venv/bin/python -m pytest tests/test_import_clash_api_clans_service.py tests/test_clash_http_client.py tests/test_no_raw_clash_requests.py`
- `venv/bin/ruff check services/import_clash_api_clans.py tests/test_import_clash_api_clans_service.py routes tests/routes tests/test_imported_clan_helpers.py`
- `npm test -- --watchAll=false --runInBand --passWithNoTests`
- `npm run build`