### PR TITLE
fix: fixed startup behaviour where the app would run with an incorrec…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 __pycache__/
 .dist/
+.venv/
 venv/
 *.env
 cache/

--- a/app.py
+++ b/app.py
@@ -40,6 +40,8 @@ def run_startup_tasks_from_env() -> None:
         initialize_mongo()
 
 
+run_startup_tasks_from_env()
+
+
 if __name__ == "__main__":
-    run_startup_tasks_from_env()
     app.run(port=5000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+import os
 import sys
 from pathlib import Path
 
 import pytest
 from flask import Flask
+
+os.environ.setdefault("CLASH_DEV_PREFLIGHT", "False")
+os.environ.setdefault("CLASH_INIT_DB_ON_START", "False")
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_PARENT = PROJECT_ROOT.parent

--- a/tests/test_imports_side_effect_free.py
+++ b/tests/test_imports_side_effect_free.py
@@ -62,6 +62,25 @@ class ImportSideEffectsTests(unittest.TestCase):
                 with self.subTest(module=module_name):
                     importlib.import_module(module_name)
 
+    def test_app_import_runs_preflight_when_enabled(self):
+        self._clear_repo_modules()
+
+        with patch.dict(
+            os.environ,
+            {
+                "DBURI": "",
+                "CLASH_INIT_DB_ON_START": "False",
+                "CLASH_DEV_PREFLIGHT": "true",
+            },
+            clear=False,
+        ):
+            with patch(
+                "ClashRecruit.services.clash_api_preflight.clash_get"
+            ) as mock_get:
+                importlib.import_module("ClashRecruit.app")
+
+        mock_get.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Run env-gated startup tasks when the Flask app module is imported, so `CLASH_DEV_PREFLIGHT=true` works with `flask run` and Docker startup.
- Add a regression test for the enabled preflight path.
- Default startup side-effect flags off in tests to avoid accidental live network or DB calls.

## Testing
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check .`