### PR TITLE
fix: changed which endpoint is used for clan requirements

### DIFF
--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -3,6 +3,17 @@
 from ..clash_http_client import get as clash_get
 
 
+def extract_clan_requirements(payload: object) -> list[int]:
+    """Extract clan requirements from a Clash clan detail payload."""
+    if not isinstance(payload, dict):
+        return [0, 0, 0]
+
+    required_league = 0
+    required_builder_trophies = payload.get("requiredBuilderBaseTrophies") or 0
+    required_townhall = payload.get("requiredTownhallLevel") or 0
+    return [required_league, required_builder_trophies, required_townhall]
+
+
 class Recruiter:
     """Wrap Clash API calls used by recruiter-facing routes."""
 
@@ -24,25 +35,11 @@ class Recruiter:
             list: Clan requirements in order `[league, builder, townhall]`.
         """
         response = clash_get(
-            f"https://api.clashofclans.com/v1/clans?name=%23{self.clan_tag}",
+            f"https://api.clashofclans.com/v1/clans/%23{self.clan_tag}",
             headers=self.headers,
         )
         self.storage = response.payload
-        long_list = self.storage.get("items") or []
-        required_townhall = 0
-        required_builder_trophies = 0
-        required_league = 0
-        for i in range(len(long_list)):
-            required_townhall = long_list[i].get("requiredTownhallLevel")
-            required_builder_trophies = long_list[i].get(
-                "requiredBuilderBaseTrophies"
-            )
-
-        self.new_clan_requirements(
-            required_league,
-            required_builder_trophies,
-            required_townhall,
-        )
+        self.new_clan_requirements(*extract_clan_requirements(self.storage))
 
         return self.requirements
 

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -12,12 +12,8 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
     fake_response = ClashApiResponse(
         200,
         {
-            "items": [
-                {
-                    "requiredTownhallLevel": 12,
-                    "requiredBuilderBaseTrophies": 2300,
-                }
-            ]
+            "requiredTownhallLevel": 12,
+            "requiredBuilderBaseTrophies": 2300,
         },
     )
     mock_get = Mock(return_value=fake_response)
@@ -28,26 +24,12 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
 
     assert requirements == [0, 2300, 12]
     mock_get.assert_called_once_with(
-        f"https://api.clashofclans.com/v1/clans?name=%23{KNOWN_STABLE_TAG}",
+        f"https://api.clashofclans.com/v1/clans/%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,
     )
 
 
-def test_pull_clan_requirements_defaults_when_api_returns_no_items(
-    monkeypatch,
-) -> None:
-    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
-
-    monkeypatch.setattr(
-        recruiter_api,
-        "clash_get",
-        Mock(return_value=ClashApiResponse(200, {"items": []})),
-    )
-
-    assert user.pull_clan_requirements() == [0, 0, 0]
-
-
-def test_pull_clan_requirements_defaults_when_items_missing(
+def test_pull_clan_requirements_defaults_when_payload_is_empty(
     monkeypatch,
 ) -> None:
     user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
@@ -59,6 +41,29 @@ def test_pull_clan_requirements_defaults_when_items_missing(
     )
 
     assert user.pull_clan_requirements() == [0, 0, 0]
+
+
+def test_pull_clan_requirements_defaults_when_payload_is_malformed(
+    monkeypatch,
+) -> None:
+    user = Recruiter(KNOWN_STABLE_TAG, MOCK_HEADERS)
+
+    monkeypatch.setattr(
+        recruiter_api,
+        "clash_get",
+        Mock(return_value=ClashApiResponse(200, [])),
+    )
+
+    assert user.pull_clan_requirements() == [0, 0, 0]
+
+
+def test_extract_clan_requirements_defaults_missing_values() -> None:
+    assert recruiter_api.extract_clan_requirements({}) == [0, 0, 0]
+
+
+def test_extract_clan_requirements_defaults_malformed_payloads() -> None:
+    assert recruiter_api.extract_clan_requirements(None) == [0, 0, 0]
+    assert recruiter_api.extract_clan_requirements([]) == [0, 0, 0]
 
 
 def test_lookup_clan_full_payload(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Replace recruiter requirement lookup with deterministic clan-tag lookup.
- Remove brittle search-response iteration that kept the last returned clan.
- Add a pure `extract_clan_requirements()` helper for requirement parsing.
- Cover empty and malformed payload behavior with unit tests.

## Testing
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check .`

## Manual Testing
- Log in as a recruiter-capable user.
- Open `/recruit`.
- Confirm the requirement fields load from the clan’s current Clash API details.
- Submit or update a listing to verify the same requirement path works during POST actions.