### PR TITLE
Fix/session state shell resilience

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -56,6 +56,40 @@ function normalizeUserInfo(data) {
   };
 }
 
+function readStoredUserInfo(username) {
+  if (!username) {
+    return null;
+  }
+
+  try {
+    const storedValue = sessionStorage.getItem("dashboard_user_info");
+    if (!storedValue) {
+      return null;
+    }
+
+    const parsed = JSON.parse(storedValue);
+    if (parsed.username !== username || !parsed.data) {
+      return null;
+    }
+
+    return normalizeUserInfo(parsed.data);
+  } catch {
+    return null;
+  }
+}
+
+function storeUserInfo(username, data) {
+  if (!username) {
+    sessionStorage.removeItem("dashboard_user_info");
+    return;
+  }
+
+  sessionStorage.setItem(
+    "dashboard_user_info",
+    JSON.stringify({ username, data })
+  );
+}
+
 function normalizeClanRoleLabel(roleValue) {
   if (!roleValue) {
     return "N/A";
@@ -94,10 +128,14 @@ function normalizeSavedClanTag(tagValue) {
 
 function Dashboard() {
   usePageTitle("Dashboard | ClashRecruit")
+  const { user, townhall, townhallWeaponLevel, recruitStatus, hasActiveListing, sessionStateLoaded } = useOutletContext();
+  const normalizedUser = user === "Guest" ? null : user;
 
   const [loading, setLoading] = useState(true);
   const [townHallImage, setTownHallImage] = useState(null);
-  const [userInfo, setUserInfo] = useState(null);
+  const [userInfo, setUserInfo] = useState(
+    () => readStoredUserInfo(normalizedUser)
+  );
   const [savedClans, setSavedClans] = useState([]);
   const [savedClansError, setSavedClansError] = useState("");
   const [savedClansActionError, setSavedClansActionError] = useState("");
@@ -105,8 +143,6 @@ function Dashboard() {
   const [removingSavedClanTag, setRemovingSavedClanTag] = useState("");
   const [copiedTag, setCopiedTag] = useState("");
   const copyResetTimerRef = useRef(null);
-  const { user, townhall, townhallWeaponLevel, recruitStatus, hasActiveListing, sessionStateLoaded } = useOutletContext();
-  const normalizedUser = user === "Guest" ? null : user;
 
   useEffect(() => {
     if (!sessionStateLoaded) {
@@ -116,6 +152,7 @@ function Dashboard() {
 
     let isMounted = true;
     setLoading(true);
+    setUserInfo(readStoredUserInfo(normalizedUser));
 
     const resolvedTownHallImage = getTownHallAsset(
       townhall,
@@ -125,9 +162,22 @@ function Dashboard() {
     Promise.all([
       preloadImage(resolvedTownHallImage).then(() => resolvedTownHallImage),
       fetch("/session-state/user-info", { credentials: "include" })
-        .then((res) => res.json())
-        .then((data) => normalizeUserInfo(data))
-        .catch(() => null),
+        .then((res) => {
+          if (!res.ok) {
+            return undefined;
+          }
+
+          return res.json();
+        })
+        .then((data) => {
+          if (data === undefined) {
+            return undefined;
+          }
+
+          storeUserInfo(normalizedUser, data);
+          return normalizeUserInfo(data);
+        })
+        .catch(() => undefined),
       fetch("/saved-clans", { credentials: "include" })
         .then(async (res) => {
           if (!res.ok) {
@@ -150,7 +200,9 @@ function Dashboard() {
         }
 
         setTownHallImage(nextTownHallImage);
-        setUserInfo(nextUserInfo);
+        if (nextUserInfo !== undefined) {
+          setUserInfo(nextUserInfo);
+        }
         setSavedClans(nextSaved.savedClanList);
         setSavedClansError(nextSaved.savedError);
       })

--- a/frontend/src/Recruiter.css
+++ b/frontend/src/Recruiter.css
@@ -5,6 +5,31 @@
     background: transparent;
 }
 
+.recruiter-error-page {
+    min-height: 45vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.recruiter-error-links {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+}
+
+.recruiter-error-links a {
+    color: black;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.recruiter-error-links a:hover {
+    text-decoration: underline;
+}
+
 .recruiter-loading {
     padding: 24px;
     background: transparent;

--- a/frontend/src/Recruiter.jsx
+++ b/frontend/src/Recruiter.jsx
@@ -19,6 +19,7 @@ function Recruiter() {
   const [status, setStatus] = useState(null);
   const [updateExpiry, setUpdateExpiry] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
+  const [loadError, setLoadError] = useState("");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [Listing, setListing] = useState("View Listing");
   const deleteNavigateTimerRef = useRef(null);
@@ -50,6 +51,15 @@ function Recruiter() {
           return;
         }
 
+        if (!recruiterResponse.ok) {
+          const errorData = await recruiterResponse.json().catch(() => ({}));
+          setLoadError(
+            errorData.message || "Please try again shortly."
+          );
+          setLoading(false);
+          return;
+        }
+
         const recruiterData = await recruiterResponse.json();
 
         if (!isMounted) {
@@ -63,10 +73,12 @@ function Recruiter() {
         setClanDescription(recruiterData.clanDescription);
         setStatus(recruiterData.status);
         setListing(recruiterData.status ? "Close Listing" : "View Listing");
+        setLoadError("");
         setLoading(false);
       } catch {
         if (isMounted) {
-          navigate("/dashboard");
+          setLoadError("Please try again shortly.");
+          setLoading(false);
         }
       }
     }
@@ -171,6 +183,26 @@ function Recruiter() {
 
   if (loading) {
     return <LoadingScreen />;
+  }
+
+  if (loadError) {
+    return (
+      <section className="recruiter-page recruiter-error-page">
+        <div className="recruiter-header">
+          <h2>Recruit Players</h2>
+          <p>{loadError}</p>
+        </div>
+
+        <div className="recruiter-error-links">
+          <a href="/recruit">Try again</a>
+          <Link
+            to="/dashboard"
+          >
+            Return to dashboard
+          </Link>
+        </div>
+      </section>
+    );
   }
 
   return (

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -32,6 +32,8 @@ function Header({ user , hasActiveListing}) {
 
     const handleLogout = async () => {
         sessionStorage.removeItem("player_name");
+        sessionStorage.removeItem("session_state");
+        sessionStorage.removeItem("dashboard_user_info");
         setOpen(false);
 
         await fetch("/logout", {

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -19,12 +19,62 @@ function readStoredUser() {
     return normalizeUser(sessionStorage.getItem("player_name"));
 }
 
+function readStoredShellState() {
+    const fallback = {
+        user: readStoredUser(),
+        hasActiveListing: false,
+        recruitStatus: false,
+        townhall: null,
+        townhallWeaponLevel: 0
+    };
+
+    try {
+        const storedValue = sessionStorage.getItem("session_state");
+        if (!storedValue) {
+            return fallback;
+        }
+
+        const parsed = JSON.parse(storedValue);
+        return {
+            user: normalizeUser(parsed.username),
+            hasActiveListing: Boolean(parsed.has_active_listing),
+            recruitStatus: Boolean(parsed.recruit_status),
+            townhall: parsed.townhall ?? null,
+            townhallWeaponLevel: parsed.townhallWeaponLevel ?? 0
+        };
+    } catch {
+        return fallback;
+    }
+}
+
+function storeShellState(data) {
+    const username = normalizeUser(data.username);
+
+    if (username) {
+        sessionStorage.setItem("player_name", username);
+        sessionStorage.setItem("session_state", JSON.stringify(data));
+    } else {
+        sessionStorage.removeItem("player_name");
+        sessionStorage.removeItem("session_state");
+        sessionStorage.removeItem("dashboard_user_info");
+    }
+}
+
 const Layout = () => {
-    const [user, setUser] = useState(() => readStoredUser());
-    const [hasActiveListing, setHasActiveListing] = useState(false);
-    const [recruitStatus, setRecruitStatus] = useState(false);
-    const [townhall, setTownhall] = useState(null);
-    const [townhallWeaponLevel, setTownhallWeaponLevel] = useState(0);
+    const storedShellState = readStoredShellState();
+    const [user, setUser] = useState(() => storedShellState.user);
+    const [hasActiveListing, setHasActiveListing] = useState(
+        () => storedShellState.hasActiveListing
+    );
+    const [recruitStatus, setRecruitStatus] = useState(
+        () => storedShellState.recruitStatus
+    );
+    const [townhall, setTownhall] = useState(
+        () => storedShellState.townhall
+    );
+    const [townhallWeaponLevel, setTownhallWeaponLevel] = useState(
+        () => storedShellState.townhallWeaponLevel
+    );
     const [sessionStateLoaded, setSessionStateLoaded] = useState(false);
 
     useEffect(() => {
@@ -38,12 +88,24 @@ const Layout = () => {
                 setTownhall(null);
                 setTownhallWeaponLevel(0);
                 setSessionStateLoaded(false);
+                sessionStorage.removeItem("session_state");
+                sessionStorage.removeItem("dashboard_user_info");
             }
 
             fetch("/session-state", { credentials: "include" })
-                .then((res) => res.json())
+                .then((res) => {
+                    if (!res.ok) {
+                        return null;
+                    }
+
+                    return res.json();
+                })
                 .then((data) => {
                     if (!isMounted) return;
+                    if (!data) {
+                        setSessionStateLoaded(true);
+                        return;
+                    }
 
                     const username = normalizeUser(data.username);
                     setUser(username);
@@ -52,21 +114,10 @@ const Layout = () => {
                     setTownhall(data.townhall);
                     setTownhallWeaponLevel(data.townhallWeaponLevel);
                     setSessionStateLoaded(true);
-
-                    if (username) {
-                        sessionStorage.setItem("player_name", username);
-                    } else {
-                        sessionStorage.removeItem("player_name");
-                    }
+                    storeShellState(data);
                 })
                 .catch(() => {
                     if (!isMounted) return;
-                    setUser(null);
-                    setHasActiveListing(false);
-                    setRecruitStatus(false);
-                    setTownhall(null);
-                    setTownhallWeaponLevel(0);
-                    sessionStorage.removeItem("player_name");
                     setSessionStateLoaded(true);
                 });
         };

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -47,6 +47,10 @@ def home():
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
+    session.pop("player_league", None)
+    session.pop("player_townhall", None)
+    session.pop("player_townhall_weapon_level", None)
+    session.pop("player_builderbase_trophies", None)
     session["player_tag"] = received_tag
     user = API(received_tag, received_token, headers)
     check_player_team = user.check_player()
@@ -61,6 +65,7 @@ def home():
         session["clan_tag"] = clan_tag
         session["player_league"] = user.league
         session["player_townhall"] = user.townhall
+        session["player_townhall_weapon_level"] = user.townhallWeaponLevel
         session["player_builderbase_trophies"] = user.builder_trophies
     else:
         status = False

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -24,12 +24,8 @@ def session_state():
     clan_tag = session.get("clan_tag")
 
     if username != "Guest":
-        player_tag = session.get("player_tag")
-        user = API(player_tag, None, headers)
-        user.check_player()
-        townhall = user.townhall
-        townhallWeaponLevel = user.townhallWeaponLevel
-        clan_tag = user.clantag or clan_tag
+        townhall = session.get("player_townhall")
+        townhallWeaponLevel = session.get("player_townhall_weapon_level")
 
     if clan_tag:
         clan_collection = get_clan_collection()

--- a/tests/routes/test_home_login_route.py
+++ b/tests/routes/test_home_login_route.py
@@ -10,6 +10,7 @@ class DummyAPI:
         self.clantag = "TESTCLAN"
         self.league = 5
         self.townhall = 13
+        self.townhallWeaponLevel = 2
         self.builder_trophies = 2400
         self.reason = None
         DummyAPI.instances.append(self)
@@ -62,16 +63,24 @@ def test_home_login_valid_player_sets_session(
         assert session["clan_tag"] == "TESTCLAN"
         assert session["player_league"] == 5
         assert session["player_townhall"] == 13
+        assert session["player_townhall_weapon_level"] == 2
         assert session["player_builderbase_trophies"] == 2400
 
 
 def test_home_login_invalid_player_sets_failure_session(
     client,
     monkeypatch,
+    set_session,
 ):
     import ClashRecruit.routes.home_route as home_route
 
     monkeypatch.setattr(home_route, "API", InvalidDummyAPI)
+    set_session(
+        player_league=5,
+        player_townhall=13,
+        player_townhall_weapon_level=2,
+        player_builderbase_trophies=2400,
+    )
 
     response = client.post(
         "/",
@@ -94,6 +103,7 @@ def test_home_login_invalid_player_sets_failure_session(
         assert session["clan_tag"] is None
         assert "player_league" not in session
         assert "player_townhall" not in session
+        assert "player_townhall_weapon_level" not in session
         assert "player_builderbase_trophies" not in session
 
 

--- a/tests/routes/test_rate_limit_route.py
+++ b/tests/routes/test_rate_limit_route.py
@@ -29,32 +29,31 @@ def test_database_count_rate_limit_skips_collection(client, monkeypatch):
     assert calls == 30
 
 
-def test_session_state_rate_limit_skips_clash_api(
+def test_session_state_rate_limit_skips_collection_after_limit(
     client, set_session, monkeypatch
 ):
     import ClashRecruit.routes.session_state_route as session_state_route
 
     calls = 0
 
-    class DummyAPI:
-        def __init__(self, player_tag, api_token, headers):
-            self.townhall = 13
-            self.townhallWeaponLevel = 4
-            self.clantag = "TESTCLAN"
-
-        def check_player(self):
-            nonlocal calls
-            calls += 1
-            return True
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called by /session-state")
 
     class DummyCollection:
         def find_one(self, query, projection=None):
+            nonlocal calls
+            calls += 1
             return None
 
     set_session(
-        player_name="Player", player_tag="PLAYER123", clan_tag="TESTCLAN"
+        player_name="Player",
+        player_tag="PLAYER123",
+        clan_tag="TESTCLAN",
+        player_townhall=13,
+        player_townhall_weapon_level=4,
     )
-    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
     monkeypatch.setattr(
         session_state_route,
         "get_clan_collection",

--- a/tests/routes/test_session_state_route.py
+++ b/tests/routes/test_session_state_route.py
@@ -1,22 +1,3 @@
-class DummyAPI:
-    instances = []
-    live_clan_tag = "LIVECLAN"
-
-    def __init__(self, player_tag, api_token, headers):
-        self.player_tag = player_tag
-        self.api_token = api_token
-        self.headers = headers
-        self.townhall = 14
-        self.townhallWeaponLevel = 3
-        self.clantag = self.live_clan_tag
-        self.check_called = False
-        DummyAPI.instances.append(self)
-
-    def check_player(self):
-        self.check_called = True
-        return True
-
-
 class DummyClanCollection:
     def __init__(self, listing):
         self.listing = listing
@@ -50,6 +31,31 @@ def test_session_state_returns_guest_defaults(client, monkeypatch):
     }
 
 
+def test_session_state_ignores_cached_player_stats_for_guest(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called for Guest")
+
+    set_session(
+        player_name="Guest",
+        player_townhall=14,
+        player_townhall_weapon_level=3,
+    )
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json()["townhall"] is None
+    assert response.get_json()["townhallWeaponLevel"] is None
+
+
 def test_session_state_returns_logged_in_player_and_active_listing(
     client,
     monkeypatch,
@@ -58,91 +64,20 @@ def test_session_state_returns_logged_in_player_and_active_listing(
     import ClashRecruit.routes.session_state_route as session_state_route
 
     collection = DummyClanCollection(listing={"_id": "listing-id"})
-    DummyAPI.instances = []
     set_session(
         player_name="test_player",
         player_tag="PLAYER123",
         recruiter_status=True,
         clan_tag="SESSIONCLAN",
-    )
-    monkeypatch.setattr(session_state_route, "API", DummyAPI)
-    monkeypatch.setattr(
-        session_state_route,
-        "get_clan_collection",
-        lambda: collection,
+        player_townhall=14,
+        player_townhall_weapon_level=3,
     )
 
-    response = client.get("/session-state")
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called by /session-state")
 
-    assert response.status_code == 200
-    assert response.get_json() == {
-        "username": "test_player",
-        "recruit_status": True,
-        "has_active_listing": True,
-        "townhall": 14,
-        "townhallWeaponLevel": 3,
-    }
-    assert DummyAPI.instances[0].player_tag == "PLAYER123"
-    assert DummyAPI.instances[0].api_token is None
-    assert DummyAPI.instances[0].check_called is True
-    assert collection.find_one_query["clan_tag"] == "LIVECLAN"
-    assert "$gt" in collection.find_one_query["expires"]
-    assert collection.find_one_projection == {"_id": 1}
-
-
-def test_session_state_returns_logged_in_player_without_active_listing(
-    client,
-    monkeypatch,
-    set_session,
-):
-    import ClashRecruit.routes.session_state_route as session_state_route
-
-    collection = DummyClanCollection(listing=None)
-    DummyAPI.instances = []
-    DummyAPI.live_clan_tag = "LIVECLAN"
-    set_session(
-        player_name="test_player",
-        player_tag="PLAYER123",
-        recruiter_status=True,
-        clan_tag="SESSIONCLAN",
-    )
-    monkeypatch.setattr(session_state_route, "API", DummyAPI)
-    monkeypatch.setattr(
-        session_state_route,
-        "get_clan_collection",
-        lambda: collection,
-    )
-
-    response = client.get("/session-state")
-
-    assert response.status_code == 200
-    assert response.get_json() == {
-        "username": "test_player",
-        "recruit_status": True,
-        "has_active_listing": False,
-        "townhall": 14,
-        "townhallWeaponLevel": 3,
-    }
-    assert collection.find_one_query["clan_tag"] == "LIVECLAN"
-
-
-def test_session_state_falls_back_to_session_clan_tag_when_api_has_none(
-    client,
-    monkeypatch,
-    set_session,
-):
-    import ClashRecruit.routes.session_state_route as session_state_route
-
-    collection = DummyClanCollection(listing={"_id": "listing-id"})
-    DummyAPI.instances = []
-    DummyAPI.live_clan_tag = None
-    set_session(
-        player_name="test_player",
-        player_tag="PLAYER123",
-        recruiter_status=True,
-        clan_tag="SESSIONCLAN",
-    )
-    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
     monkeypatch.setattr(
         session_state_route,
         "get_clan_collection",
@@ -160,4 +95,87 @@ def test_session_state_falls_back_to_session_clan_tag_when_api_has_none(
         "townhallWeaponLevel": 3,
     }
     assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"
-    DummyAPI.live_clan_tag = "LIVECLAN"
+    assert "$gt" in collection.find_one_query["expires"]
+    assert collection.find_one_projection == {"_id": 1}
+
+
+def test_session_state_returns_logged_in_player_without_active_listing(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing=None)
+    set_session(
+        player_name="test_player",
+        player_tag="PLAYER123",
+        recruiter_status=True,
+        clan_tag="SESSIONCLAN",
+        player_townhall=14,
+        player_townhall_weapon_level=3,
+    )
+
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called by /session-state")
+
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": False,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"
+
+
+def test_session_state_uses_session_clan_tag_without_live_refresh(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing={"_id": "listing-id"})
+    set_session(
+        player_name="test_player",
+        player_tag="PLAYER123",
+        recruiter_status=True,
+        clan_tag="SESSIONCLAN",
+        player_townhall=14,
+        player_townhall_weapon_level=3,
+    )
+
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called by /session-state")
+
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": True,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"


### PR DESCRIPTION
## Summary
- Stop `/session-state` from calling the Clash API during app shell load.
- Return shell state from Flask session data plus the local active-listing check.
- Cache last valid shell and dashboard user-info data on the frontend so rate-limited refreshes do not clear visible user data.
- Show a centered recruiter rate-limit message with link-style navigation instead of redirecting away on load failure.

## Testing
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check .`
- Manually tested by refreshing pages until 429 Too Many Requests.

## Notes
- Frontend build was not run locally because this shell does not have `node`/`npm` available.