### PR TITLE
Fix/issue 2 1 service layer

### DIFF
--- a/routes/imported_clans_route.py
+++ b/routes/imported_clans_route.py
@@ -1,13 +1,11 @@
 """Register routes for handling imported clans."""
 
-import re
-from datetime import datetime, timezone
-
 from flask import Blueprint, jsonify, request
 
 from ..services.import_clash_api_clans import (
     get_imported_clan,
 )
+from ..services.imported_clan_search import get_imported_clans_response
 from ..services.mongo_db_client import get_clan_collection
 from .rate_limit import rate_limit
 from .validation import (
@@ -58,48 +56,6 @@ def _get_requested_offset():
     return query_int(request, "offset", default=0, min_value=0)
 
 
-def _build_imported_query(filters):
-    """Build a MongoDB query for imported clans from request filter data."""
-    query = {
-        "source": "clash_api_import",
-        "expires": {"$gt": datetime.now(timezone.utc)},
-    }
-
-    name = filters.get("name")
-    if name:
-        query["name"] = {"$regex": re.escape(name.strip()), "$options": "i"}
-
-    min_clan_level = filters.get("minClanLevel")
-    if min_clan_level is not None:
-        query["clan_info.clan_level"] = {"$gte": min_clan_level}
-
-    min_clan_points = filters.get("clanPoints")
-    if min_clan_points is not None:
-        query["clan_info.clanPoints"] = {"$gte": min_clan_points}
-
-    requirements = filters.get("requirements", {})
-    members = requirements.get("members", {})
-    min_members = members.get("min")
-    max_members = members.get("max")
-    if min_members is not None or max_members is not None:
-        member_range = {}
-        if min_members is not None:
-            member_range["$gte"] = min_members
-        if max_members is not None:
-            member_range["$lte"] = max_members
-        query["clan_info.member_count"] = member_range
-
-    war_frequency = filters.get("warFrequency")
-    if war_frequency:
-        query["clan_info.warFrequency"] = war_frequency
-
-    location = filters.get("location")
-    if location:
-        query["clan_info.location.name"] = location
-
-    return query
-
-
 @imported_clans_bp.post("/imported_clans")
 @rate_limit("imported_clans", limit=20, window_seconds=60)
 def imported_clans_post():
@@ -112,42 +68,18 @@ def imported_clans_post():
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    clan_collection = get_clan_collection()
-
-    clan_tag = raw_form.get("clanTag")
-    if clan_tag is not None:
-        clan = get_imported_clan(clan_tag)
-        if clan is None:
-            return jsonify({"error": "Imported clan not found"}), 404
-        return jsonify(clan)
-
-
-    filters = raw_form.get("filters", {})
-    query = _build_imported_query(filters)
-    total = clan_collection.count_documents(query)
-    items = list(
-        clan_collection.find(query, {"_id": 0})
-        .sort(
-            [
-                ("last_discovered", -1),
-                ("last_updated", -1),
-                ("clan_info.clan_level", -1),
-                ("clan_info.member_count", -1),
-                ("clan_tag", 1),
-            ]
-        )
-        .skip(requested_offset)
-        .limit(requested_limit)
+    payload, status_code = get_imported_clans_response(
+        raw_form,
+        limit=requested_limit,
+        offset=requested_offset,
+        clan_collection=(
+            None
+            if raw_form.get("clanTag") is not None
+            else get_clan_collection()
+        ),
+        imported_clan_lookup=get_imported_clan,
     )
-
-    return jsonify(
-        {
-            "items": items,
-            "total": total,
-            "limit": requested_limit,
-            "offset": requested_offset,
-        }
-    )
+    return jsonify(payload), status_code
 
 
 def _validate_imported_payload(payload):

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -1,13 +1,14 @@
 """Register routes for handling recruitee requests."""
 
-import re
-from datetime import datetime, timezone
-
 from flask import Blueprint, jsonify, request, session
 
 from ..config import headers
 from ..services.maxtownhall import refresh
 from ..services.mongo_db_client import get_clan_collection
+from ..services.recruitee_search import (
+    get_recruitee_list_response,
+    get_recruitee_post_response,
+)
 from .rate_limit import rate_limit
 from .validation import (
     CLASH_WAR_FREQUENCIES,
@@ -41,11 +42,6 @@ RECRUITEE_FILTER_FIELDS = {
 }
 RECRUITEE_REQUIREMENT_FIELDS = {"townhall", "league", "members"}
 MEMBER_FILTER_FIELDS = {"min", "max"}
-MATCHMAKING_SESSION_FIELDS = {
-    "player_league": "requirements.0",
-    "player_builderbase_trophies": "requirements.1",
-    "player_townhall": "requirements.2",
-}
 
 
 def _get_requested_limit(default_limit):
@@ -69,41 +65,6 @@ def _should_include_total():
     return query_bool(request, "includeTotal", default=False)
 
 
-def _get_matchmaking_base_query():
-    """Return a safe clan match query for the current session."""
-    player_name = session.get("player_name", None)
-    if not player_name or player_name == "Guest":
-        return {}
-
-    stats = {}
-    for session_key, query_key in MATCHMAKING_SESSION_FIELDS.items():
-        value = session.get(session_key)
-        if value is None:
-            return {}
-        stats[query_key] = _session_int(value, session_key)
-
-    return {query_key: {"$lte": value} for query_key, value in stats.items()}
-
-
-def _session_int(value, field_name):
-    if isinstance(value, bool):
-        raise RequestValidationError(f"{field_name} is invalid.")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped and stripped.isdecimal():
-            return int(stripped)
-    raise RequestValidationError(f"{field_name} is invalid.")
-
-
-def _active_listing_query(query=None):
-    """Return a listing query scoped to listings that have not expired."""
-    active_query = dict(query or {})
-    active_query["expires"] = {"$gt": datetime.now(timezone.utc)}
-    return active_query
-
-
 @recruitee_bp.get("/recruitee")
 @rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
@@ -116,32 +77,17 @@ def recruitee_get():
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    clan_collection = get_clan_collection()
     try:
-        base_query = _get_matchmaking_base_query()
+        payload, status_code = get_recruitee_list_response(
+            dict(session),
+            limit=requested_limit,
+            offset=requested_offset,
+            include_total=include_total,
+            clan_collection=get_clan_collection(),
+        )
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
-    query = _active_listing_query(base_query)
-
-    data = list(
-        clan_collection.find(query, {"_id": 0})
-        .sort([("last_updated", -1), ("clan_tag", 1)])
-        .skip(requested_offset)
-        .limit(requested_limit)
-    )
-
-    if not include_total:
-        return jsonify(data)
-
-    total = clan_collection.count_documents(query)
-    return jsonify(
-        {
-            "items": data,
-            "total": total,
-            "limit": requested_limit,
-            "offset": requested_offset,
-        }
-    )
+    return jsonify(payload), status_code
 
 
 @recruitee_bp.post("/recruitee")
@@ -157,85 +103,14 @@ def recruitee_post():
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    clan_collection = get_clan_collection()
-
-    clan_tag = raw_form.get("clanTag")
-    if clan_tag is not None:
-        data = clan_collection.find_one(
-            _active_listing_query({"clan_tag": clan_tag}), {"_id": 0}
-        )
-        if data is None:
-            return jsonify({"error": "Clan not found"}), 404
-        return jsonify(data)
-
-
-    filters = raw_form.get("filters", {})
-    query = {}
-
-    name = filters.get("name", None)
-    if name:
-        query["name"] = {"$regex": re.escape(name.strip()), "$options": "i"}
-    requirements = filters.get("requirements", {})
-    min_townhall = requirements.get("townhall", None)
-    min_league = requirements.get("league", None)
-    if min_townhall is not None:
-        query["requirements.2"] = {"$gte": min_townhall}
-    if min_league is not None:
-        query["requirements.0"] = {"$gte": min_league}
-
-    min_clan_level = filters.get("minClanLevel", None)
-    if min_clan_level is not None:
-        query["clan_info.clan_level"] = {"$gte": min_clan_level}
-
-    min_clan_points = filters.get("clanPoints", None)
-    if min_clan_points is not None:
-        query["clan_info.clanPoints"] = {"$gte": min_clan_points}
-
-    members = requirements.get("members", {})
-    min_members = members.get("min", None)
-    max_members = members.get("max", None)
-    if min_members is not None or max_members is not None:
-        member_range = {}
-        if min_members is not None:
-            member_range["$gte"] = min_members
-        if max_members is not None:
-            member_range["$lte"] = max_members
-        query["clan_info.member_count"] = member_range
-    war_frequency = filters.get("warFrequency", None)
-    if war_frequency:
-        query["clan_info.warFrequency"] = war_frequency
-
-    location_id = filters.get("location_id", None)
-    if location_id:
-        try:
-            query["clan_info.location.id"] = int(location_id)
-        except (TypeError, ValueError):
-            return jsonify({"error": "Invalid location_id"}), 400
-    else:
-        location_name = filters.get("location", None)
-        if location_name:
-            query["clan_info.location.name"] = location_name
-
-    query = _active_listing_query(query)
-    data = list(
-        clan_collection.find(query, {"_id": 0})
-        .sort([("last_updated", -1), ("clan_tag", 1)])
-        .skip(requested_offset)
-        .limit(requested_limit)
+    payload, status_code = get_recruitee_post_response(
+        raw_form,
+        limit=requested_limit,
+        offset=requested_offset,
+        include_total=include_total,
+        clan_collection=get_clan_collection(),
     )
-
-    if not include_total:
-        return jsonify(data)
-
-    total = clan_collection.count_documents(query)
-    return jsonify(
-        {
-            "items": data,
-            "total": total,
-            "limit": requested_limit,
-            "offset": requested_offset,
-        }
-    )
+    return jsonify(payload), status_code
 
 
 def _validate_recruitee_payload(payload):

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -1,75 +1,17 @@
 """Register routes for saved a users saved clans."""
 
-from datetime import datetime, timezone
-
 from flask import Blueprint, jsonify, session
 
 from ..services.mongo_db_client import get_clan_collection, get_user_collection
+from ..services.saved_clans import (
+    add_saved_clan as add_saved_clan_service,
+    delete_saved_clan as delete_saved_clan_service,
+    get_saved_clans_payload,
+)
 from .rate_limit import rate_limit
 from .validation import RequestValidationError, normalize_tag
 
 saved_clans_bp = Blueprint("saved_clans", __name__)
-
-MAX_SAVED_CLANS = 10
-
-
-def _hydrate_saved_clans(saved_clan_tags):
-    """Build saved clan response objects from stored clan tags.
-
-    For each saved clan tag, this helper looks up the matching clan listing in
-    the database and returns a normalized object for the response payload. If a
-    saved tag no longer has an active listing, the function still includes that
-    tag in the returned list with fallback values and marks the listing as
-    unavailable.
-
-    Args:
-        saved_clan_tags (list): The saved clan tags associated with the current
-            user.
-
-    Returns:
-        list: A list of hydrated saved clan objects in the same order as the
-            provided saved clan tags.
-    """
-    clan_collection = get_clan_collection()
-    now = datetime.now(timezone.utc)
-    listings = list(
-        clan_collection.find(
-            {"clan_tag": {"$in": saved_clan_tags}, "expires": {"$gt": now}},
-            {
-                "_id": 0,
-                "clan_tag": 1,
-                "name": 1,
-                "requirements": 1,
-                "clan_info": 1,
-            },
-        )
-    )
-    listing_by_saved_tag = {
-        listing["clan_tag"]: listing for listing in listings
-    }
-
-    hydrated = []
-    for saved_tag in saved_clan_tags:
-        listing = listing_by_saved_tag.get(saved_tag)
-        clan_info = listing.get("clan_info", {}) if listing else {}
-
-        hydrated.append(
-            {
-                "clan_tag": saved_tag,
-                "name": (
-                    (listing.get("name") if listing else None)
-                    or clan_info.get("name")
-                    or saved_tag
-                ),
-                "requirements": (
-                    listing.get("requirements") if listing else None
-                ),
-                "clan_info": clan_info,
-                "listing_available": bool(listing),
-            }
-        )
-
-    return hydrated
 
 
 @saved_clans_bp.get("/saved-clans")
@@ -80,24 +22,12 @@ def get_saved_clans():
     if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
-    user_collection = get_user_collection()
-    user_doc = (
-        user_collection.find_one(
-            {"player_tag": player_tag},
-            {"_id": 0, "saved_clans": 1},
-        )
-        or {}
+    payload = get_saved_clans_payload(
+        player_tag,
+        get_user_collection(),
+        get_clan_collection(),
     )
-    saved_clan_tags = user_doc.get("saved_clans", [])
-    hydrated = _hydrate_saved_clans(saved_clan_tags)
-
-    return jsonify(
-        {
-            "saved_clans": hydrated,
-            "count": len(saved_clan_tags),
-            "max_saved_clans": MAX_SAVED_CLANS,
-        }
-    ), 200
+    return jsonify(payload), 200
 
 
 @saved_clans_bp.post("/saved-clans/<clan_tag>")
@@ -112,59 +42,17 @@ def add_saved_clan(clan_tag):
     if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
-    user_collection = get_user_collection()
     try:
         normalized_tag = normalize_tag(clan_tag, "clan_tag")
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    current_doc = (
-        user_collection.find_one(
-            {"player_tag": player_tag},
-            {"_id": 0, "saved_clans": 1},
-        )
-        or {}
+    payload, status_code = add_saved_clan_service(
+        player_tag,
+        normalized_tag,
+        get_user_collection(),
     )
-    current_saved = current_doc.get("saved_clans", [])
-    if normalized_tag in current_saved:
-        return jsonify(
-            {
-                "message": "Clan already saved.",
-                "clan_tag": normalized_tag,
-                "count": len(current_saved),
-                "max_saved_clans": MAX_SAVED_CLANS,
-            }
-        ), 200
-
-    if len(current_saved) >= MAX_SAVED_CLANS:
-        return jsonify(
-            {
-                "message": (
-                    "You can save up to 10 clans. Remove one before saving "
-                    "another."
-                ),
-                "count": len(current_saved),
-                "max_saved_clans": MAX_SAVED_CLANS,
-            }
-        ), 409
-
-    user_collection.update_one(
-        {"player_tag": player_tag},
-        {
-            "$addToSet": {"saved_clans": normalized_tag},
-            "$setOnInsert": {"player_tag": player_tag},
-        },
-        upsert=True,
-    )
-
-    return jsonify(
-        {
-            "message": "Clan saved.",
-            "clan_tag": normalized_tag,
-            "count": len(current_saved) + 1,
-            "max_saved_clans": MAX_SAVED_CLANS,
-        }
-    ), 200
+    return jsonify(payload), status_code
 
 
 @saved_clans_bp.delete("/saved-clans/<clan_tag>")
@@ -180,20 +68,17 @@ def delete_saved_clan(clan_tag):
     if player_tag is None:
         return jsonify({"message": "Unauthorized"}), 401
 
-    user_collection = get_user_collection()
     try:
         normalized_tag = normalize_tag(clan_tag, "clan_tag")
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
-    user_collection.update_one(
-        {"player_tag": player_tag},
-        {"$pull": {"saved_clans": normalized_tag}},
+    payload, status_code = delete_saved_clan_service(
+        player_tag,
+        normalized_tag,
+        get_user_collection(),
     )
-
-    return jsonify(
-        {"message": "Saved clan removed.", "clan_tag": normalized_tag}
-    ), 200
+    return jsonify(payload), status_code
 
 
 def _validated_session_player_tag():

--- a/routes/saved_clans_route.py
+++ b/routes/saved_clans_route.py
@@ -5,7 +5,11 @@ from flask import Blueprint, jsonify, session
 from ..services.mongo_db_client import get_clan_collection, get_user_collection
 from ..services.saved_clans import (
     add_saved_clan as add_saved_clan_service,
+)
+from ..services.saved_clans import (
     delete_saved_clan as delete_saved_clan_service,
+)
+from ..services.saved_clans import (
     get_saved_clans_payload,
 )
 from .rate_limit import rate_limit

--- a/routes/session_state_route.py
+++ b/routes/session_state_route.py
@@ -1,12 +1,14 @@
 """Register routes for handling session state requests."""
 
-from datetime import datetime, timezone
-
 from flask import Blueprint, jsonify, session
 
 from ..api.clash_api import API
 from ..config import headers
 from ..services.mongo_db_client import get_clan_collection
+from ..services.session_state import (
+    get_session_state_payload,
+    get_user_info_payload,
+)
 from .rate_limit import rate_limit
 from .validation import RequestValidationError, normalize_tag
 
@@ -18,30 +20,19 @@ session_state_bp = Blueprint("session_state", __name__)
 def session_state():
     """Return current session status, player state, and active listing info."""
     username = session.get("player_name", "Guest")
-    recruit_status = bool(session.get("recruiter_status"))
-    has_active_listing = False
-    townhall = None
-    townhallWeaponLevel = None
     clan_tag = _normalized_session_tag("clan_tag")
 
-    if username != "Guest":
-        townhall = session.get("player_townhall")
-        townhallWeaponLevel = session.get("player_townhall_weapon_level")
-
-    if clan_tag:
-        clan_collection = get_clan_collection()
-        now = datetime.now(timezone.utc)
-        listing = clan_collection.find_one(
-            {"clan_tag": clan_tag, "expires": {"$gt": now}}, {"_id": 1}
-        )
-        has_active_listing = listing is not None
-
     return jsonify(
-        username=username,
-        recruit_status=recruit_status,
-        has_active_listing=has_active_listing,
-        townhall=townhall,
-        townhallWeaponLevel=townhallWeaponLevel,
+        get_session_state_payload(
+            username=username,
+            recruit_status=bool(session.get("recruiter_status")),
+            clan_tag=clan_tag,
+            townhall=session.get("player_townhall"),
+            townhall_weapon_level=session.get(
+                "player_townhall_weapon_level"
+            ),
+            clan_collection=get_clan_collection() if clan_tag else None,
+        )
     )
 
 
@@ -51,21 +42,12 @@ def session_state_user_info():
     """Return extended player info for the current session when available."""
     player_tag = _normalized_session_tag("player_tag")
 
-    if player_tag is None:
-        return jsonify({})
-
-    user = API(player_tag, None, headers)
-    stats = user.check_player(
-        [
-            "expLevel",
-            "leagueTier",
-            "builderBaseLeague",
-            "builderHallLevel",
-            "clan",
-        ]
+    return jsonify(
+        get_user_info_payload(
+            player_tag,
+            lambda tag: API(tag, None, headers),
+        )
     )
-
-    return jsonify(stats or {})
 
 
 def _normalized_session_tag(field_name):

--- a/services/imported_clan_search.py
+++ b/services/imported_clan_search.py
@@ -1,0 +1,92 @@
+"""Service functions for imported clan lookup and search."""
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+IMPORTED_CLAN_SORT = [
+    ("last_discovered", -1),
+    ("last_updated", -1),
+    ("clan_info.clan_level", -1),
+    ("clan_info.member_count", -1),
+    ("clan_tag", 1),
+]
+
+
+def get_imported_clans_response(
+    payload: dict[str, Any],
+    *,
+    limit: int,
+    offset: int,
+    clan_collection: Any,
+    imported_clan_lookup: Any,
+) -> tuple[dict[str, Any], int]:
+    """Return an imported clan lookup or filtered search response."""
+    clan_tag = payload.get("clanTag")
+    if clan_tag is not None:
+        clan = imported_clan_lookup(clan_tag)
+        if clan is None:
+            return {"error": "Imported clan not found"}, 404
+        return clan, 200
+
+    filters = payload.get("filters", {})
+    query = build_imported_query(filters)
+    total = clan_collection.count_documents(query)
+    items = list(
+        clan_collection.find(query, {"_id": 0})
+        .sort(IMPORTED_CLAN_SORT)
+        .skip(offset)
+        .limit(limit)
+    )
+
+    return (
+        {
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        },
+        200,
+    )
+
+
+def build_imported_query(filters: dict[str, Any]) -> dict[str, Any]:
+    """Build a MongoDB query for imported clans from filter data."""
+    query = {
+        "source": "clash_api_import",
+        "expires": {"$gt": datetime.now(timezone.utc)},
+    }
+
+    name = filters.get("name")
+    if name:
+        query["name"] = {"$regex": re.escape(name.strip()), "$options": "i"}
+
+    min_clan_level = filters.get("minClanLevel")
+    if min_clan_level is not None:
+        query["clan_info.clan_level"] = {"$gte": min_clan_level}
+
+    min_clan_points = filters.get("clanPoints")
+    if min_clan_points is not None:
+        query["clan_info.clanPoints"] = {"$gte": min_clan_points}
+
+    requirements = filters.get("requirements", {})
+    members = requirements.get("members", {})
+    min_members = members.get("min")
+    max_members = members.get("max")
+    if min_members is not None or max_members is not None:
+        member_range = {}
+        if min_members is not None:
+            member_range["$gte"] = min_members
+        if max_members is not None:
+            member_range["$lte"] = max_members
+        query["clan_info.member_count"] = member_range
+
+    war_frequency = filters.get("warFrequency")
+    if war_frequency:
+        query["clan_info.warFrequency"] = war_frequency
+
+    location = filters.get("location")
+    if location:
+        query["clan_info.location.name"] = location
+
+    return query

--- a/services/recruitee_search.py
+++ b/services/recruitee_search.py
@@ -1,0 +1,179 @@
+"""Service functions for recruitee clan listing search."""
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from ..routes.validation import RequestValidationError
+
+MATCHMAKING_SESSION_FIELDS = {
+    "player_league": "requirements.0",
+    "player_builderbase_trophies": "requirements.1",
+    "player_townhall": "requirements.2",
+}
+RECRUITEE_SORT = [("last_updated", -1), ("clan_tag", 1)]
+
+
+def get_recruitee_list_response(
+    session_data: dict[str, Any],
+    *,
+    limit: int,
+    offset: int,
+    include_total: bool,
+    clan_collection: Any,
+) -> tuple[Any, int]:
+    """Return clans for a session with optional total metadata."""
+    query = active_listing_query(get_matchmaking_base_query(session_data))
+    return _paginated_response(
+        query,
+        limit=limit,
+        offset=offset,
+        include_total=include_total,
+        clan_collection=clan_collection,
+    ), 200
+
+
+def get_recruitee_post_response(
+    payload: dict[str, Any],
+    *,
+    limit: int,
+    offset: int,
+    include_total: bool,
+    clan_collection: Any,
+) -> tuple[Any, int]:
+    """Return clan details by tag or a filtered clan list."""
+    clan_tag = payload.get("clanTag")
+    if clan_tag is not None:
+        data = clan_collection.find_one(
+            active_listing_query({"clan_tag": clan_tag}),
+            {"_id": 0},
+        )
+        if data is None:
+            return {"error": "Clan not found"}, 404
+        return data, 200
+
+    query = active_listing_query(build_recruitee_filter_query(
+        payload.get("filters", {})
+    ))
+    return _paginated_response(
+        query,
+        limit=limit,
+        offset=offset,
+        include_total=include_total,
+        clan_collection=clan_collection,
+    ), 200
+
+
+def get_matchmaking_base_query(
+    session_data: dict[str, Any],
+) -> dict[str, dict[str, int]]:
+    """Return a clan match query for the current player session."""
+    player_name = session_data.get("player_name")
+    if not player_name or player_name == "Guest":
+        return {}
+
+    stats = {}
+    for session_key, query_key in MATCHMAKING_SESSION_FIELDS.items():
+        value = session_data.get(session_key)
+        if value is None:
+            return {}
+        stats[query_key] = _session_int(value, session_key)
+
+    return {query_key: {"$lte": value} for query_key, value in stats.items()}
+
+
+def build_recruitee_filter_query(filters: dict[str, Any]) -> dict[str, Any]:
+    """Build a MongoDB query for recruitee search filters."""
+    query = {}
+
+    name = filters.get("name")
+    if name:
+        query["name"] = {"$regex": re.escape(name.strip()), "$options": "i"}
+
+    requirements = filters.get("requirements", {})
+    min_townhall = requirements.get("townhall")
+    min_league = requirements.get("league")
+    if min_townhall is not None:
+        query["requirements.2"] = {"$gte": min_townhall}
+    if min_league is not None:
+        query["requirements.0"] = {"$gte": min_league}
+
+    min_clan_level = filters.get("minClanLevel")
+    if min_clan_level is not None:
+        query["clan_info.clan_level"] = {"$gte": min_clan_level}
+
+    min_clan_points = filters.get("clanPoints")
+    if min_clan_points is not None:
+        query["clan_info.clanPoints"] = {"$gte": min_clan_points}
+
+    members = requirements.get("members", {})
+    min_members = members.get("min")
+    max_members = members.get("max")
+    if min_members is not None or max_members is not None:
+        member_range = {}
+        if min_members is not None:
+            member_range["$gte"] = min_members
+        if max_members is not None:
+            member_range["$lte"] = max_members
+        query["clan_info.member_count"] = member_range
+
+    war_frequency = filters.get("warFrequency")
+    if war_frequency:
+        query["clan_info.warFrequency"] = war_frequency
+
+    location_id = filters.get("location_id")
+    if location_id:
+        query["clan_info.location.id"] = int(location_id)
+    else:
+        location_name = filters.get("location")
+        if location_name:
+            query["clan_info.location.name"] = location_name
+
+    return query
+
+
+def active_listing_query(
+    query: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a query scoped to active listings."""
+    active_query = dict(query or {})
+    active_query["expires"] = {"$gt": datetime.now(timezone.utc)}
+    return active_query
+
+
+def _paginated_response(
+    query: dict[str, Any],
+    *,
+    limit: int,
+    offset: int,
+    include_total: bool,
+    clan_collection: Any,
+) -> Any:
+    data = list(
+        clan_collection.find(query, {"_id": 0})
+        .sort(RECRUITEE_SORT)
+        .skip(offset)
+        .limit(limit)
+    )
+
+    if not include_total:
+        return data
+
+    return {
+        "items": data,
+        "total": clan_collection.count_documents(query),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def _session_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise RequestValidationError(f"{field_name} is invalid.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped.isdecimal():
+            return int(stripped)
+    raise RequestValidationError(f"{field_name} is invalid.")

--- a/services/saved_clans.py
+++ b/services/saved_clans.py
@@ -1,0 +1,146 @@
+"""Service functions for saved clan operations."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+MAX_SAVED_CLANS = 10
+
+
+def get_saved_clans_payload(
+    player_tag: str,
+    user_collection: Any,
+    clan_collection: Any,
+) -> dict[str, Any]:
+    """Return the saved-clans response payload for a player."""
+    user_doc = (
+        user_collection.find_one(
+            {"player_tag": player_tag},
+            {"_id": 0, "saved_clans": 1},
+        )
+        or {}
+    )
+    saved_clan_tags = user_doc.get("saved_clans", [])
+    hydrated = hydrate_saved_clans(saved_clan_tags, clan_collection)
+
+    return {
+        "saved_clans": hydrated,
+        "count": len(saved_clan_tags),
+        "max_saved_clans": MAX_SAVED_CLANS,
+    }
+
+
+def add_saved_clan(
+    player_tag: str,
+    clan_tag: str,
+    user_collection: Any,
+) -> tuple[dict[str, Any], int]:
+    """Save a clan tag for a player and return the response payload."""
+    current_doc = (
+        user_collection.find_one(
+            {"player_tag": player_tag},
+            {"_id": 0, "saved_clans": 1},
+        )
+        or {}
+    )
+    current_saved = current_doc.get("saved_clans", [])
+    if clan_tag in current_saved:
+        return (
+            {
+                "message": "Clan already saved.",
+                "clan_tag": clan_tag,
+                "count": len(current_saved),
+                "max_saved_clans": MAX_SAVED_CLANS,
+            },
+            200,
+        )
+
+    if len(current_saved) >= MAX_SAVED_CLANS:
+        return (
+            {
+                "message": (
+                    "You can save up to 10 clans. Remove one before saving "
+                    "another."
+                ),
+                "count": len(current_saved),
+                "max_saved_clans": MAX_SAVED_CLANS,
+            },
+            409,
+        )
+
+    user_collection.update_one(
+        {"player_tag": player_tag},
+        {
+            "$addToSet": {"saved_clans": clan_tag},
+            "$setOnInsert": {"player_tag": player_tag},
+        },
+        upsert=True,
+    )
+
+    return (
+        {
+            "message": "Clan saved.",
+            "clan_tag": clan_tag,
+            "count": len(current_saved) + 1,
+            "max_saved_clans": MAX_SAVED_CLANS,
+        },
+        200,
+    )
+
+
+def delete_saved_clan(
+    player_tag: str,
+    clan_tag: str,
+    user_collection: Any,
+) -> tuple[dict[str, Any], int]:
+    """Remove a saved clan tag for a player."""
+    user_collection.update_one(
+        {"player_tag": player_tag},
+        {"$pull": {"saved_clans": clan_tag}},
+    )
+    return {"message": "Saved clan removed.", "clan_tag": clan_tag}, 200
+
+
+def hydrate_saved_clans(
+    saved_clan_tags: list[str],
+    clan_collection: Any,
+) -> list[dict[str, Any]]:
+    """Build saved clan response objects from stored clan tags."""
+    now = datetime.now(timezone.utc)
+    listings = list(
+        clan_collection.find(
+            {"clan_tag": {"$in": saved_clan_tags}, "expires": {"$gt": now}},
+            {
+                "_id": 0,
+                "clan_tag": 1,
+                "name": 1,
+                "requirements": 1,
+                "clan_info": 1,
+            },
+        )
+    )
+    listing_by_saved_tag = {
+        listing["clan_tag"]: listing for listing in listings
+    }
+
+    hydrated = []
+    for saved_tag in saved_clan_tags:
+        listing = listing_by_saved_tag.get(saved_tag)
+        clan_info = listing.get("clan_info", {}) if listing else {}
+
+        hydrated.append(
+            {
+                "clan_tag": saved_tag,
+                "name": (
+                    (listing.get("name") if listing else None)
+                    or clan_info.get("name")
+                    or saved_tag
+                ),
+                "requirements": (
+                    listing.get("requirements") if listing else None
+                ),
+                "clan_info": clan_info,
+                "listing_available": bool(listing),
+            }
+        )
+
+    return hydrated

--- a/services/session_state.py
+++ b/services/session_state.py
@@ -1,0 +1,58 @@
+"""Service functions for session and user state responses."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+USER_INFO_FIELDS = [
+    "expLevel",
+    "leagueTier",
+    "builderBaseLeague",
+    "builderHallLevel",
+    "clan",
+]
+
+
+def get_session_state_payload(
+    *,
+    username: str,
+    recruit_status: bool,
+    clan_tag: str | None,
+    townhall: Any,
+    townhall_weapon_level: Any,
+    clan_collection: Any,
+) -> dict[str, Any]:
+    """Return current session status and active listing state."""
+    has_active_listing = False
+    response_townhall = None
+    response_townhall_weapon_level = None
+
+    if username != "Guest":
+        response_townhall = townhall
+        response_townhall_weapon_level = townhall_weapon_level
+
+    if clan_tag and clan_collection is not None:
+        listing = clan_collection.find_one(
+            {
+                "clan_tag": clan_tag,
+                "expires": {"$gt": datetime.now(timezone.utc)},
+            },
+            {"_id": 1},
+        )
+        has_active_listing = listing is not None
+
+    return {
+        "username": username,
+        "recruit_status": recruit_status,
+        "has_active_listing": has_active_listing,
+        "townhall": response_townhall,
+        "townhallWeaponLevel": response_townhall_weapon_level,
+    }
+
+
+def get_user_info_payload(player_tag: str | None, api_factory: Any) -> dict:
+    """Return extended player info for a player tag."""
+    if player_tag is None:
+        return {}
+
+    user = api_factory(player_tag)
+    return user.check_player(USER_INFO_FIELDS) or {}

--- a/tests/test_imported_clan_helpers.py
+++ b/tests/test_imported_clan_helpers.py
@@ -1,10 +1,10 @@
 import pytest
 from ClashRecruit.routes.imported_clans_route import (
-    _build_imported_query,
     _get_requested_limit,
     _get_requested_offset,
 )
 from ClashRecruit.routes.validation import RequestValidationError
+from ClashRecruit.services.imported_clan_search import build_imported_query
 from flask import Flask
 
 
@@ -57,7 +57,7 @@ def test_invalid_pagination_raises_validation_error(
 
 
 def test_build_imported_query_empty_filters_returns_active_imports() -> None:
-    query = _build_imported_query({})
+    query = build_imported_query({})
 
     assert query == {
         "source": "clash_api_import",
@@ -67,7 +67,7 @@ def test_build_imported_query_empty_filters_returns_active_imports() -> None:
 
 
 def test_build_imported_query_escapes_name_and_ignores_empty() -> None:
-    query = _build_imported_query(
+    query = build_imported_query(
         {
             "name": "  test.*(name)  ",
             "warFrequency": "",
@@ -95,7 +95,7 @@ def test_build_imported_query_member_ranges(
     members: dict[str, int],
     expected: dict[str, int],
 ) -> None:
-    query = _build_imported_query(
+    query = build_imported_query(
         {
             "requirements": {"members": members},
         }
@@ -107,7 +107,7 @@ def test_build_imported_query_member_ranges(
 
 
 def test_build_imported_query_all_scalar_filters() -> None:
-    query = _build_imported_query(
+    query = build_imported_query(
         {
             "minClanLevel": 10,
             "clanPoints": 35000,

--- a/tests/test_imported_clan_search_service.py
+++ b/tests/test_imported_clan_search_service.py
@@ -1,0 +1,132 @@
+from ClashRecruit.services.imported_clan_search import (
+    IMPORTED_CLAN_SORT,
+    build_imported_query,
+    get_imported_clans_response,
+)
+
+
+class DummyCursor:
+    def __init__(self, docs):
+        self.docs = docs
+        self.sort_fields = None
+        self.skip_count = None
+        self.limit_count = None
+
+    def sort(self, fields):
+        self.sort_fields = fields
+        return self
+
+    def skip(self, count):
+        self.skip_count = count
+        return self
+
+    def limit(self, count):
+        self.limit_count = count
+        return self
+
+    def __iter__(self):
+        start = self.skip_count or 0
+        stop = start + self.limit_count
+        return iter(self.docs[start:stop])
+
+
+class DummyClanCollection:
+    def __init__(self, docs):
+        self.cursor = DummyCursor(docs)
+        self.count_query = None
+        self.find_query = None
+        self.find_projection = None
+
+    def count_documents(self, query):
+        self.count_query = query
+        return len(self.cursor.docs)
+
+    def find(self, query, projection):
+        self.find_query = query
+        self.find_projection = projection
+        return self.cursor
+
+
+def test_build_imported_query_uses_filters():
+    query = build_imported_query(
+        {
+            "name": "  Test.*  ",
+            "minClanLevel": 12,
+            "clanPoints": 40000,
+            "requirements": {"members": {"min": 30, "max": 45}},
+            "warFrequency": "always",
+            "location": "Canada",
+        }
+    )
+
+    assert query["source"] == "clash_api_import"
+    assert "$gt" in query["expires"]
+    assert query["name"] == {"$regex": "Test\\.\\*", "$options": "i"}
+    assert query["clan_info.clan_level"] == {"$gte": 12}
+    assert query["clan_info.clanPoints"] == {"$gte": 40000}
+    assert query["clan_info.member_count"] == {"$gte": 30, "$lte": 45}
+    assert query["clan_info.warFrequency"] == "always"
+    assert query["clan_info.location.name"] == "Canada"
+
+
+def test_imported_clans_response_returns_paginated_search():
+    collection = DummyClanCollection(
+        [
+            {"clan_tag": "ONE", "name": "First"},
+            {"clan_tag": "TWO", "name": "Second"},
+            {"clan_tag": "THREE", "name": "Third"},
+        ]
+    )
+
+    payload, status_code = get_imported_clans_response(
+        {"filters": {"location": "Canada"}},
+        limit=1,
+        offset=1,
+        clan_collection=collection,
+        imported_clan_lookup=lambda clan_tag: None,
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "items": [{"clan_tag": "TWO", "name": "Second"}],
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+    }
+    assert collection.count_query == collection.find_query
+    assert collection.find_query["clan_info.location.name"] == "Canada"
+    assert collection.find_projection == {"_id": 0}
+    assert collection.cursor.sort_fields == IMPORTED_CLAN_SORT
+
+
+def test_imported_clans_response_returns_tag_lookup():
+    lookup_calls = []
+
+    def lookup(clan_tag):
+        lookup_calls.append(clan_tag)
+        return {"clan_tag": clan_tag, "name": "test_clan"}
+
+    payload, status_code = get_imported_clans_response(
+        {"clanTag": "TEST123"},
+        limit=10,
+        offset=0,
+        clan_collection=object(),
+        imported_clan_lookup=lookup,
+    )
+
+    assert status_code == 200
+    assert payload == {"clan_tag": "TEST123", "name": "test_clan"}
+    assert lookup_calls == ["TEST123"]
+
+
+def test_imported_clans_response_returns_404_for_missing_tag():
+    payload, status_code = get_imported_clans_response(
+        {"clanTag": "MISSING"},
+        limit=10,
+        offset=0,
+        clan_collection=object(),
+        imported_clan_lookup=lambda clan_tag: None,
+    )
+
+    assert status_code == 404
+    assert payload == {"error": "Imported clan not found"}

--- a/tests/test_recruitee_search_service.py
+++ b/tests/test_recruitee_search_service.py
@@ -1,5 +1,4 @@
 import pytest
-
 from ClashRecruit.routes.validation import RequestValidationError
 from ClashRecruit.services.recruitee_search import (
     RECRUITEE_SORT,

--- a/tests/test_recruitee_search_service.py
+++ b/tests/test_recruitee_search_service.py
@@ -1,0 +1,220 @@
+import pytest
+
+from ClashRecruit.routes.validation import RequestValidationError
+from ClashRecruit.services.recruitee_search import (
+    RECRUITEE_SORT,
+    build_recruitee_filter_query,
+    get_matchmaking_base_query,
+    get_recruitee_list_response,
+    get_recruitee_post_response,
+)
+
+
+class DummyCursor:
+    def __init__(self, docs):
+        self.docs = docs
+        self.sort_fields = None
+        self.skip_count = None
+        self.limit_count = None
+
+    def sort(self, fields):
+        self.sort_fields = fields
+        return self
+
+    def skip(self, count):
+        self.skip_count = count
+        return self
+
+    def limit(self, count):
+        self.limit_count = count
+        return self
+
+    def __iter__(self):
+        start = self.skip_count or 0
+        stop = start + self.limit_count
+        return iter(self.docs[start:stop])
+
+
+class DummyClanCollection:
+    def __init__(self, docs=None, tag_result=None):
+        self.cursor = DummyCursor(docs or [])
+        self.tag_result = tag_result
+        self.count_query = None
+        self.find_query = None
+        self.find_projection = None
+        self.find_one_query = None
+        self.find_one_projection = None
+
+    def count_documents(self, query):
+        self.count_query = query
+        return len(self.cursor.docs)
+
+    def find(self, query, projection):
+        self.find_query = query
+        self.find_projection = projection
+        return self.cursor
+
+    def find_one(self, query, projection):
+        self.find_one_query = query
+        self.find_one_projection = projection
+        return self.tag_result
+
+
+def test_matchmaking_base_query_uses_logged_in_player_stats():
+    query = get_matchmaking_base_query(
+        {
+            "player_name": "test_player",
+            "player_league": "5",
+            "player_builderbase_trophies": "2200",
+            "player_townhall": "13",
+        }
+    )
+
+    assert query == {
+        "requirements.0": {"$lte": 5},
+        "requirements.1": {"$lte": 2200},
+        "requirements.2": {"$lte": 13},
+    }
+
+
+def test_matchmaking_base_query_falls_back_for_guest_or_incomplete_stats():
+    assert get_matchmaking_base_query({"player_name": "Guest"}) == {}
+    assert get_matchmaking_base_query({
+        "player_name": "test_player",
+        "player_league": 5,
+    }) == {}
+
+
+def test_matchmaking_base_query_rejects_bad_session_stat():
+    with pytest.raises(RequestValidationError) as exc:
+        get_matchmaking_base_query(
+            {
+                "player_name": "test_player",
+                "player_league": "not-a-league",
+                "player_builderbase_trophies": 2200,
+                "player_townhall": 13,
+            }
+        )
+
+    assert exc.value.message == "player_league is invalid."
+
+
+def test_build_recruitee_filter_query_uses_filters():
+    query = build_recruitee_filter_query(
+        {
+            "name": "  Test.*  ",
+            "requirements": {
+                "townhall": 12,
+                "league": 4,
+                "members": {"min": 30, "max": 45},
+            },
+            "minClanLevel": 10,
+            "clanPoints": 35000,
+            "warFrequency": "always",
+            "location_id": "32000007",
+        }
+    )
+
+    assert query == {
+        "name": {"$regex": "Test\\.\\*", "$options": "i"},
+        "requirements.2": {"$gte": 12},
+        "requirements.0": {"$gte": 4},
+        "clan_info.clan_level": {"$gte": 10},
+        "clan_info.clanPoints": {"$gte": 35000},
+        "clan_info.member_count": {"$gte": 30, "$lte": 45},
+        "clan_info.warFrequency": "always",
+        "clan_info.location.id": 32000007,
+    }
+
+
+def test_recruitee_list_response_filters_and_includes_total():
+    collection = DummyClanCollection(
+        [
+            {"clan_tag": "TEST1", "name": "test_clan_1"},
+            {"clan_tag": "TEST2", "name": "test_clan_2"},
+            {"clan_tag": "TEST3", "name": "test_clan_3"},
+        ]
+    )
+
+    payload, status_code = get_recruitee_list_response(
+        {
+            "player_name": "test_player",
+            "player_league": 5,
+            "player_builderbase_trophies": 2200,
+            "player_townhall": 13,
+        },
+        limit=1,
+        offset=1,
+        include_total=True,
+        clan_collection=collection,
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "items": [{"clan_tag": "TEST2", "name": "test_clan_2"}],
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+    }
+    assert collection.find_query["requirements.0"] == {"$lte": 5}
+    assert "$gt" in collection.find_query["expires"]
+    assert collection.count_query == collection.find_query
+    assert collection.find_projection == {"_id": 0}
+    assert collection.cursor.sort_fields == RECRUITEE_SORT
+
+
+def test_recruitee_post_response_returns_tag_lookup():
+    collection = DummyClanCollection(
+        tag_result={"clan_tag": "TEST123", "name": "test_clan"}
+    )
+
+    payload, status_code = get_recruitee_post_response(
+        {"clanTag": "TEST123"},
+        limit=10,
+        offset=0,
+        include_total=False,
+        clan_collection=collection,
+    )
+
+    assert status_code == 200
+    assert payload == {"clan_tag": "TEST123", "name": "test_clan"}
+    assert collection.find_one_query["clan_tag"] == "TEST123"
+    assert "$gt" in collection.find_one_query["expires"]
+    assert collection.find_one_projection == {"_id": 0}
+
+
+def test_recruitee_post_response_returns_404_for_missing_tag():
+    collection = DummyClanCollection(tag_result=None)
+
+    payload, status_code = get_recruitee_post_response(
+        {"clanTag": "MISSING"},
+        limit=10,
+        offset=0,
+        include_total=False,
+        clan_collection=collection,
+    )
+
+    assert status_code == 404
+    assert payload == {"error": "Clan not found"}
+
+
+def test_recruitee_post_response_returns_raw_list_without_total():
+    collection = DummyClanCollection(
+        [{"clan_tag": "TEST123", "name": "test_clan"}]
+    )
+
+    payload, status_code = get_recruitee_post_response(
+        {"filters": {"location": "International"}},
+        limit=10,
+        offset=0,
+        include_total=False,
+        clan_collection=collection,
+    )
+
+    assert status_code == 200
+    assert payload == [{"clan_tag": "TEST123", "name": "test_clan"}]
+    assert collection.find_query["clan_info.location.name"] == (
+        "International"
+    )
+    assert "$gt" in collection.find_query["expires"]
+    assert collection.count_query is None

--- a/tests/test_saved_clans_service.py
+++ b/tests/test_saved_clans_service.py
@@ -1,0 +1,161 @@
+from ClashRecruit.services.saved_clans import (
+    add_saved_clan,
+    delete_saved_clan,
+    get_saved_clans_payload,
+)
+
+
+class DummyUserCollection:
+    def __init__(self, saved_clans=None):
+        self.saved_clans = saved_clans or []
+        self.find_one_query = None
+        self.find_one_projection = None
+        self.update_call = None
+
+    def find_one(self, query, projection):
+        self.find_one_query = query
+        self.find_one_projection = projection
+        return {"saved_clans": self.saved_clans}
+
+    def update_one(self, query, update, upsert=False):
+        self.update_call = (query, update, upsert)
+
+
+class DummyClanCollection:
+    def __init__(self, listings):
+        self.listings = listings
+        self.find_query = None
+        self.find_projection = None
+
+    def find(self, query, projection):
+        self.find_query = query
+        self.find_projection = projection
+        return self.listings
+
+
+def test_get_saved_clans_payload_hydrates_available_and_missing_listings():
+    user_collection = DummyUserCollection(["ABC123", "MISSING"])
+    clan_collection = DummyClanCollection(
+        [
+            {
+                "clan_tag": "ABC123",
+                "name": "test_clan",
+                "requirements": [1, 2, 3],
+                "clan_info": {"name": "test_clan_info"},
+            }
+        ]
+    )
+
+    payload = get_saved_clans_payload(
+        "PLAYER123",
+        user_collection,
+        clan_collection,
+    )
+
+    assert payload == {
+        "saved_clans": [
+            {
+                "clan_tag": "ABC123",
+                "name": "test_clan",
+                "requirements": [1, 2, 3],
+                "clan_info": {"name": "test_clan_info"},
+                "listing_available": True,
+            },
+            {
+                "clan_tag": "MISSING",
+                "name": "MISSING",
+                "requirements": None,
+                "clan_info": {},
+                "listing_available": False,
+            },
+        ],
+        "count": 2,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.find_one_query == {"player_tag": "PLAYER123"}
+    assert clan_collection.find_query["clan_tag"] == {
+        "$in": ["ABC123", "MISSING"],
+    }
+    assert "$gt" in clan_collection.find_query["expires"]
+
+
+def test_add_saved_clan_adds_tag_when_under_limit():
+    user_collection = DummyUserCollection(["EXISTING"])
+
+    payload, status_code = add_saved_clan(
+        "PLAYER123",
+        "ABC123",
+        user_collection,
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "message": "Clan saved.",
+        "clan_tag": "ABC123",
+        "count": 2,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.update_call == (
+        {"player_tag": "PLAYER123"},
+        {
+            "$addToSet": {"saved_clans": "ABC123"},
+            "$setOnInsert": {"player_tag": "PLAYER123"},
+        },
+        True,
+    )
+
+
+def test_add_saved_clan_returns_existing_without_update():
+    user_collection = DummyUserCollection(["ABC123"])
+
+    payload, status_code = add_saved_clan(
+        "PLAYER123",
+        "ABC123",
+        user_collection,
+    )
+
+    assert status_code == 200
+    assert payload["message"] == "Clan already saved."
+    assert payload["count"] == 1
+    assert user_collection.update_call is None
+
+
+def test_add_saved_clan_returns_conflict_at_limit():
+    user_collection = DummyUserCollection([f"TAG{i}" for i in range(10)])
+
+    payload, status_code = add_saved_clan(
+        "PLAYER123",
+        "ABC123",
+        user_collection,
+    )
+
+    assert status_code == 409
+    assert payload == {
+        "message": (
+            "You can save up to 10 clans. Remove one before saving another."
+        ),
+        "count": 10,
+        "max_saved_clans": 10,
+    }
+    assert user_collection.update_call is None
+
+
+def test_delete_saved_clan_removes_tag():
+    user_collection = DummyUserCollection()
+
+    payload, status_code = delete_saved_clan(
+        "PLAYER123",
+        "ABC123",
+        user_collection,
+    )
+
+    assert status_code == 200
+    assert payload == {
+        "message": "Saved clan removed.",
+        "clan_tag": "ABC123",
+    }
+    assert user_collection.update_call == (
+        {"player_tag": "PLAYER123"},
+        {"$pull": {"saved_clans": "ABC123"}},
+        False,
+    )

--- a/tests/test_session_state_service.py
+++ b/tests/test_session_state_service.py
@@ -1,0 +1,94 @@
+from ClashRecruit.services.session_state import (
+    USER_INFO_FIELDS,
+    get_session_state_payload,
+    get_user_info_payload,
+)
+
+
+class DummyClanCollection:
+    def __init__(self, listing):
+        self.listing = listing
+        self.find_one_query = None
+        self.find_one_projection = None
+
+    def find_one(self, query, projection):
+        self.find_one_query = query
+        self.find_one_projection = projection
+        return self.listing
+
+
+def test_session_state_payload_ignores_guest_cached_stats():
+    collection = DummyClanCollection(listing=None)
+
+    payload = get_session_state_payload(
+        username="Guest",
+        recruit_status=False,
+        clan_tag=None,
+        townhall=14,
+        townhall_weapon_level=3,
+        clan_collection=collection,
+    )
+
+    assert payload == {
+        "username": "Guest",
+        "recruit_status": False,
+        "has_active_listing": False,
+        "townhall": None,
+        "townhallWeaponLevel": None,
+    }
+    assert collection.find_one_query is None
+
+
+def test_session_state_payload_checks_active_listing_for_logged_in_player():
+    collection = DummyClanCollection(listing={"_id": "listing-id"})
+
+    payload = get_session_state_payload(
+        username="test_player",
+        recruit_status=True,
+        clan_tag="SESSIONCLAN",
+        townhall=14,
+        townhall_weapon_level=3,
+        clan_collection=collection,
+    )
+
+    assert payload == {
+        "username": "test_player",
+        "recruit_status": True,
+        "has_active_listing": True,
+        "townhall": 14,
+        "townhallWeaponLevel": 3,
+    }
+    assert collection.find_one_query["clan_tag"] == "SESSIONCLAN"
+    assert "$gt" in collection.find_one_query["expires"]
+    assert collection.find_one_projection == {"_id": 1}
+
+
+def test_user_info_payload_returns_empty_without_player_tag():
+    def fail_api_factory(tag):
+        raise AssertionError("API should not be called")
+
+    assert get_user_info_payload(None, fail_api_factory) == {}
+
+
+def test_user_info_payload_returns_selected_player_stats():
+    class DummyAPI:
+        def __init__(self, player_tag):
+            self.player_tag = player_tag
+            self.requested_fields = None
+
+        def check_player(self, fields):
+            self.requested_fields = fields
+            return {"player_tag": self.player_tag, "expLevel": 120}
+
+    instances = []
+
+    def api_factory(player_tag):
+        api = DummyAPI(player_tag)
+        instances.append(api)
+        return api
+
+    assert get_user_info_payload("PLAYER123", api_factory) == {
+        "player_tag": "PLAYER123",
+        "expLevel": 120,
+    }
+    assert instances[0].requested_fields == USER_INFO_FIELDS


### PR DESCRIPTION
## Summary

Extracts route business logic into service-layer functions so route handlers stay thin and the core behavior can be unit tested without Flask’s test client.

## What Changed

- Moved saved-clan DB logic, saved-clan hydration, max-save handling, and response shaping into `services/saved_clans.py`
- Moved session-state active-listing lookup and user-info lookup into `services/session_state.py`
- Moved imported-clan query construction, tag lookup, pagination, sorting, and response shaping into `services/imported_clan_search.py`
- Moved recruitee matchmaking, active listing queries, tag lookup, search filters, pagination, and response shaping into `services/recruitee_search.py`
- Kept routes focused on request/session reading, validation, service calls, and `jsonify(...)`
- Added direct service unit tests for extracted behavior

## Validation

- `pytest tests/test_saved_clans_service.py tests/test_session_state_service.py tests/test_imported_clan_search_service.py tests/test_recruitee_search_service.py`
- Result: `21 passed`

## Notes

Route response contracts, status codes, validation messages, and session keys were preserved.