### PR TITLE
Fix/input validation

### DIFF
--- a/frontend/src/LookingForClan.jsx
+++ b/frontend/src/LookingForClan.jsx
@@ -58,6 +58,43 @@ function normalizeListingPayload(payload) {
   };
 }
 
+async function getResponseErrorMessage(response, fallbackMessage) {
+  const payload = await response.json().catch(() => ({}));
+  return formatApiErrorMessage(payload.error || payload.message || fallbackMessage);
+}
+
+function formatApiErrorMessage(message) {
+  const trimmed = String(message || "").trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const fieldMessage = trimmed.match(
+    /^([A-Za-z][A-Za-z0-9_.]*)(\s+(?:is|must|should|cannot)\b.*)$/
+  );
+  if (fieldMessage) {
+    return `${formatFieldName(fieldMessage[1])}${fieldMessage[2]}`;
+  }
+
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+function formatFieldName(fieldName) {
+  const readable = fieldName
+    .split(".")
+    .map((part) => (
+      part
+        .replace(/_/g, " ")
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    ))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+
+  return readable.charAt(0).toUpperCase() + readable.slice(1);
+}
+
 function LookingForClan() {
     usePageTitle("Find a Clan | ClashRecruit")
     
@@ -165,7 +202,9 @@ function LookingForClan() {
         : await fetch(url);
 
       if (!response.ok) {
-        throw new Error("Failed to load clans.");
+        throw new Error(
+          await getResponseErrorMessage(response, "Failed to load clans.")
+        );
       }
 
       const payload = await response.json();
@@ -260,7 +299,14 @@ function LookingForClan() {
           },
           body: JSON.stringify(filterPayload),
         });
-        if (!response.ok) throw new Error("Failed to fetch filtered clans.");
+        if (!response.ok) {
+          throw new Error(
+            await getResponseErrorMessage(
+              response,
+              "Failed to fetch filtered clans."
+            )
+          );
+        }
         const data = await response.json();
         if (controller.signal.aborted) {
           return;
@@ -270,7 +316,9 @@ function LookingForClan() {
         setTotalResults(normalized.total);
       } catch (error) {
         if (error.name !== "AbortError") {
-          setFilterError("Could not apply filters right now. Please try again.");
+          setFilterError(
+            error.message || "Could not apply filters right now. Please try again."
+          );
         }
       } finally {
         if (requestControllerRef.current === controller) {

--- a/routes/home_route.py
+++ b/routes/home_route.py
@@ -9,14 +9,16 @@ from ..services.rate_limiter import is_rate_limited
 from .rate_limit import rate_limit
 from .validation import (
     RequestValidationError,
+    ensure_allowed_fields,
     get_json_object,
     normalize_tag,
-    optional_string,
+    required_string,
 )
 
 home_bp = Blueprint("home", __name__)
 LOGIN_RATE_LIMIT = 5
 LOGIN_RATE_WINDOW_SECONDS = 5
+LOGIN_FIELDS = {"playerTag", "apiToken"}
 
 
 @home_bp.post("/")
@@ -42,8 +44,9 @@ def home():
 
     try:
         data = get_json_object(request)
+        ensure_allowed_fields(data, LOGIN_FIELDS, "login")
         received_tag = normalize_tag(data.get("playerTag"), "playerTag")
-        received_token = optional_string(data, "apiToken", max_length=128)
+        received_token = required_string(data, "apiToken", max_length=128)
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -13,6 +13,7 @@ from .validation import (
     CLASH_WAR_FREQUENCIES,
     RequestValidationError,
     ensure_allowed_fields,
+    ensure_exactly_one_field,
     ensure_object,
     get_json_object,
     normalize_tag,
@@ -148,12 +149,17 @@ def imported_clans_post():
 def _validate_imported_payload(payload):
     """Return normalized imported-clans POST payload."""
     ensure_allowed_fields(payload, IMPORTED_PAYLOAD_FIELDS, "imported clans")
+    payload_mode = ensure_exactly_one_field(
+        payload,
+        IMPORTED_PAYLOAD_FIELDS,
+        "imported clans payload",
+    )
     normalized = {}
-    if "clanTag" in payload:
+    if payload_mode == "clanTag":
         normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
         return normalized
 
-    filters = ensure_object(payload.get("filters"), "filters")
+    filters = ensure_object(payload["filters"], "filters")
     normalized["filters"] = _validate_imported_filters(filters)
     return normalized
 

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -27,6 +27,8 @@ from .validation import (
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
 MAX_LIMIT = 200
+MAX_CLAN_LEVEL = 99
+MAX_CLAN_POINTS = 400000
 IMPORTED_PAYLOAD_FIELDS = {"clanTag", "filters"}
 IMPORTED_FILTER_FIELDS = {
     "name",
@@ -174,10 +176,20 @@ def _validate_imported_filters(filters):
     if name:
         normalized["name"] = name
 
-    min_clan_level = optional_int(filters, "minClanLevel", min_value=0)
+    min_clan_level = optional_int(
+        filters,
+        "minClanLevel",
+        min_value=0,
+        max_value=MAX_CLAN_LEVEL,
+    )
     if min_clan_level is not None:
         normalized["minClanLevel"] = min_clan_level
-    clan_points = optional_int(filters, "clanPoints", min_value=0)
+    clan_points = optional_int(
+        filters,
+        "clanPoints",
+        min_value=0,
+        max_value=MAX_CLAN_POINTS,
+    )
     if clan_points is not None:
         normalized["clanPoints"] = clan_points
 

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -95,8 +95,8 @@ def imported_clans_post():
 
     clan_collection = get_clan_collection()
 
-    clan_tag = raw_form.get("clanTag") or raw_form.get("clan_tag")
-    if clan_tag:
+    clan_tag = raw_form.get("clanTag")
+    if clan_tag is not None:
         clan = get_imported_clan(clan_tag)
         if clan is None:
             return jsonify({"error": "Imported clan not found"}), 404
@@ -134,9 +134,8 @@ def imported_clans_post():
 def _validate_imported_payload(payload):
     """Return normalized imported-clans POST payload."""
     normalized = {}
-    raw_tag = payload.get("clanTag") or payload.get("clan_tag")
-    if raw_tag is not None:
-        normalized["clanTag"] = normalize_tag(raw_tag, "clanTag")
+    if "clanTag" in payload:
+        normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
         return normalized
 
     filters = ensure_object(payload.get("filters"), "filters")

--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -10,10 +10,13 @@ from ..services.import_clash_api_clans import (
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
 from .validation import (
+    CLASH_WAR_FREQUENCIES,
     RequestValidationError,
+    ensure_allowed_fields,
     ensure_object,
     get_json_object,
     normalize_tag,
+    optional_enum,
     optional_int,
     optional_string,
     query_int,
@@ -22,6 +25,17 @@ from .validation import (
 imported_clans_bp = Blueprint("imported_clans", __name__)
 
 MAX_LIMIT = 200
+IMPORTED_PAYLOAD_FIELDS = {"clanTag", "filters"}
+IMPORTED_FILTER_FIELDS = {
+    "name",
+    "minClanLevel",
+    "clanPoints",
+    "requirements",
+    "warFrequency",
+    "location",
+}
+IMPORTED_REQUIREMENT_FIELDS = {"members"}
+MEMBER_FILTER_FIELDS = {"min", "max"}
 
 
 def _get_requested_limit(default_limit):
@@ -133,6 +147,7 @@ def imported_clans_post():
 
 def _validate_imported_payload(payload):
     """Return normalized imported-clans POST payload."""
+    ensure_allowed_fields(payload, IMPORTED_PAYLOAD_FIELDS, "imported clans")
     normalized = {}
     if "clanTag" in payload:
         normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
@@ -144,6 +159,7 @@ def _validate_imported_payload(payload):
 
 
 def _validate_imported_filters(filters):
+    ensure_allowed_fields(filters, IMPORTED_FILTER_FIELDS, "filter")
     normalized = {}
 
     name = optional_string(filters, "name", max_length=120)
@@ -161,6 +177,11 @@ def _validate_imported_filters(filters):
         filters.get("requirements"),
         "filters.requirements",
     )
+    ensure_allowed_fields(
+        requirements,
+        IMPORTED_REQUIREMENT_FIELDS,
+        "requirements",
+    )
     members = ensure_object(
         requirements.get("members"),
         "filters.requirements.members",
@@ -169,7 +190,11 @@ def _validate_imported_filters(filters):
     if normalized_members:
         normalized["requirements"] = {"members": normalized_members}
 
-    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    war_frequency = optional_enum(
+        filters,
+        "warFrequency",
+        CLASH_WAR_FREQUENCIES,
+    )
     if war_frequency:
         normalized["warFrequency"] = war_frequency
 
@@ -181,6 +206,7 @@ def _validate_imported_filters(filters):
 
 
 def _validate_members_filter(members):
+    ensure_allowed_fields(members, MEMBER_FILTER_FIELDS, "members")
     normalized = {}
     min_members = optional_int(members, "min", min_value=0, max_value=50)
     max_members = optional_int(members, "max", min_value=0, max_value=50)

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -10,6 +10,7 @@ from .validation import (
     CLASH_WAR_FREQUENCIES,
     RequestValidationError,
     ensure_allowed_fields,
+    ensure_exactly_one_field,
     ensure_object,
     get_json_object,
     normalize_tag,
@@ -225,12 +226,17 @@ def recruitee_post():
 def _validate_recruitee_payload(payload):
     """Return normalized recruitee POST payload."""
     ensure_allowed_fields(payload, RECRUITEE_PAYLOAD_FIELDS, "recruitee")
+    payload_mode = ensure_exactly_one_field(
+        payload,
+        RECRUITEE_PAYLOAD_FIELDS,
+        "recruitee payload",
+    )
     normalized = {}
-    if "clanTag" in payload:
+    if payload_mode == "clanTag":
         normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
         return normalized
 
-    filters = ensure_object(payload.get("filters"), "filters")
+    filters = ensure_object(payload["filters"], "filters")
     normalized["filters"] = _validate_filter_payload(filters)
     return normalized
 

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -103,8 +103,8 @@ def recruitee_post():
 
     clan_collection = get_clan_collection()
 
-    clan_tag = raw_form.get("clanTag") or raw_form.get("clan_tag")
-    if clan_tag:
+    clan_tag = raw_form.get("clanTag")
+    if clan_tag is not None:
         data = clan_collection.find_one({"clan_tag": clan_tag}, {"_id": 0})
         if data is None:
             return jsonify({"error": "Clan not found"}), 404
@@ -182,9 +182,8 @@ def recruitee_post():
 def _validate_recruitee_payload(payload):
     """Return normalized recruitee POST payload."""
     normalized = {}
-    raw_tag = payload.get("clanTag") or payload.get("clan_tag")
-    if raw_tag is not None:
-        normalized["clanTag"] = normalize_tag(raw_tag, "clanTag")
+    if "clanTag" in payload:
+        normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
         return normalized
 
     filters = ensure_object(payload.get("filters"), "filters")

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -7,10 +7,13 @@ from flask import Blueprint, jsonify, request, session
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
 from .validation import (
+    CLASH_WAR_FREQUENCIES,
     RequestValidationError,
+    ensure_allowed_fields,
     ensure_object,
     get_json_object,
     normalize_tag,
+    optional_enum,
     optional_int,
     optional_string,
     query_int,
@@ -19,6 +22,18 @@ from .validation import (
 recruitee_bp = Blueprint("recruitee", __name__)
 
 MAX_LIMIT = 200
+RECRUITEE_PAYLOAD_FIELDS = {"clanTag", "filters"}
+RECRUITEE_FILTER_FIELDS = {
+    "name",
+    "requirements",
+    "minClanLevel",
+    "clanPoints",
+    "warFrequency",
+    "location_id",
+    "location",
+}
+RECRUITEE_REQUIREMENT_FIELDS = {"townhall", "league", "members"}
+MEMBER_FILTER_FIELDS = {"min", "max"}
 
 
 def _get_requested_limit(default_limit):
@@ -181,6 +196,7 @@ def recruitee_post():
 
 def _validate_recruitee_payload(payload):
     """Return normalized recruitee POST payload."""
+    ensure_allowed_fields(payload, RECRUITEE_PAYLOAD_FIELDS, "recruitee")
     normalized = {}
     if "clanTag" in payload:
         normalized["clanTag"] = normalize_tag(payload["clanTag"], "clanTag")
@@ -192,6 +208,7 @@ def _validate_recruitee_payload(payload):
 
 
 def _validate_filter_payload(filters):
+    ensure_allowed_fields(filters, RECRUITEE_FILTER_FIELDS, "filter")
     normalized = {}
 
     name = optional_string(filters, "name", max_length=120)
@@ -201,6 +218,11 @@ def _validate_filter_payload(filters):
     requirements = ensure_object(
         filters.get("requirements"),
         "filters.requirements",
+    )
+    ensure_allowed_fields(
+        requirements,
+        RECRUITEE_REQUIREMENT_FIELDS,
+        "requirements",
     )
     normalized_requirements = {}
     townhall = optional_int(
@@ -232,7 +254,11 @@ def _validate_filter_payload(filters):
     if clan_points is not None:
         normalized["clanPoints"] = clan_points
 
-    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    war_frequency = optional_enum(
+        filters,
+        "warFrequency",
+        CLASH_WAR_FREQUENCIES,
+    )
     if war_frequency:
         normalized["warFrequency"] = war_frequency
 
@@ -248,6 +274,7 @@ def _validate_filter_payload(filters):
 
 
 def _validate_members_filter(members):
+    ensure_allowed_fields(members, MEMBER_FILTER_FIELDS, "members")
     normalized = {}
     min_members = optional_int(members, "min", min_value=0, max_value=50)
     max_members = optional_int(members, "max", min_value=0, max_value=50)

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -16,6 +16,7 @@ from .validation import (
     optional_enum,
     optional_int,
     optional_string,
+    query_bool,
     query_int,
 )
 
@@ -55,7 +56,7 @@ def _get_requested_offset():
 
 def _should_include_total():
     """Return whether the response should include paginated total metadata."""
-    return request.args.get("includeTotal", "0") == "1"
+    return query_bool(request, "includeTotal", default=False)
 
 
 @recruitee_bp.get("/recruitee")
@@ -66,6 +67,7 @@ def recruitee_get():
         default_limit = 10
         requested_limit = _get_requested_limit(default_limit)
         requested_offset = _get_requested_offset()
+        include_total = _should_include_total()
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
@@ -90,7 +92,7 @@ def recruitee_get():
         .limit(requested_limit)
     )
 
-    if not _should_include_total():
+    if not include_total:
         return jsonify(data)
 
     total = clan_collection.count_documents(base_query)
@@ -112,6 +114,7 @@ def recruitee_post():
         default_limit = 10
         requested_limit = _get_requested_limit(default_limit)
         requested_offset = _get_requested_offset()
+        include_total = _should_include_total()
         raw_form = _validate_recruitee_payload(get_json_object(request))
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
@@ -180,7 +183,7 @@ def recruitee_post():
         .limit(requested_limit)
     )
 
-    if not _should_include_total():
+    if not include_total:
         return jsonify(data)
 
     total = clan_collection.count_documents(query)

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -35,6 +35,11 @@ RECRUITEE_FILTER_FIELDS = {
 }
 RECRUITEE_REQUIREMENT_FIELDS = {"townhall", "league", "members"}
 MEMBER_FILTER_FIELDS = {"min", "max"}
+MATCHMAKING_SESSION_FIELDS = {
+    "player_league": "requirements.0",
+    "player_builderbase_trophies": "requirements.1",
+    "player_townhall": "requirements.2",
+}
 
 
 def _get_requested_limit(default_limit):
@@ -59,6 +64,34 @@ def _should_include_total():
     return query_bool(request, "includeTotal", default=False)
 
 
+def _get_matchmaking_base_query():
+    """Return a safe clan match query for the current session."""
+    player_name = session.get("player_name", None)
+    if not player_name or player_name == "Guest":
+        return {}
+
+    stats = {}
+    for session_key, query_key in MATCHMAKING_SESSION_FIELDS.items():
+        value = session.get(session_key)
+        if value is None:
+            return {}
+        stats[query_key] = _session_int(value, session_key)
+
+    return {query_key: {"$lte": value} for query_key, value in stats.items()}
+
+
+def _session_int(value, field_name):
+    if isinstance(value, bool):
+        raise RequestValidationError(f"{field_name} is invalid.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped.isdecimal():
+            return int(stripped)
+    raise RequestValidationError(f"{field_name} is invalid.")
+
+
 @recruitee_bp.get("/recruitee")
 @rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
@@ -72,18 +105,10 @@ def recruitee_get():
         return jsonify({"error": exc.message}), 400
 
     clan_collection = get_clan_collection()
-    player_name = session.get("player_name", None)
-
-    if not player_name or player_name == "Guest":
-        base_query = {}
-    else:
-        base_query = {
-            "requirements.0": {"$lte": session.get("player_league")},
-            "requirements.1": {
-                "$lte": session.get("player_builderbase_trophies")
-            },
-            "requirements.2": {"$lte": session.get("player_townhall")},
-        }
+    try:
+        base_query = _get_matchmaking_base_query()
+    except RequestValidationError as exc:
+        return jsonify({"error": exc.message}), 400
 
     data = list(
         clan_collection.find(base_query, {"_id": 0})

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, request, session
 
+from ..config import headers
+from ..services.maxtownhall import refresh
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
 from .validation import (
@@ -25,6 +27,8 @@ from .validation import (
 recruitee_bp = Blueprint("recruitee", __name__)
 
 MAX_LIMIT = 200
+MAX_CLAN_LEVEL = 99
+MAX_CLAN_POINTS = 400000
 RECRUITEE_PAYLOAD_FIELDS = {"clanTag", "filters"}
 RECRUITEE_FILTER_FIELDS = {
     "name",
@@ -274,9 +278,13 @@ def _validate_filter_payload(filters):
         requirements,
         "townhall",
         min_value=0,
-        max_value=25,
     )
     if townhall is not None:
+        max_townhall = refresh(headers)
+        if townhall > max_townhall:
+            raise RequestValidationError(
+                f"townhall must be at most {max_townhall}."
+            )
         normalized_requirements["townhall"] = townhall
     league = optional_int(requirements, "league", min_value=0, max_value=34)
     if league is not None:
@@ -292,10 +300,20 @@ def _validate_filter_payload(filters):
     if normalized_requirements:
         normalized["requirements"] = normalized_requirements
 
-    min_clan_level = optional_int(filters, "minClanLevel", min_value=0)
+    min_clan_level = optional_int(
+        filters,
+        "minClanLevel",
+        min_value=0,
+        max_value=MAX_CLAN_LEVEL,
+    )
     if min_clan_level is not None:
         normalized["minClanLevel"] = min_clan_level
-    clan_points = optional_int(filters, "clanPoints", min_value=0)
+    clan_points = optional_int(
+        filters,
+        "clanPoints",
+        min_value=0,
+        max_value=MAX_CLAN_POINTS,
+    )
     if clan_points is not None:
         normalized["clanPoints"] = clan_points
 

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -9,6 +9,7 @@ from ..services.recruiter_listing import (
 )
 from .validation import (
     RequestValidationError,
+    ensure_allowed_fields,
     get_json_object,
     optional_bool,
     optional_string,
@@ -23,6 +24,16 @@ RECRUITER_ACTION_RATE_LIMITS = {
     "new": 1,
     "update": 2,
 }
+MAX_BUILDER_BASE_TROPHIES = 10000
+NEW_LISTING_FIELDS = {
+    "status",
+    "requiredLeague",
+    "requiredBuilderLeague",
+    "requiredTownhall",
+    "description",
+}
+UPDATE_LISTING_FIELDS = NEW_LISTING_FIELDS | {"updateExpiry", "expiry"}
+REMOVE_LISTING_FIELDS = {"status"}
 
 
 @recruiter_bp.route("/recruiter", methods=["GET", "POST"])
@@ -106,7 +117,13 @@ def _validate_recruiter_payload(data):
 
     normalized = {"status": status}
     if status == "removeListing":
+        ensure_allowed_fields(data, REMOVE_LISTING_FIELDS, "recruiter")
         return normalized
+
+    allowed_fields = (
+        UPDATE_LISTING_FIELDS if status == "update" else NEW_LISTING_FIELDS
+    )
+    ensure_allowed_fields(data, allowed_fields, "recruiter")
 
     normalized["requiredLeague"] = required_int(
         data,
@@ -118,6 +135,7 @@ def _validate_recruiter_payload(data):
         data,
         "requiredBuilderLeague",
         min_value=0,
+        max_value=MAX_BUILDER_BASE_TROPHIES,
     )
     normalized["requiredTownhall"] = required_int(
         data,
@@ -136,10 +154,5 @@ def _validate_recruiter_payload(data):
         if update_expiry is None:
             raise RequestValidationError("updateExpiry is required.")
         normalized["updateExpiry"] = update_expiry
-        if not update_expiry:
-            expiry = optional_string(data, "expiry", max_length=128)
-            if not expiry:
-                raise RequestValidationError("expiry is required.")
-            normalized["expiry"] = expiry
 
     return normalized

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -2,6 +2,8 @@
 
 from flask import Blueprint, jsonify, request, session
 
+from ..config import headers
+from ..services.maxtownhall import refresh
 from ..services.rate_limiter import is_rate_limited
 from ..services.recruiter_listing import (
     get_recruiter_listing_page,
@@ -160,8 +162,12 @@ def _validate_recruiter_payload(data):
         data,
         "requiredTownhall",
         min_value=0,
-        max_value=25,
     )
+    max_townhall = refresh(headers)
+    if normalized["requiredTownhall"] > max_townhall:
+        raise RequestValidationError(
+            f"requiredTownhall must be at most {max_townhall}."
+        )
     normalized["description"] = optional_string(
         data,
         "description",

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -11,6 +11,7 @@ from .validation import (
     RequestValidationError,
     ensure_allowed_fields,
     get_json_object,
+    normalize_tag,
     optional_bool,
     optional_string,
     required_int,
@@ -39,8 +40,10 @@ REMOVE_LISTING_FIELDS = {"status"}
 @recruiter_bp.route("/recruiter", methods=["GET", "POST"])
 def recruit():
     """Return recruiter listing data or create, update, and remove listings."""
-    if not session.get("recruiter_status"):
-        return jsonify({"message": "Forbidden"}), 403
+    try:
+        session_data = _validate_recruiter_session()
+    except RequestValidationError as exc:
+        return jsonify({"message": exc.message}), 403
 
     if request.method == "GET":
         limited_response = _rate_limit_recruiter_get()
@@ -48,25 +51,41 @@ def recruit():
             return limited_response
 
         payload, status_code = get_recruiter_listing_page(
-            session.get("clan_tag")
+            session_data["clan_tag"]
         )
         return jsonify(payload), status_code
 
     try:
         data = _validate_recruiter_payload(get_json_object(request))
+        if data.get("status") == "new":
+            session_data["player_tag"] = _validated_session_tag(
+                "player_tag",
+            )
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    limited_response = _rate_limit_recruiter_action(data)
+    limited_response = _rate_limit_recruiter_action(data, session_data)
     if limited_response:
         return limited_response
 
     payload, status_code = handle_recruiter_listing_action(
-        session.get("clan_tag"),
-        session.get("player_tag"),
+        session_data["clan_tag"],
+        session_data.get("player_tag"),
         data,
     )
     return jsonify(payload), status_code
+
+
+def _validate_recruiter_session():
+    """Return normalized recruiter session identity data."""
+    if session.get("recruiter_status") is not True:
+        raise RequestValidationError("Forbidden")
+
+    return {"clan_tag": _validated_session_tag("clan_tag")}
+
+
+def _validated_session_tag(field_name):
+    return normalize_tag(session.get(field_name), field_name)
 
 
 def _rate_limit_recruiter_get():
@@ -86,14 +105,14 @@ def _rate_limit_recruiter_get():
     return response, 429
 
 
-def _rate_limit_recruiter_action(data):
+def _rate_limit_recruiter_action(data, session_data):
     """Return a 429 response when a listing mutation is being spammed."""
     action = data.get("status")
     limit = RECRUITER_ACTION_RATE_LIMITS.get(action)
     if limit is None:
         return None
 
-    clan_tag = session.get("clan_tag") or "unknown"
+    clan_tag = session_data["clan_tag"]
     limited, retry_after = is_rate_limited(
         f"recruiter_action:{action}:{clan_tag}",
         limit=limit,

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -73,11 +73,11 @@ def _hydrate_saved_clans(saved_clan_tags):
 @rate_limit("saved_clans_get", limit=30, window_seconds=60)
 def get_saved_clans():
     """Return the current user's saved clans and limits as JSON."""
-    user_collection = get_user_collection()
-    player_tag = session.get("player_tag")
-    if not player_tag:
+    player_tag = _validated_session_player_tag()
+    if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
+    user_collection = get_user_collection()
     user_doc = (
         user_collection.find_one(
             {"player_tag": player_tag},
@@ -105,11 +105,11 @@ def add_saved_clan(clan_tag):
     Args:
         clan_tag (str): The clan tag to save for the current user.
     """
-    user_collection = get_user_collection()
-    player_tag = session.get("player_tag")
-    if not player_tag:
+    player_tag = _validated_session_player_tag()
+    if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
+    user_collection = get_user_collection()
     try:
         normalized_tag = normalize_tag(clan_tag, "clan_tag")
     except RequestValidationError as exc:
@@ -173,11 +173,11 @@ def delete_saved_clan(clan_tag):
         clan_tag (str): The clan tag to remove from the current user's saved
             clans.
     """
-    user_collection = get_user_collection()
-    player_tag = session.get("player_tag")
-    if not player_tag:
+    player_tag = _validated_session_player_tag()
+    if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
+    user_collection = get_user_collection()
     try:
         normalized_tag = normalize_tag(clan_tag, "clan_tag")
     except RequestValidationError as exc:
@@ -191,3 +191,10 @@ def delete_saved_clan(clan_tag):
     return jsonify(
         {"message": "Saved clan removed.", "clan_tag": normalized_tag}
     ), 200
+
+
+def _validated_session_player_tag():
+    try:
+        return normalize_tag(session.get("player_tag"), "player_tag")
+    except RequestValidationError:
+        return None

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -17,6 +17,8 @@ from .validation import (
 
 search_clans_bp = Blueprint("search_clans", __name__)
 
+MAX_CLAN_LEVEL = 99
+MAX_CLAN_POINTS = 400000
 SEARCH_FILTER_FIELDS = {
     "name",
     "warFrequency",
@@ -125,12 +127,14 @@ def _validate_search_filters(filters):
         normalized,
         "minClanPoints",
         min_value=0,
+        max_value=MAX_CLAN_POINTS,
     )
     _copy_optional_int(
         filters,
         normalized,
         "minClanLevel",
         min_value=1,
+        max_value=MAX_CLAN_LEVEL,
     )
     _copy_optional_int(
         filters,

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -6,21 +6,17 @@ from ..api.recruitee_api import Recruitee
 from ..config import headers
 from .rate_limit import rate_limit
 from .validation import (
+    CLASH_WAR_FREQUENCIES,
     RequestValidationError,
+    ensure_allowed_fields,
     get_json_object,
+    optional_enum,
     optional_int,
     optional_string,
 )
 
 search_clans_bp = Blueprint("search_clans", __name__)
 
-WAR_FREQUENCIES = {
-    "always",
-    "moreThanOncePerWeek",
-    "oncePerWeek",
-    "lessThanOncePerWeek",
-    "never",
-}
 SEARCH_FILTER_FIELDS = {
     "name",
     "warFrequency",
@@ -80,17 +76,19 @@ def search_clans():
 
 def _validate_search_filters(filters):
     """Return normalized Clash clan search filters and pagination cursor."""
-    _reject_unknown_fields(filters)
+    ensure_allowed_fields(filters, ALLOWED_SEARCH_FIELDS, "search")
 
     normalized = {}
     name = optional_string(filters, "name", max_length=120)
     if name:
         normalized["name"] = name
 
-    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    war_frequency = optional_enum(
+        filters,
+        "warFrequency",
+        CLASH_WAR_FREQUENCIES,
+    )
     if war_frequency:
-        if war_frequency not in WAR_FREQUENCIES:
-            raise RequestValidationError("warFrequency is invalid.")
         normalized["warFrequency"] = war_frequency
 
     _copy_optional_int(
@@ -154,14 +152,6 @@ def _validate_search_filters(filters):
         )
 
     return normalized, after
-
-
-def _reject_unknown_fields(filters):
-    unknown_fields = sorted(set(filters) - ALLOWED_SEARCH_FIELDS)
-    if unknown_fields:
-        raise RequestValidationError(
-            f"Unsupported search field: {unknown_fields[0]}."
-        )
 
 
 def _copy_optional_int(filters, normalized, field_name, **bounds):

--- a/routes/search_clans_route.py
+++ b/routes/search_clans_route.py
@@ -5,9 +5,35 @@ from flask import Blueprint, jsonify, request, session
 from ..api.recruitee_api import Recruitee
 from ..config import headers
 from .rate_limit import rate_limit
-from .validation import RequestValidationError, get_json_object
+from .validation import (
+    RequestValidationError,
+    get_json_object,
+    optional_int,
+    optional_string,
+)
 
 search_clans_bp = Blueprint("search_clans", __name__)
+
+WAR_FREQUENCIES = {
+    "always",
+    "moreThanOncePerWeek",
+    "oncePerWeek",
+    "lessThanOncePerWeek",
+    "never",
+}
+SEARCH_FILTER_FIELDS = {
+    "name",
+    "warFrequency",
+    "locationId",
+    "minMembers",
+    "maxMembers",
+    "minClanPoints",
+    "minClanLevel",
+    "labelIds",
+    "limit",
+}
+PAGINATION_FIELDS = {"after"}
+ALLOWED_SEARCH_FIELDS = SEARCH_FILTER_FIELDS | PAGINATION_FIELDS
 
 
 @search_clans_bp.post("/search_clans")
@@ -15,7 +41,7 @@ search_clans_bp = Blueprint("search_clans", __name__)
 def search_clans():
     """Search clans using provided filters and return matching results."""
     try:
-        filters = _validate_search_filters(get_json_object(request))
+        filters, after = _validate_search_filters(get_json_object(request))
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
@@ -23,7 +49,7 @@ def search_clans():
         session.get("player_tag"),
         headers,
     )
-    clans = user.searchClan(filters, filters.get("after"))
+    clans = user.searchClan(filters, after)
 
     error = clans.get("error")
     if error:
@@ -53,18 +79,102 @@ def search_clans():
 
 
 def _validate_search_filters(filters):
-    """Return a shallow-normalized Clash clan search filter dict."""
+    """Return normalized Clash clan search filters and pagination cursor."""
+    _reject_unknown_fields(filters)
+
     normalized = {}
-    for key, value in filters.items():
-        if value is None:
-            continue
-        if isinstance(value, bool) or not isinstance(value, (str, int)):
-            raise RequestValidationError(
-                f"{key} must be a string or integer."
-            )
-        if isinstance(value, str):
-            value = value.strip()
-            if not value:
-                continue
-        normalized[key] = value
-    return normalized
+    name = optional_string(filters, "name", max_length=120)
+    if name:
+        normalized["name"] = name
+
+    war_frequency = optional_string(filters, "warFrequency", max_length=40)
+    if war_frequency:
+        if war_frequency not in WAR_FREQUENCIES:
+            raise RequestValidationError("warFrequency is invalid.")
+        normalized["warFrequency"] = war_frequency
+
+    _copy_optional_int(
+        filters,
+        normalized,
+        "locationId",
+        min_value=1,
+    )
+    min_members = _copy_optional_int(
+        filters,
+        normalized,
+        "minMembers",
+        min_value=1,
+        max_value=50,
+    )
+    max_members = _copy_optional_int(
+        filters,
+        normalized,
+        "maxMembers",
+        min_value=1,
+        max_value=50,
+    )
+    if (
+        min_members is not None
+        and max_members is not None
+        and min_members > max_members
+    ):
+        raise RequestValidationError(
+            "minMembers must be less than or equal to maxMembers."
+        )
+
+    _copy_optional_int(
+        filters,
+        normalized,
+        "minClanPoints",
+        min_value=0,
+    )
+    _copy_optional_int(
+        filters,
+        normalized,
+        "minClanLevel",
+        min_value=1,
+    )
+    _copy_optional_int(
+        filters,
+        normalized,
+        "limit",
+        min_value=1,
+        max_value=100,
+    )
+
+    label_ids = optional_string(filters, "labelIds", max_length=240)
+    if label_ids:
+        normalized["labelIds"] = _validate_label_ids(label_ids)
+
+    after = optional_string(filters, "after", max_length=512)
+
+    if not any(key in normalized for key in SEARCH_FILTER_FIELDS - {"limit"}):
+        raise RequestValidationError(
+            "Add at least one random clan filter before searching."
+        )
+
+    return normalized, after
+
+
+def _reject_unknown_fields(filters):
+    unknown_fields = sorted(set(filters) - ALLOWED_SEARCH_FIELDS)
+    if unknown_fields:
+        raise RequestValidationError(
+            f"Unsupported search field: {unknown_fields[0]}."
+        )
+
+
+def _copy_optional_int(filters, normalized, field_name, **bounds):
+    value = optional_int(filters, field_name, **bounds)
+    if value is not None:
+        normalized[field_name] = value
+    return value
+
+
+def _validate_label_ids(label_ids):
+    ids = [label_id.strip() for label_id in label_ids.split(",")]
+    if not all(label_id.isdecimal() for label_id in ids):
+        raise RequestValidationError(
+            "labelIds must be a comma-separated list of integers."
+        )
+    return ",".join(ids)

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -8,6 +8,7 @@ from ..api.clash_api import API
 from ..config import headers
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
+from .validation import RequestValidationError, normalize_tag
 
 session_state_bp = Blueprint("session_state", __name__)
 
@@ -21,7 +22,7 @@ def session_state():
     has_active_listing = False
     townhall = None
     townhallWeaponLevel = None
-    clan_tag = session.get("clan_tag")
+    clan_tag = _normalized_session_tag("clan_tag")
 
     if username != "Guest":
         townhall = session.get("player_townhall")
@@ -48,9 +49,9 @@ def session_state():
 @rate_limit("session_state_user_info", limit=10, window_seconds=60)
 def session_state_user_info():
     """Return extended player info for the current session when available."""
-    player_tag = session.get("player_tag", "Guest")
+    player_tag = _normalized_session_tag("player_tag")
 
-    if player_tag == "Guest":
+    if player_tag is None:
         return jsonify({})
 
     user = API(player_tag, None, headers)
@@ -65,3 +66,15 @@ def session_state_user_info():
     )
 
     return jsonify(stats or {})
+
+
+def _normalized_session_tag(field_name):
+    value = session.get(field_name)
+    if value is None or value == "Guest":
+        return None
+
+    try:
+        return normalize_tag(value, field_name)
+    except RequestValidationError:
+        session.pop(field_name, None)
+        return None

--- a/routes/validation.py
+++ b/routes/validation.py
@@ -6,6 +6,13 @@ from typing import Any
 from flask import Request
 
 TAG_PATTERN = re.compile(r"^[A-Z0-9]+$")
+CLASH_WAR_FREQUENCIES = {
+    "always",
+    "moreThanOncePerWeek",
+    "oncePerWeek",
+    "lessThanOncePerWeek",
+    "never",
+}
 
 
 class RequestValidationError(ValueError):
@@ -51,6 +58,19 @@ def ensure_object(value: Any, field_name: str) -> dict[str, Any]:
     return value
 
 
+def ensure_allowed_fields(
+    payload: dict[str, Any],
+    allowed_fields: set[str],
+    object_name: str,
+) -> None:
+    """Raise when a request object contains unsupported fields."""
+    unknown_fields = sorted(set(payload) - allowed_fields)
+    if unknown_fields:
+        raise RequestValidationError(
+            f"Unsupported {object_name} field: {unknown_fields[0]}."
+        )
+
+
 def optional_string(
     payload: dict[str, Any],
     field_name: str,
@@ -79,6 +99,20 @@ def optional_bool(payload: dict[str, Any], field_name: str) -> bool | None:
         return None
     if not isinstance(value, bool):
         raise RequestValidationError(f"{field_name} must be a boolean.")
+    return value
+
+
+def optional_enum(
+    payload: dict[str, Any],
+    field_name: str,
+    allowed_values: set[str],
+) -> str | None:
+    """Return an optional string enum field."""
+    value = optional_string(payload, field_name, max_length=40)
+    if not value:
+        return None
+    if value not in allowed_values:
+        raise RequestValidationError(f"{field_name} is invalid.")
     return value
 
 

--- a/routes/validation.py
+++ b/routes/validation.py
@@ -90,6 +90,21 @@ def ensure_allowed_fields(
         )
 
 
+def ensure_exactly_one_field(
+    payload: dict[str, Any],
+    field_names: set[str],
+    object_name: str,
+) -> str:
+    """Return the single present field from a one-of request contract."""
+    present_fields = sorted(field_names & set(payload))
+    if len(present_fields) != 1:
+        expected = " or ".join(sorted(field_names))
+        raise RequestValidationError(
+            f"{object_name} must include exactly one of {expected}."
+        )
+    return present_fields[0]
+
+
 def optional_string(
     payload: dict[str, Any],
     field_name: str,
@@ -109,6 +124,19 @@ def optional_string(
             f"{field_name} must be {max_length} characters or fewer."
         )
     return normalized
+
+
+def required_string(
+    payload: dict[str, Any],
+    field_name: str,
+    *,
+    max_length: int | None = None,
+) -> str:
+    """Return a required trimmed string field."""
+    value = optional_string(payload, field_name, max_length=max_length)
+    if not value:
+        raise RequestValidationError(f"{field_name} is required.")
+    return value
 
 
 def optional_bool(payload: dict[str, Any], field_name: str) -> bool | None:

--- a/routes/validation.py
+++ b/routes/validation.py
@@ -49,6 +49,25 @@ def query_int(
     return parsed
 
 
+def query_bool(
+    request: Request,
+    field_name: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Return a validated boolean query parameter."""
+    value = request.args.get(field_name)
+    if value is None:
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true"}:
+        return True
+    if normalized in {"0", "false"}:
+        return False
+    raise RequestValidationError(f"{field_name} must be true or false.")
+
+
 def ensure_object(value: Any, field_name: str) -> dict[str, Any]:
     """Return a dict value or raise a validation error for bad shape."""
     if value is None:

--- a/services/recruiter_listing.py
+++ b/services/recruiter_listing.py
@@ -123,7 +123,8 @@ def update_recruiter_listing(
         update_doc["expires"] = expiry
         status = expiry
     else:
-        status = data.get("expiry")
+        existing = clan_collection.find_one(_listing_query(clan_tag)) or {}
+        status = existing.get("expires")
 
     clan_collection.update_one(
         _listing_query(clan_tag),

--- a/tests/routes/test_home_login_route.py
+++ b/tests/routes/test_home_login_route.py
@@ -150,6 +150,41 @@ def test_home_login_returns_400_for_invalid_player_tag(client, monkeypatch):
     assert DummyAPI.instances == []
 
 
+def test_home_login_returns_400_for_missing_api_token(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post("/", json={"playerTag": "PLAYER123"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "apiToken is required."}
+    assert DummyAPI.instances == []
+
+
+def test_home_login_returns_400_for_unknown_field(client, monkeypatch):
+    import ClashRecruit.routes.home_route as home_route
+
+    DummyAPI.instances = []
+    monkeypatch.setattr(home_route, "API", DummyAPI)
+
+    response = client.post(
+        "/",
+        json={
+            "playerTag": "PLAYER123",
+            "apiToken": "token-123",
+            "extra": "nope",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported login field: extra."
+    }
+    assert DummyAPI.instances == []
+
+
 def test_home_login_rate_limits_repeated_attempts(client, monkeypatch):
     import ClashRecruit.routes.home_route as home_route
 

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -445,6 +445,52 @@ def test_imported_clans_post_returns_400_for_invalid_numeric_filter(
     }
 
 
+def test_imported_clans_post_returns_400_for_huge_clan_points(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"clanPoints": 400001}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "clanPoints must be at most 400000."
+    }
+
+
+def test_imported_clans_post_returns_400_for_huge_min_clan_level(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"minClanLevel": 100}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "minClanLevel must be at most 99."
+    }
+
+
 def test_imported_clans_post_returns_400_for_invalid_limit(
     client,
     monkeypatch,

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -192,6 +192,78 @@ def test_imported_clans_post_returns_404_for_missing_tag(
     assert response.get_json() == {"error": "Imported clan not found"}
 
 
+def test_imported_clans_post_returns_400_for_empty_payload(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post("/imported_clans", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": (
+            "imported clans payload must include exactly one of "
+            "clanTag or filters."
+        )
+    }
+
+
+def test_imported_clans_post_returns_400_for_ambiguous_payload(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"clanTag": "TEST123", "filters": {}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": (
+            "imported clans payload must include exactly one of "
+            "clanTag or filters."
+        )
+    }
+
+
+def test_imported_clans_post_returns_400_for_clan_tag_alias(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"clan_tag": "TEST123"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported imported clans field: clan_tag."
+    }
+
+
 def test_imported_clans_post_returns_400_for_bad_filter_shape(
     client,
     monkeypatch,

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -133,6 +133,42 @@ def test_imported_clans_post_returns_clan_by_tag(
     assert lookup_calls == ["TEST123"]
 
 
+def test_imported_clans_post_returns_400_for_empty_clan_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post("/imported_clans", json={"clanTag": ""})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "clanTag is required."}
+
+
+def test_imported_clans_post_returns_400_for_bad_clan_tag_type(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post("/imported_clans", json={"clanTag": []})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "clanTag must be a string."}
+
+
 def test_imported_clans_post_returns_404_for_missing_tag(
     client,
     monkeypatch,
@@ -150,7 +186,7 @@ def test_imported_clans_post_returns_404_for_missing_tag(
         lambda clan_tag: None,
     )
 
-    response = client.post("/imported_clans", json={"clan_tag": "MISSING"})
+    response = client.post("/imported_clans", json={"clanTag": "MISSING"})
 
     assert response.status_code == 404
     assert response.get_json() == {"error": "Imported clan not found"}

--- a/tests/routes/test_imported_clans_route.py
+++ b/tests/routes/test_imported_clans_route.py
@@ -215,6 +215,134 @@ def test_imported_clans_post_returns_400_for_bad_filter_shape(
     }
 
 
+def test_imported_clans_post_returns_400_for_unknown_filter_field(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"unexpected": "value"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported filter field: unexpected."
+    }
+
+
+def test_imported_clans_post_returns_400_for_unknown_nested_filter_field(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"requirements": {"members": {"minimum": 30}}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported members field: minimum."
+    }
+
+
+def test_imported_clans_post_returns_400_for_invalid_war_frequency(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: object(),
+    )
+
+    response = client.post(
+        "/imported_clans",
+        json={"filters": {"warFrequency": "sometimes"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "warFrequency is invalid."}
+
+
+def test_imported_clans_post_allows_empty_filters_as_browse(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.imported_clans_route as imported_clans_route
+
+    class DummyCursor:
+        def __init__(self, docs):
+            self.docs = docs
+            self.sort_fields = None
+            self.skip_count = None
+            self.limit_count = None
+
+        def sort(self, fields):
+            self.sort_fields = fields
+            return self
+
+        def skip(self, count):
+            self.skip_count = count
+            return self
+
+        def limit(self, count):
+            self.limit_count = count
+            return self
+
+        def __iter__(self):
+            return iter(self.docs)
+
+    class DummyClanCollection:
+        def __init__(self):
+            self.cursor = DummyCursor(
+                [{"clan_tag": "ONE", "name": "First"}]
+            )
+            self.count_query = None
+            self.find_query = None
+
+        def count_documents(self, query):
+            self.count_query = query
+            return 1
+
+        def find(self, query, projection):
+            self.find_query = query
+            return self.cursor
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        imported_clans_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/imported_clans", json={"filters": {}})
+
+    assert response.status_code == 200
+    assert response.get_json()["items"] == [
+        {"clan_tag": "ONE", "name": "First"}
+    ]
+    assert collection.count_query == {"source": "clash_api_import"}
+    assert collection.find_query == {"source": "clash_api_import"}
+
+
 def test_imported_clans_post_returns_400_for_invalid_numeric_filter(
     client,
     monkeypatch,

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -135,6 +135,91 @@ def test_recruitee_get_returns_guest_default_raw_list(
     assert collection.cursor.limit_count == 10
 
 
+def test_recruitee_get_accepts_true_include_total(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    )
+
+    set_session(player_name="Guest")
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?includeTotal=true")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "items": [{"clan_tag": "TEST1", "name": "test_clan_1"}],
+        "total": 1,
+        "limit": 10,
+        "offset": 0,
+    }
+    assert collection.find_query == {}
+    assert collection.count_query == {}
+
+
+def test_recruitee_get_accepts_false_include_total(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    )
+
+    set_session(player_name="Guest")
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?includeTotal=false")
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"clan_tag": "TEST1", "name": "test_clan_1"}
+    ]
+    assert collection.find_query == {}
+    assert collection.count_query is None
+
+
+def test_recruitee_get_returns_400_for_invalid_include_total(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+
+    set_session(player_name="Guest")
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?includeTotal=maybe")
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "includeTotal must be true or false."
+    }
+    assert collection.find_query is None
+    assert collection.count_query is None
+
+
 def test_recruitee_post_filters_and_paginates_with_total(
     client,
     monkeypatch,

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -345,6 +345,7 @@ def test_recruitee_post_filters_and_paginates_with_total(
         "get_clan_collection",
         lambda: collection,
     )
+    monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
 
     response = client.post(
         "/recruitee?includeTotal=1&limit=2&offset=0",
@@ -747,6 +748,80 @@ def test_recruitee_post_returns_400_for_unknown_nested_filter_field(
     assert collection.find_query is None
 
 
+def test_recruitee_post_rejects_townhall_above_current_max(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"requirements": {"townhall": 18}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "townhall must be at most 17."}
+    assert collection.find_query is None
+
+
+def test_recruitee_post_rejects_clan_points_above_max(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"clanPoints": 400001}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "clanPoints must be at most 400000."
+    }
+    assert collection.find_query is None
+
+
+def test_recruitee_post_rejects_min_clan_level_above_max(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"minClanLevel": 100}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "minClanLevel must be at most 99."
+    }
+    assert collection.find_query is None
+
+
 def test_recruitee_post_returns_400_for_invalid_war_frequency(
     client,
     monkeypatch,
@@ -806,6 +881,7 @@ def test_recruitee_post_normalizes_numeric_string_filters(
         "get_clan_collection",
         lambda: collection,
     )
+    monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
 
     response = client.post(
         "/recruitee",

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -416,6 +416,103 @@ def test_recruitee_post_returns_400_for_bad_nested_filter_shape(
     assert collection.find_query is None
 
 
+def test_recruitee_post_returns_400_for_unknown_filter_field(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"unexpected": "value"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported filter field: unexpected."
+    }
+    assert collection.find_query is None
+
+
+def test_recruitee_post_returns_400_for_unknown_nested_filter_field(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"requirements": {"members": {"minimum": 30}}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported members field: minimum."
+    }
+    assert collection.find_query is None
+
+
+def test_recruitee_post_returns_400_for_invalid_war_frequency(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"warFrequency": "sometimes"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "warFrequency is invalid."}
+    assert collection.find_query is None
+
+
+def test_recruitee_post_allows_empty_filters_as_browse(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST123", "name": "test_clan"}]
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"filters": {}})
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"clan_tag": "TEST123", "name": "test_clan"}
+    ]
+    assert collection.find_query == {}
+
+
 def test_recruitee_post_normalizes_numeric_string_filters(
     client,
     monkeypatch,

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -101,6 +101,96 @@ def test_recruitee_get_filters_logged_in_player_with_total(
     assert collection.cursor.limit_count == 1
 
 
+def test_recruitee_get_falls_back_to_guest_query_for_incomplete_stats(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    )
+
+    set_session(
+        player_name="test_player",
+        player_league=5,
+        player_townhall=13,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee")
+
+    assert response.status_code == 200
+    assert response.get_json() == [
+        {"clan_tag": "TEST1", "name": "test_clan_1"}
+    ]
+    assert collection.find_query == {}
+
+
+def test_recruitee_get_normalizes_string_matchmaking_stats(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+
+    set_session(
+        player_name="test_player",
+        player_league="5",
+        player_builderbase_trophies="2200",
+        player_townhall="13",
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee")
+
+    assert response.status_code == 200
+    assert collection.find_query == {
+        "requirements.0": {"$lte": 5},
+        "requirements.1": {"$lte": 2200},
+        "requirements.2": {"$lte": 13},
+    }
+
+
+def test_recruitee_get_returns_400_for_malformed_matchmaking_stat(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+
+    set_session(
+        player_name="test_player",
+        player_league="not-a-league",
+        player_builderbase_trophies=2200,
+        player_townhall=13,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "player_league is invalid."}
+    assert collection.find_query is None
+
+
 def test_recruitee_get_returns_guest_default_raw_list(
     client,
     monkeypatch,

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -544,6 +544,84 @@ def test_recruitee_post_returns_404_for_missing_clan_tag(
     assert collection.find_one_projection == {"_id": 0}
 
 
+def test_recruitee_post_returns_400_for_empty_payload(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": (
+            "recruitee payload must include exactly one of "
+            "clanTag or filters."
+        )
+    }
+    assert collection.find_query is None
+    assert collection.find_one_query is None
+
+
+def test_recruitee_post_returns_400_for_ambiguous_payload(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"clanTag": "TEST123", "filters": {}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": (
+            "recruitee payload must include exactly one of "
+            "clanTag or filters."
+        )
+    }
+    assert collection.find_query is None
+    assert collection.find_one_query is None
+
+
+def test_recruitee_post_returns_400_for_clan_tag_alias(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"clan_tag": "TEST123"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported recruitee field: clan_tag."
+    }
+    assert collection.find_query is None
+    assert collection.find_one_query is None
+
+
 def test_recruitee_post_returns_400_for_list_payload(
     client,
     monkeypatch,

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -229,6 +229,48 @@ def test_recruitee_post_returns_clan_by_tag(
     assert collection.find_query is None
 
 
+def test_recruitee_post_returns_400_for_empty_clan_tag(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"clanTag": ""})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "clanTag is required."}
+    assert collection.find_query is None
+    assert collection.find_one_query is None
+
+
+def test_recruitee_post_returns_400_for_bad_clan_tag_type(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.post("/recruitee", json={"clanTag": []})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "clanTag must be a string."}
+    assert collection.find_query is None
+    assert collection.find_one_query is None
+
+
 def test_recruitee_post_filters_by_location_name_without_location_id(
     client,
     monkeypatch,

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -63,9 +63,11 @@ class DummyRecruiter:
 
 
 def setup_recruiter_route(monkeypatch, collection):
+    import ClashRecruit.routes.recruiter_route as recruiter_route
     import ClashRecruit.services.recruiter_listing as recruiter_listing
 
     DummyRecruiter.instances = []
+    monkeypatch.setattr(recruiter_route, "refresh", lambda headers: 17)
     monkeypatch.setattr(recruiter_listing, "Recruiter", DummyRecruiter)
     monkeypatch.setattr(
         recruiter_listing,
@@ -536,6 +538,32 @@ def test_recruiter_post_returns_400_for_huge_builder_league(
     assert response.status_code == 400
     assert response.get_json() == {
         "error": "requiredBuilderLeague must be at most 10000."
+    }
+    assert collection.inserted_doc is None
+
+
+def test_recruiter_post_returns_400_for_townhall_above_current_max(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 2600,
+            "requiredTownhall": 18,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "requiredTownhall must be at most 17."
     }
     assert collection.inserted_doc is None
 

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -78,6 +78,41 @@ def test_recruiter_get_forbidden_without_recruiter_status(client):
     assert response.get_json() == {"message": "Forbidden"}
 
 
+def test_recruiter_get_forbidden_without_clan_tag(client, set_session):
+    set_session(recruiter_status=True)
+
+    response = client.get("/recruiter")
+
+    assert response.status_code == 403
+    assert response.get_json() == {"message": "clan_tag must be a string."}
+
+
+def test_recruiter_get_forbidden_for_malformed_clan_tag(
+    client,
+    set_session,
+):
+    set_session(recruiter_status=True, clan_tag="bad-tag!")
+
+    response = client.get("/recruiter")
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "message": "clan_tag must contain only letters and numbers."
+    }
+
+
+def test_recruiter_get_forbidden_for_truthy_recruiter_status(
+    client,
+    set_session,
+):
+    set_session(recruiter_status="true", clan_tag="TEST123")
+
+    response = client.get("/recruiter")
+
+    assert response.status_code == 403
+    assert response.get_json() == {"message": "Forbidden"}
+
+
 def test_recruiter_get_returns_existing_listing(
     client,
     monkeypatch,
@@ -181,6 +216,31 @@ def test_recruiter_post_creates_new_listing(
     )
     assert isinstance(collection.inserted_doc["last_updated"], datetime)
     assert isinstance(collection.inserted_doc["expires"], datetime)
+
+
+def test_recruiter_post_create_returns_400_without_player_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 2400,
+            "requiredTownhall": 13,
+            "description": "new_description",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "player_tag must be a string."}
+    assert collection.inserted_doc is None
 
 
 def test_recruiter_post_updates_listing_and_refreshes_expiry(

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -219,12 +219,17 @@ def test_recruiter_post_updates_listing_and_refreshes_expiry(
     assert isinstance(set_doc["expires"], datetime)
 
 
-def test_recruiter_post_updates_listing_and_preserves_provided_expiry(
+def test_recruiter_post_updates_listing_and_preserves_existing_expiry(
     client,
     monkeypatch,
     set_session,
 ):
-    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    collection = DummyClanCollection(
+        existing={
+            "requirements": [1, 2, 3],
+            "expires": "existing_expiry",
+        },
+    )
     setup_recruiter_route(monkeypatch, collection)
     set_session(recruiter_status=True, clan_tag="TEST123")
 
@@ -237,7 +242,7 @@ def test_recruiter_post_updates_listing_and_preserves_provided_expiry(
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": False,
-            "expiry": "provided_expiry",
+            "expiry": "client_controlled_expiry",
         },
     )
     update_query, update_doc = collection.update_call
@@ -245,7 +250,7 @@ def test_recruiter_post_updates_listing_and_preserves_provided_expiry(
 
     assert response.status_code == 200
     assert response.get_json() == {
-        "status": "provided_expiry",
+        "status": "existing_expiry",
         "message": "Listing updated successfully.",
     }
     assert update_query == {
@@ -382,6 +387,81 @@ def test_recruiter_post_returns_400_for_bad_requirement_type(
     assert response.status_code == 400
     assert response.get_json() == {
         "error": "requiredLeague must be an integer."
+    }
+    assert collection.inserted_doc is None
+
+
+def test_recruiter_post_returns_400_for_unknown_new_field(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 2400,
+            "requiredTownhall": 13,
+            "description": "new_description",
+            "expiry": "not_allowed_for_new",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported recruiter field: expiry."
+    }
+    assert collection.inserted_doc is None
+
+
+def test_recruiter_post_returns_400_for_unknown_remove_field(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={"status": "removeListing", "requiredLeague": 5},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Unsupported recruiter field: requiredLeague."
+    }
+    assert collection.delete_query is None
+
+
+def test_recruiter_post_returns_400_for_huge_builder_league(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 5,
+            "requiredBuilderLeague": 999999,
+            "requiredTownhall": 13,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "requiredBuilderLeague must be at most 10000."
     }
     assert collection.inserted_doc is None
 

--- a/tests/routes/test_saved_clans_authorized_route.py
+++ b/tests/routes/test_saved_clans_authorized_route.py
@@ -67,6 +67,45 @@ def test_saved_clans_get_hydrates_available_and_missing_listings(
     }
 
 
+def test_saved_clans_get_normalizes_session_player_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    class DummyUserCollection:
+        def find_one(self, query, projection):
+            assert query == {"player_tag": "PLAYER123"}
+            assert projection == {"_id": 0, "saved_clans": 1}
+            return {"saved_clans": []}
+
+    class DummyClanCollection:
+        def find(self, query, projection):
+            return []
+
+    set_session(player_tag="#player123")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        lambda: DummyUserCollection(),
+    )
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_clan_collection",
+        lambda: DummyClanCollection(),
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "saved_clans": [],
+        "count": 0,
+        "max_saved_clans": 10,
+    }
+
+
 def test_saved_clans_get_returns_empty_saved_list(
     client,
     monkeypatch,

--- a/tests/routes/test_saved_clans_unauthorized_route.py
+++ b/tests/routes/test_saved_clans_unauthorized_route.py
@@ -59,3 +59,72 @@ def test_saved_clans_delete_unauthorized_returns_401(client, monkeypatch):
 
     assert response.status_code == 401
     assert response.get_json() == {"message": "Unauthorized"}
+
+
+def test_saved_clans_get_malformed_session_player_tag_returns_401(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    def fail_get_user_collection():
+        raise AssertionError("user collection should not be used")
+
+    set_session(player_tag="bad-tag!")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        fail_get_user_collection,
+    )
+
+    response = client.get("/saved-clans")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}
+
+
+def test_saved_clans_post_malformed_session_player_tag_returns_401(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    def fail_get_user_collection():
+        raise AssertionError("user collection should not be used")
+
+    set_session(player_tag="bad-tag!")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        fail_get_user_collection,
+    )
+
+    response = client.post("/saved-clans/ABC123")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}
+
+
+def test_saved_clans_delete_malformed_session_player_tag_returns_401(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.saved_clans_route as saved_clans_route
+
+    def fail_get_user_collection():
+        raise AssertionError("user collection should not be used")
+
+    set_session(player_tag="bad-tag!")
+    monkeypatch.setattr(
+        saved_clans_route,
+        "get_user_collection",
+        fail_get_user_collection,
+    )
+
+    response = client.delete("/saved-clans/ABC123")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"message": "Unauthorized"}

--- a/tests/routes/test_search_clans_route.py
+++ b/tests/routes/test_search_clans_route.py
@@ -49,12 +49,12 @@ def test_search_clans_returns_success_payload(
     }
     assert DummyRecruitee.instances[0].player_tag == "PLAYER123"
     assert DummyRecruitee.instances[0].search_call == (
-        {"name": "test", "after": "cursor-0"},
+        {"name": "test"},
         "cursor-0",
     )
 
 
-def test_search_clans_maps_empty_filter_error(client, monkeypatch):
+def test_search_clans_returns_400_for_empty_filter(client, monkeypatch):
     setup_search_route(
         monkeypatch,
         {
@@ -72,10 +72,9 @@ def test_search_clans_maps_empty_filter_error(client, monkeypatch):
 
     assert response.status_code == 400
     assert response.get_json() == {
-        "error": "Add at least one random clan filter before searching.",
-        "reason": "badRequest",
-        "message": "At least one filtering parameter must exist",
+        "error": "Add at least one random clan filter before searching."
     }
+    assert DummyRecruitee.instances == []
 
 
 def test_search_clans_maps_generic_api_error(client, monkeypatch):
@@ -125,7 +124,117 @@ def test_search_clans_returns_400_for_nested_filter_value(client, monkeypatch):
     response = client.post("/search_clans", json={"name": {"bad": "shape"}})
 
     assert response.status_code == 400
+    assert response.get_json() == {"error": "name must be a string."}
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_unknown_field(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={"name": "test", "typoField": "ignored-before"},
+    )
+
+    assert response.status_code == 400
     assert response.get_json() == {
-        "error": "name must be a string or integer."
+        "error": "Unsupported search field: typoField."
     }
     assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_negative_number(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={"name": "test", "minMembers": -1},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "minMembers must be at least 1."
+    }
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_invalid_war_frequency(
+    client,
+    monkeypatch,
+):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={"warFrequency": "sometimes"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "warFrequency is invalid."}
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_after_without_filter(
+    client,
+    monkeypatch,
+):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post("/search_clans", json={"after": "cursor-0"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Add at least one random clan filter before searching."
+    }
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_validates_supported_filters(client, monkeypatch):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={
+            "name": " test ",
+            "warFrequency": "always",
+            "locationId": "32000007",
+            "minMembers": "5",
+            "maxMembers": 45,
+            "minClanPoints": "1000",
+            "minClanLevel": "3",
+            "labelIds": " 56000000,56000001 ",
+            "limit": "20",
+            "after": "cursor-0",
+        },
+    )
+
+    assert response.status_code == 200
+    assert DummyRecruitee.instances[0].search_call == (
+        {
+            "name": "test",
+            "warFrequency": "always",
+            "locationId": 32000007,
+            "minMembers": 5,
+            "maxMembers": 45,
+            "minClanPoints": 1000,
+            "minClanLevel": 3,
+            "labelIds": "56000000,56000001",
+            "limit": 20,
+        },
+        "cursor-0",
+    )

--- a/tests/routes/test_search_clans_route.py
+++ b/tests/routes/test_search_clans_route.py
@@ -164,6 +164,48 @@ def test_search_clans_returns_400_for_negative_number(client, monkeypatch):
     assert DummyRecruitee.instances == []
 
 
+def test_search_clans_returns_400_for_huge_min_clan_points(
+    client,
+    monkeypatch,
+):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={"minClanPoints": 400001},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "minClanPoints must be at most 400000."
+    }
+    assert DummyRecruitee.instances == []
+
+
+def test_search_clans_returns_400_for_huge_min_clan_level(
+    client,
+    monkeypatch,
+):
+    setup_search_route(
+        monkeypatch,
+        {"items": [], "after": None, "error": None},
+    )
+
+    response = client.post(
+        "/search_clans",
+        json={"minClanLevel": 100},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "minClanLevel must be at most 99."
+    }
+    assert DummyRecruitee.instances == []
+
+
 def test_search_clans_returns_400_for_invalid_war_frequency(
     client,
     monkeypatch,

--- a/tests/routes/test_session_state_route.py
+++ b/tests/routes/test_session_state_route.py
@@ -99,6 +99,61 @@ def test_session_state_returns_logged_in_player_and_active_listing(
     assert collection.find_one_projection == {"_id": 1}
 
 
+def test_session_state_normalizes_session_clan_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    collection = DummyClanCollection(listing={"_id": "listing-id"})
+    set_session(
+        player_name="test_player",
+        clan_tag="#sessionclan",
+        player_townhall=14,
+        player_townhall_weapon_level=3,
+    )
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json()["has_active_listing"] is True
+    assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"
+
+
+def test_session_state_ignores_malformed_session_clan_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    def fail_get_clan_collection():
+        raise AssertionError("Mongo should not be called for bad clan tag")
+
+    set_session(
+        player_name="test_player",
+        clan_tag="bad-tag!",
+        player_townhall=14,
+        player_townhall_weapon_level=3,
+    )
+    monkeypatch.setattr(
+        session_state_route,
+        "get_clan_collection",
+        fail_get_clan_collection,
+    )
+
+    response = client.get("/session-state")
+
+    assert response.status_code == 200
+    assert response.get_json()["has_active_listing"] is False
+
+
 def test_session_state_returns_logged_in_player_without_active_listing(
     client,
     monkeypatch,

--- a/tests/routes/test_session_state_user_info_route.py
+++ b/tests/routes/test_session_state_user_info_route.py
@@ -65,3 +65,50 @@ def test_session_state_user_info_returns_player_stats(
         "builderHallLevel",
         "clan",
     ]
+
+
+def test_session_state_user_info_normalizes_player_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class DummyAPI:
+        instances = []
+
+        def __init__(self, player_tag, api_token, headers):
+            self.player_tag = player_tag
+            DummyAPI.instances.append(self)
+
+        def check_player(self, fields):
+            return {"player_tag": self.player_tag}
+
+    set_session(player_tag="#player123")
+    monkeypatch.setattr(session_state_route, "API", DummyAPI)
+
+    response = client.get("/session-state/user-info")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"player_tag": "PLAYER123"}
+    assert DummyAPI.instances[0].player_tag == "PLAYER123"
+
+
+def test_session_state_user_info_returns_empty_for_malformed_player_tag(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.session_state_route as session_state_route
+
+    class FailIfCalledAPI:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("API should not be called for bad player tag")
+
+    set_session(player_tag="bad-tag!")
+    monkeypatch.setattr(session_state_route, "API", FailIfCalledAPI)
+
+    response = client.get("/session-state/user-info")
+
+    assert response.status_code == 200
+    assert response.get_json() == {}

--- a/tests/test_recruiter_listing_service.py
+++ b/tests/test_recruiter_listing_service.py
@@ -196,8 +196,13 @@ def test_update_recruiter_listing_refreshes_expiry(monkeypatch):
     }
 
 
-def test_update_recruiter_listing_preserves_provided_expiry(monkeypatch):
-    collection = DummyClanCollection(existing={"requirements": [1, 2, 3]})
+def test_update_recruiter_listing_preserves_existing_expiry(monkeypatch):
+    collection = DummyClanCollection(
+        existing={
+            "requirements": [1, 2, 3],
+            "expires": "existing_expiry",
+        },
+    )
     setup_recruiter_listing(monkeypatch, collection)
 
     payload, status_code = recruiter_listing.update_recruiter_listing(
@@ -208,7 +213,7 @@ def test_update_recruiter_listing_preserves_provided_expiry(monkeypatch):
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": False,
-            "expiry": "provided_expiry",
+            "expiry": "client_controlled_expiry",
         },
     )
     _, update_doc = collection.update_call
@@ -216,8 +221,12 @@ def test_update_recruiter_listing_preserves_provided_expiry(monkeypatch):
 
     assert status_code == 200
     assert payload == {
-        "status": "provided_expiry",
+        "status": "existing_expiry",
         "message": "Listing updated successfully.",
+    }
+    assert collection.find_one_query == {
+        "clan_tag": "TEST123",
+        "source": {"$ne": "clash_api_import"},
     }
     assert "expires" not in set_doc
 


### PR DESCRIPTION
## Summary

This PR tightens request contracts, validates user/session-backed inputs before they reach business logic, and adds route/service test coverage for invalid payloads, malformed tags, unsafe session state, and query parameter handling.

## Changes

### Request contract validation

- Adds shared validation helpers for:
  - JSON object parsing
  - allowed-field enforcement
  - exact one-of payload mode checks
  - required/optional strings
  - required/optional integers
  - boolean query params
  - enum validation
  - Clash tag normalization
- Enforces strict POST payload contracts for:
  - `/`
  - `/recruitee`
  - `/imported_clans`
  - `/search_clans`
  - `/recruiter`
- Rejects unknown fields and ambiguous payload shapes.
- Rejects `clan_tag` input aliases for lookup payloads; `clanTag` is the request contract.

### Recruitee/imported clan validation

- Validates local listing filter schemas.
- Rejects unknown top-level and nested filter fields.
- Validates `warFrequency` against Clash API enum values.
- Validates `includeTotal` as an explicit boolean query flag.
- Normalizes logged-in matchmaking session stats before Mongo comparisons.
- Handles incomplete/malformed matchmaking session values safely.
- Preserves broad browse behavior for empty filter objects.
- Merges latest `main` active-listing filtering so expired listings are excluded.

### Recruiter validation

- Adds action-specific recruiter payload allowlists.
- Caps `requiredBuilderLeague`.
- Stops trusting client-provided `expiry`; preserved expiry is read server-side.
- Validates recruiter session preconditions:
  - `recruiter_status is True`
  - normalized `clan_tag`
  - normalized `player_tag` for create actions

### Session and saved clans validation

- Normalizes session-backed `clan_tag` before active listing checks.
- Normalizes session-backed `player_tag` before Clash API user-info calls.
- Treats malformed session tags as guest/empty state where appropriate.
- Validates saved-clans session `player_tag` before DB reads/writes.
- Returns unauthorized for malformed saved-clans session identity.

## Testing

Ran:

```bash
./venv/bin/python -m pytest
./venv/bin/python -m ruff check routes tests