### PR TITLE
Treat expired listings as inactive

### DIFF
--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -1,5 +1,7 @@
 """Register home routes for login, logout, and database count requests."""
 
+from datetime import datetime, timezone
+
 from flask import Blueprint, jsonify, request, session
 
 from ..api.clash_api import API
@@ -91,7 +93,13 @@ def home():
 def database_count():
     """Return the current number of stored clans in the database."""
     clan_collection = get_clan_collection()
-    return jsonify({"clan_count": clan_collection.count_documents({})})
+    return jsonify(
+        {
+            "clan_count": clan_collection.count_documents(
+                {"expires": {"$gt": datetime.now(timezone.utc)}}
+            )
+        }
+    )
 
 
 @home_bp.post("/logout")

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -1,6 +1,7 @@
 """Register routes for handling imported clans."""
 
 import re
+from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, request
 
@@ -44,6 +45,7 @@ def _build_imported_query(filters):
     """Build a MongoDB query for imported clans from request filter data."""
     query = {
         "source": "clash_api_import",
+        "expires": {"$gt": datetime.now(timezone.utc)},
     }
 
     name = filters.get("name")

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -1,6 +1,7 @@
 """Register routes for handling recruitee requests."""
 
 import re
+from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, request, session
 
@@ -43,6 +44,13 @@ def _should_include_total():
     return request.args.get("includeTotal", "0") == "1"
 
 
+def _active_listing_query(query=None):
+    """Return a listing query scoped to listings that have not expired."""
+    active_query = dict(query or {})
+    active_query["expires"] = {"$gt": datetime.now(timezone.utc)}
+    return active_query
+
+
 @recruitee_bp.get("/recruitee")
 @rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
@@ -67,9 +75,10 @@ def recruitee_get():
             },
             "requirements.2": {"$lte": session.get("player_townhall")},
         }
+    query = _active_listing_query(base_query)
 
     data = list(
-        clan_collection.find(base_query, {"_id": 0})
+        clan_collection.find(query, {"_id": 0})
         .sort([("last_updated", -1), ("clan_tag", 1)])
         .skip(requested_offset)
         .limit(requested_limit)
@@ -78,7 +87,7 @@ def recruitee_get():
     if not _should_include_total():
         return jsonify(data)
 
-    total = clan_collection.count_documents(base_query)
+    total = clan_collection.count_documents(query)
     return jsonify(
         {
             "items": data,
@@ -105,7 +114,9 @@ def recruitee_post():
 
     clan_tag = raw_form.get("clanTag") or raw_form.get("clan_tag")
     if clan_tag:
-        data = clan_collection.find_one({"clan_tag": clan_tag}, {"_id": 0})
+        data = clan_collection.find_one(
+            _active_listing_query({"clan_tag": clan_tag}), {"_id": 0}
+        )
         if data is None:
             return jsonify({"error": "Clan not found"}), 404
         return jsonify(data)
@@ -158,6 +169,7 @@ def recruitee_post():
         if location_name:
             query["clan_info.location.name"] = location_name
 
+    query = _active_listing_query(query)
     data = list(
         clan_collection.find(query, {"_id": 0})
         .sort([("last_updated", -1), ("clan_tag", 1)])

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -1,5 +1,7 @@
 """Register routes for saved a users saved clans."""
 
+from datetime import datetime, timezone
+
 from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import get_clan_collection, get_user_collection
@@ -29,9 +31,10 @@ def _hydrate_saved_clans(saved_clan_tags):
             provided saved clan tags.
     """
     clan_collection = get_clan_collection()
+    now = datetime.now(timezone.utc)
     listings = list(
         clan_collection.find(
-            {"clan_tag": {"$in": saved_clan_tags}},
+            {"clan_tag": {"$in": saved_clan_tags}, "expires": {"$gt": now}},
             {
                 "_id": 0,
                 "clan_tag": 1,

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -446,7 +446,11 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
         return None
 
     clan = _clan_collection().find_one(
-        {"clan_tag": clean_tag, "source": "clash_api_import"},
+        {
+            "clan_tag": clean_tag,
+            "source": "clash_api_import",
+            "expires": {"$gt": _now()},
+        },
         {"_id": 0},
     )
     if clan is not None:
@@ -486,6 +490,10 @@ def get_imported_clan(clan_tag: str | None) -> dict[str, Any] | None:
         upsert=True,
     )
     return _clan_collection().find_one(
-        {"clan_tag": clean_tag, "source": "clash_api_import"},
+        {
+            "clan_tag": clean_tag,
+            "source": "clash_api_import",
+            "expires": {"$gt": _now()},
+        },
         {"_id": 0},
     )

--- a/services/recruiter_listing.py
+++ b/services/recruiter_listing.py
@@ -16,7 +16,7 @@ def get_recruiter_listing_page(
 ) -> tuple[dict[str, object], int]:
     """Return recruiter listing form data for a clan."""
     clan_collection = get_clan_collection()
-    existing = clan_collection.find_one(_listing_query(clan_tag))
+    existing = clan_collection.find_one(_active_listing_query(clan_tag))
 
     recruiter = _recruiter_with_requirements(clan_tag)
     if existing:
@@ -95,7 +95,11 @@ def create_recruiter_listing(
         "expires": expiry,
     }
     render_data = document.copy()
-    clan_collection.insert_one(document)
+    clan_collection.replace_one(
+        _listing_query(clan_tag),
+        document,
+        upsert=True,
+    )
     render_data["status"] = expiry
     render_data["message"] = "Listing created successfully."
 
@@ -150,6 +154,12 @@ def _listing_query(clan_tag: str | None) -> dict[str, object]:
         "clan_tag": clan_tag,
         "source": {"$ne": "clash_api_import"},
     }
+
+
+def _active_listing_query(clan_tag: str | None) -> dict[str, object]:
+    query = _listing_query(clan_tag)
+    query["expires"] = {"$gt": datetime.now(timezone.utc)}
+    return query
 
 
 def _recruiter_with_requirements(clan_tag: str | None) -> Recruiter:

--- a/services/refresh_db.py
+++ b/services/refresh_db.py
@@ -40,6 +40,7 @@ def refresh_membercount() -> None:
                 "last_updated": {
                     "$lte": datetime.now(timezone.utc) - THRESHOLD
                 },
+                "expires": {"$gt": datetime.now(timezone.utc)},
             }
         )
     )

--- a/tests/routes/test_home_database_count_route.py
+++ b/tests/routes/test_home_database_count_route.py
@@ -3,7 +3,7 @@ def test_database_count_returns_mocked_count(client, monkeypatch):
 
     class DummyCollection:
         def count_documents(self, query):
-            assert query == {}
+            assert "$gt" in query["expires"]
             return 42
 
     monkeypatch.setattr(

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -74,6 +74,7 @@ def test_imported_clans_post_filters_and_paginates(
 
     expected_query = {
         "source": "clash_api_import",
+        "expires": collection.find_query["expires"],
         "name": {"$regex": "Test\\.\\*", "$options": "i"},
         "clan_info.clan_level": {"$gte": 12},
         "clan_info.clanPoints": {"$gte": 40000},
@@ -91,6 +92,7 @@ def test_imported_clans_post_filters_and_paginates(
     }
     assert collection.count_query == expected_query
     assert collection.find_query == expected_query
+    assert "$gt" in collection.find_query["expires"]
     assert collection.find_projection == {"_id": 0}
     assert collection.cursor.sort_fields == [
         ("last_discovered", -1),

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -81,6 +81,7 @@ def test_recruitee_get_filters_logged_in_player_with_total(
         "requirements.0": {"$lte": 5},
         "requirements.1": {"$lte": 2200},
         "requirements.2": {"$lte": 13},
+        "expires": collection.find_query["expires"],
     }
 
     assert response.status_code == 200
@@ -92,6 +93,7 @@ def test_recruitee_get_filters_logged_in_player_with_total(
     }
     assert collection.find_query == expected_query
     assert collection.count_query == expected_query
+    assert "$gt" in collection.find_query["expires"]
     assert collection.find_projection == {"_id": 0}
     assert collection.cursor.sort_fields == [
         ("last_updated", -1),
@@ -129,7 +131,10 @@ def test_recruitee_get_returns_guest_default_raw_list(
         {"clan_tag": "TEST1", "name": "test_clan_1"},
         {"clan_tag": "TEST2", "name": "test_clan_2"},
     ]
-    assert collection.find_query == {}
+    assert collection.find_query == {
+        "expires": collection.find_query["expires"],
+    }
+    assert "$gt" in collection.find_query["expires"]
     assert collection.count_query is None
     assert collection.cursor.skip_count == 0
     assert collection.cursor.limit_count == 10
@@ -182,6 +187,7 @@ def test_recruitee_post_filters_and_paginates_with_total(
         "clan_info.member_count": {"$gte": 30, "$lte": 45},
         "clan_info.warFrequency": "always",
         "clan_info.location.id": 32000007,
+        "expires": collection.find_query["expires"],
     }
 
     assert response.status_code == 200
@@ -196,6 +202,7 @@ def test_recruitee_post_filters_and_paginates_with_total(
     }
     assert collection.find_query == expected_query
     assert collection.count_query == expected_query
+    assert "$gt" in collection.find_query["expires"]
     assert collection.find_projection == {"_id": 0}
     assert collection.cursor.sort_fields == [
         ("last_updated", -1),
@@ -224,7 +231,11 @@ def test_recruitee_post_returns_clan_by_tag(
 
     assert response.status_code == 200
     assert response.get_json() == {"clan_tag": "TEST123", "name": "test_clan"}
-    assert collection.find_one_query == {"clan_tag": "TEST123"}
+    assert collection.find_one_query == {
+        "clan_tag": "TEST123",
+        "expires": collection.find_one_query["expires"],
+    }
+    assert "$gt" in collection.find_one_query["expires"]
     assert collection.find_one_projection == {"_id": 0}
     assert collection.find_query is None
 
@@ -255,7 +266,9 @@ def test_recruitee_post_filters_by_location_name_without_location_id(
     ]
     assert collection.find_query == {
         "clan_info.location.name": "International",
+        "expires": collection.find_query["expires"],
     }
+    assert "$gt" in collection.find_query["expires"]
     assert collection.count_query is None
 
 
@@ -323,7 +336,11 @@ def test_recruitee_post_returns_404_for_missing_clan_tag(
 
     assert response.status_code == 404
     assert response.get_json() == {"error": "Clan not found"}
-    assert collection.find_one_query == {"clan_tag": "MISSING"}
+    assert collection.find_one_query == {
+        "clan_tag": "MISSING",
+        "expires": collection.find_one_query["expires"],
+    }
+    assert "$gt" in collection.find_one_query["expires"]
     assert collection.find_one_projection == {"_id": 0}
 
 
@@ -409,4 +426,6 @@ def test_recruitee_post_normalizes_numeric_string_filters(
         "clan_info.clan_level": {"$gte": 10},
         "clan_info.clanPoints": {"$gte": 35000},
         "clan_info.member_count": {"$gte": 30, "$lte": 45},
+        "expires": collection.find_query["expires"],
     }
+    assert "$gt" in collection.find_query["expires"]

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -12,6 +12,7 @@ class DummyClanCollection:
         self.deleted_count = deleted_count
         self.find_one_query = None
         self.inserted_doc = None
+        self.replace_call = None
         self.update_call = None
         self.delete_query = None
 
@@ -20,6 +21,10 @@ class DummyClanCollection:
         return self.existing
 
     def insert_one(self, doc):
+        self.inserted_doc = doc
+
+    def replace_one(self, query, doc, upsert=False):
+        self.replace_call = (query, doc, upsert)
         self.inserted_doc = doc
 
     def update_one(self, query, update):
@@ -106,7 +111,9 @@ def test_recruiter_get_returns_existing_listing(
     assert collection.find_one_query == {
         "clan_tag": "TEST123",
         "source": {"$ne": "clash_api_import"},
+        "expires": collection.find_one_query["expires"],
     }
+    assert "$gt" in collection.find_one_query["expires"]
     assert DummyRecruiter.instances[0].pull_called is True
     assert DummyRecruiter.instances[0].lookup_modes == []
 
@@ -134,7 +141,9 @@ def test_recruiter_get_returns_default_listing_and_lookup_description(
     assert collection.find_one_query == {
         "clan_tag": "TEST123",
         "source": {"$ne": "clash_api_import"},
+        "expires": collection.find_one_query["expires"],
     }
+    assert "$gt" in collection.find_one_query["expires"]
     assert DummyRecruiter.instances[0].pull_called is True
     assert DummyRecruiter.instances[0].lookup_modes == ["description"]
 
@@ -181,6 +190,11 @@ def test_recruiter_post_creates_new_listing(
     )
     assert isinstance(collection.inserted_doc["last_updated"], datetime)
     assert isinstance(collection.inserted_doc["expires"], datetime)
+    assert collection.replace_call == (
+        {"clan_tag": "TEST123", "source": {"$ne": "clash_api_import"}},
+        collection.inserted_doc,
+        True,
+    )
 
 
 def test_recruiter_post_updates_listing_and_refreshes_expiry(

--- a/tests/routes/test_saved_clans_authorized_route.py
+++ b/tests/routes/test_saved_clans_authorized_route.py
@@ -13,7 +13,8 @@ def test_saved_clans_get_hydrates_available_and_missing_listings(
 
     class DummyClanCollection:
         def find(self, query, projection):
-            assert query == {"clan_tag": {"$in": ["ABC123", "MISSING"]}}
+            assert query["clan_tag"] == {"$in": ["ABC123", "MISSING"]}
+            assert "$gt" in query["expires"]
             assert projection == {
                 "_id": 0,
                 "clan_tag": 1,
@@ -82,7 +83,8 @@ def test_saved_clans_get_returns_empty_saved_list(
 
     class DummyClanCollection:
         def find(self, query, projection):
-            assert query == {"clan_tag": {"$in": []}}
+            assert query["clan_tag"] == {"$in": []}
+            assert "$gt" in query["expires"]
             assert projection == {
                 "_id": 0,
                 "clan_tag": 1,

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -686,10 +686,15 @@ def test_get_imported_clan_returns_cached_document_without_fetch(
     assert result == cached
     assert clan_collection.find_one_calls == [
         (
-            {"clan_tag": "TEST123", "source": "clash_api_import"},
+            {
+                "clan_tag": "TEST123",
+                "source": "clash_api_import",
+                "expires": clan_collection.find_one_calls[0][0]["expires"],
+            },
             {"_id": 0},
         )
     ]
+    assert "$gt" in clan_collection.find_one_calls[0][0]["expires"]
 
 
 def test_get_imported_clan_fetches_caches_and_returns_imported_document(

--- a/tests/test_imported_clan_helpers.py
+++ b/tests/test_imported_clan_helpers.py
@@ -56,8 +56,14 @@ def test_invalid_pagination_raises_validation_error(
                 _get_requested_offset()
 
 
-def test_build_imported_query_empty_filters_returns_source_only() -> None:
-    assert _build_imported_query({}) == {"source": "clash_api_import"}
+def test_build_imported_query_empty_filters_returns_active_imports() -> None:
+    query = _build_imported_query({})
+
+    assert query == {
+        "source": "clash_api_import",
+        "expires": query["expires"],
+    }
+    assert "$gt" in query["expires"]
 
 
 def test_build_imported_query_escapes_name_and_ignores_empty() -> None:
@@ -71,8 +77,10 @@ def test_build_imported_query_escapes_name_and_ignores_empty() -> None:
 
     assert query == {
         "source": "clash_api_import",
+        "expires": query["expires"],
         "name": {"$regex": "test\\.\\*\\(name\\)", "$options": "i"},
     }
+    assert "$gt" in query["expires"]
 
 
 @pytest.mark.parametrize(
@@ -94,6 +102,7 @@ def test_build_imported_query_member_ranges(
     )
 
     assert query["source"] == "clash_api_import"
+    assert "$gt" in query["expires"]
     assert query["clan_info.member_count"] == expected
 
 
@@ -109,8 +118,10 @@ def test_build_imported_query_all_scalar_filters() -> None:
 
     assert query == {
         "source": "clash_api_import",
+        "expires": query["expires"],
         "clan_info.clan_level": {"$gte": 10},
         "clan_info.clanPoints": {"$gte": 35000},
         "clan_info.warFrequency": "always",
         "clan_info.location.name": "International",
     }
+    assert "$gt" in query["expires"]

--- a/tests/test_recruiter_listing_service.py
+++ b/tests/test_recruiter_listing_service.py
@@ -16,6 +16,7 @@ class DummyClanCollection:
         self.deleted_count = deleted_count
         self.find_one_query = None
         self.inserted_doc = None
+        self.replace_call = None
         self.update_call = None
         self.delete_query = None
 
@@ -24,6 +25,10 @@ class DummyClanCollection:
         return self.existing
 
     def insert_one(self, doc):
+        self.inserted_doc = doc
+
+    def replace_one(self, query, doc, upsert=False):
+        self.replace_call = (query, doc, upsert)
         self.inserted_doc = doc
 
     def update_one(self, query, update):
@@ -104,6 +109,7 @@ def test_get_recruiter_listing_page_returns_existing_listing(monkeypatch):
     assert collection.find_one_query == {
         "clan_tag": "TEST123",
         "source": {"$ne": "clash_api_import"},
+        "expires": {"$gt": FROZEN_NOW},
     }
     assert DummyRecruiter.instances[0].pull_called is True
     assert DummyRecruiter.instances[0].lookup_modes == []
@@ -158,6 +164,11 @@ def test_create_recruiter_listing_inserts_live_listing(monkeypatch):
     assert payload["status"] == expiry
     assert collection.inserted_doc["last_updated"] == FROZEN_NOW
     assert collection.inserted_doc["expires"] == expiry
+    assert collection.replace_call == (
+        {"clan_tag": "TEST123", "source": {"$ne": "clash_api_import"}},
+        collection.inserted_doc,
+        True,
+    )
 
 
 def test_update_recruiter_listing_refreshes_expiry(monkeypatch):

--- a/tests/test_refresh_db_service.py
+++ b/tests/test_refresh_db_service.py
@@ -50,7 +50,8 @@ def test_refresh_membercount_updates_stale_entries(monkeypatch):
     refresh_db.refresh_membercount()
 
     assert clan_collection.find_query == {
-        "last_updated": {"$lte": frozen_now - refresh_db.THRESHOLD}
+        "last_updated": {"$lte": frozen_now - refresh_db.THRESHOLD},
+        "expires": {"$gt": frozen_now},
     }
     assert [instance.clan_tag for instance in DummyRecruiter.instances] == [
         "TEST123",


### PR DESCRIPTION
## Summary
- Add explicit `expires > now` filters to listing reads, counts, saved-clan hydration, imported listing lookup, and member-count refresh
- Update recruiter listing creation to replace/upsert existing live-listing docs so expired TTL leftovers do not block recreation
- Update route and service tests to verify expired-but-present listings are ignored logically

## Tests
- `venv/bin/pytest`
- `venv/bin/ruff check .`