### PR TITLE
Add legal pages and crawler rules

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,8 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /dashboard
+Disallow: /login
+Disallow: /recruit
+
+Allow: /privacy
+Allow: /terms

--- a/frontend/src/LegalPage.jsx
+++ b/frontend/src/LegalPage.jsx
@@ -1,0 +1,271 @@
+import { Link } from "react-router-dom";
+import usePageTitle from "./hooks/usePageTitle";
+import "./StaticPage.css";
+
+const legalPages = {
+  privacy: {
+    title: "Privacy Policy",
+    eyebrow: "Legal",
+    intro: "Last Updated: June 6, 2026",
+    sections: [
+      {
+        title: "Introduction",
+        body: [
+          <>ClashRecruit is a web app that helps Clash of Clans players and clans connect for recruitment.</>,
+          <>This Privacy Policy explains how ClashRecruit collects, uses, stores, shares, and protects information when users access or use the service. ClashRecruit is currently operated as a hobby project.</>
+        ]
+      },
+      {
+        title: "Data Collection",
+        body: [
+          <>ClashRecruit does not require user registration or account creation.</>,
+          <>ClashRecruit may collect or process Clash of Clans player tags, Clash of Clans API tokens entered by users for account ownership verification, Clash of Clans player and clan information retrieved through the Clash of Clans API, user-generated clan listings and related listing metadata, saved or favorited clans associated with a player tag, creator identifiers tied to clan listings, IP-based rate limiting identifiers, session cookie data used to maintain session state, and listing ownership tokens or similar pseudonymous identifiers used to maintain functionality and prevent abuse.</>,
+          <>Clash of Clans API tokens are used only temporarily for verification with the Clash of Clans API and are discarded after verification. ClashRecruit does not store Clash of Clans API tokens.</>,
+          <>ClashRecruit does not collect user messaging or private communication data. However, it does process user-generated clan listings and related metadata.</>,
+          <>ClashRecruit does not collect government ID, financial data, precise location, health data, children's data, private messages, or other sensitive data.</>
+        ]
+      },
+      {
+        title: "Data Usage",
+        body: [
+          <>ClashRecruit uses collected information to verify that a user owns a Clash of Clans account, retrieve Clash of Clans player and clan information, allow users to create, update, extend, delete, browse, save, and favorite clan listings, display public clan listings to other users, maintain session state, apply rate limits and protect the service from abuse, and respond to privacy-related requests.</>
+        ]
+      },
+      {
+        title: "Cookies",
+        body: [
+          <>ClashRecruit uses cookies for session functionality.</>,
+          <>ClashRecruit does not use analytics cookies and does not currently use analytics tools.</>
+        ]
+      },
+      {
+        title: "Third Parties",
+        body: [
+          <>ClashRecruit uses the Clash of Clans API / Supercell to verify Clash of Clans account ownership and retrieve Clash of Clans player and clan information.</>,
+          <>Data shared with the Clash of Clans API / Supercell includes the Clash of Clans player tag and Clash of Clans API token entered by the user.</>,
+          <>ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.</>,
+          <>ClashRecruit does not sell user data.</>
+        ]
+      },
+      {
+        title: "Data Sharing",
+        body: [
+          <>Clan listings may be visible to other users of ClashRecruit.</>,
+          <>ClashRecruit shares data with the Clash of Clans API / Supercell only as needed to verify account ownership and retrieve Clash of Clans player or clan information.</>,
+          <>ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.</>,
+          <>ClashRecruit does not sell personal data.</>
+        ]
+      },
+      {
+        title: "Retention",
+        body: [
+          <>Clan listings are kept for one week unless the user extends or deletes the listing.</>,
+          <>Saved clan records and listing ownership metadata are retained until the user deletes the associated saved clan or listing.</>,
+          <>Session cookies are temporary and used for session management.</>,
+          <>IP-based rate limiting data is retained temporarily on a rolling short-term basis for security and abuse prevention purposes.</>,
+          <>Users do not have ClashRecruit accounts, so account deletion is not available. Users may manually delete their clan listings and saved clans.</>
+        ]
+      },
+      {
+        title: "Security",
+        body: [
+          <>ClashRecruit uses HTTPS for the deployed service.</>,
+          <>ClashRecruit uses TLS encryption in transit for all network communications through MongoDB Atlas and supported infrastructure.</>,
+          <>Stored database data is encrypted at rest by MongoDB Atlas using provider-managed encryption keys. Customer-managed encryption keys are not enabled.</>,
+          <>ClashRecruit does not use end-to-end encryption, client-side encryption, or user-managed encryption keys.</>,
+          <>ClashRecruit does not collect passwords, so password hashing is not applicable.</>,
+          <>ClashRecruit uses access controls so users can update or delete their own listings.</>
+        ]
+      },
+      {
+        title: "User Rights",
+        body: [
+          <>Users may delete their clan listings and saved clans through ClashRecruit functionality. Users may also contact ClashRecruit to request deletion of any data associated with them where applicable.</>,
+          <>Users may correct or update their clan listings through ClashRecruit functionality.</>,
+          <>Users may contact ClashRecruit with privacy-related questions.</>
+        ]
+      },
+      {
+        title: "Contact",
+        body: [
+          <>
+            For privacy-related questions or requests, contact ClashRecruit by email at{" "}
+            <a href="mailto:clashrecruitsupport@gmail.com">
+              clashrecruitsupport@gmail.com
+            </a>{" "}
+            or through our{" "}
+            <a
+              href="https://discord.gg/9zTNTfVhBD"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Discord
+            </a>
+            .
+          </>
+        ]
+      },
+      {
+        title: "Disclaimer",
+        body: [
+          <>ClashRecruit is an unofficial fan-made service and is not affiliated with, endorsed by, sponsored by, or specifically approved by Supercell. Clash of Clans and related names, marks, and assets are the property of Supercell. Use of Supercell-related content is intended to comply with Supercell's Fan Content Policy.</>
+        ]
+      }
+    ]
+  },
+  terms: {
+    title: "Terms of Service",
+    eyebrow: "Legal",
+    intro: "Last Updated: June 6, 2026",
+    sections: [
+      {
+        title: "Overview",
+        body: [
+          <>ClashRecruit is a web application that helps Clash of Clans players and clans connect for recruitment purposes.</>,
+          <>By accessing or using ClashRecruit, you agree to these Terms of Service.</>,
+          <>ClashRecruit is an unofficial fan-made project and is not affiliated with, endorsed by, sponsored by, or approved by Supercell.</>
+        ]
+      },
+      {
+        title: "Eligibility",
+        body: [
+          <>ClashRecruit is intended for general use by Clash of Clans players.</>,
+          <>You are responsible for ensuring that your use of the service complies with the laws of your jurisdiction.</>,
+          <>The service is not specifically directed toward children, but may be used where permitted under applicable law.</>
+        ]
+      },
+      {
+        title: "No Accounts",
+        body: [
+          <>ClashRecruit does not require user accounts or registration.</>,
+          <>The service operates using session identifiers, player tags, and listing ownership tokens to manage functionality.</>,
+          <>You are responsible for maintaining access to any identifiers associated with your listings.</>
+        ]
+      },
+      {
+        title: "User Content (Clan Listings)",
+        body: [
+          <>Users may create, edit, and delete clan recruitment listings.</>,
+          <>By submitting a listing, you grant ClashRecruit permission to display the listing publicly on the platform and store and process the listing as required for service functionality.</>,
+          <>You are responsible for the content you submit, including its accuracy and legality.</>,
+          <>ClashRecruit does not guarantee the accuracy, availability, or reliability of user-generated content.</>
+        ]
+      },
+      {
+        title: "Prohibited Use",
+        body: [
+          <>You agree not to use the service for unlawful purposes, attempt to disrupt or damage the service, use bots, scrapers, or automated tools without permission, bypass rate limits or security protections, submit misleading, abusive, or harmful content, impersonate others, or misrepresent clans or identities.</>,
+          <>ClashRecruit may restrict or remove access for violations of these rules.</>
+        ]
+      },
+      {
+        title: "Third-Party Services",
+        body: [
+          <>ClashRecruit relies on third-party services, including Supercell (Clash of Clans API) and MongoDB Atlas (database hosting).</>,
+          <>These services operate under their own terms and policies.</>,
+          <>ClashRecruit is not responsible for the availability, performance, or actions of third-party services.</>
+        ]
+      },
+      {
+        title: "Service Availability",
+        body: [
+          <>ClashRecruit is provided on an <strong>"as is"</strong> and <strong>"as available"</strong> basis.</>,
+          <>The service may be modified, suspended, or discontinued at any time without notice.</>,
+          <>No guarantees are made regarding uptime, reliability, or continued availability.</>
+        ]
+      },
+      {
+        title: "Data and Privacy",
+        body: [
+          <>Your use of ClashRecruit is also governed by the Privacy Policy.</>,
+          <>By using the service, you acknowledge that data such as player tags, clan listings, and session identifiers may be collected and processed as described in the Privacy Policy.</>
+        ]
+      },
+      {
+        title: "Termination",
+        body: [
+          <>ClashRecruit reserves the right to restrict or remove access to the service at its discretion, including for violations of these Terms, abuse or misuse of the platform, or security or operational concerns.</>
+        ]
+      },
+      {
+        title: "Limitation of Liability",
+        body: [
+          <>To the maximum extent permitted by law, ClashRecruit is not liable for any damages or losses resulting from use or inability to use the service, reliance on user-generated content, third-party service failures, data loss, or unauthorized access.</>
+        ]
+      },
+      {
+        title: "Changes to the Terms",
+        body: [
+          <>ClashRecruit may update these Terms of Service at any time.</>,
+          <>Continued use of the service after changes are posted constitutes acceptance of the updated Terms.</>
+        ]
+      },
+      {
+        title: "Contact",
+        body: [
+          <>
+            For questions regarding these Terms, contact ClashRecruit by email at{" "}
+            <a href="mailto:clashrecruitsupport@gmail.com">
+              clashrecruitsupport@gmail.com
+            </a>{" "}
+            or through our{" "}
+            <a
+              href="https://discord.gg/9zTNTfVhBD"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Discord
+            </a>
+            .
+          </>
+        ]
+      },
+      {
+        title: "Fan Content Disclaimer",
+        body: [
+          <>ClashRecruit is a fan-made project.</>,
+          <>Clash of Clans and related assets are the property of Supercell. This project is intended to comply with Supercell's Fan Content Policy.</>
+        ]
+      }
+    ]
+  }
+};
+
+function sectionId(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+function LegalPage({ page }) {
+  const content = legalPages[page];
+
+  usePageTitle(`${content.title} | ClashRecruit`);
+
+  return (
+    <div className="static-page static-page--legal">
+      <section className="static-page__hero">
+        <span className="static-page__eyebrow">{content.eyebrow}</span>
+        <h1>{content.title}</h1>
+        <p>{content.intro}</p>
+      </section>
+
+      <section className="static-page__content" aria-label={`${content.title} content`}>
+        {content.sections.map((section) => (
+          <article className="static-page__section" id={sectionId(section.title)} key={sectionId(section.title)}>
+            <h2>{section.title}</h2>
+            {section.body.map((paragraph, index) => (
+              <p key={`${section.title}-${index}`}>{paragraph}</p>
+            ))}
+          </article>
+        ))}
+      </section>
+
+      <div className="static-page__actions">
+        <Link to="/" className="static-page__button">
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default LegalPage;

--- a/frontend/src/StaticPage.css
+++ b/frontend/src/StaticPage.css
@@ -91,6 +91,7 @@
   border: 0;
   border-radius: 0;
   box-shadow: none;
+  scroll-margin-top: 96px;
 }
 
 .static-page--legal .static-page__section + .static-page__section {

--- a/frontend/src/StaticPage.css
+++ b/frontend/src/StaticPage.css
@@ -1,0 +1,150 @@
+.static-page {
+  width: min(980px, 100%);
+  margin: 0 auto;
+  padding: 42px 24px 56px;
+  box-sizing: border-box;
+  color: #201913;
+}
+
+.static-page__hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 28px 0 24px;
+}
+
+.static-page__eyebrow {
+  color: #7a241f;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.static-page__hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.7rem);
+  line-height: 1;
+}
+
+.static-page__hero p {
+  max-width: 64ch;
+  margin: 0;
+  color: #594b3f;
+  font-size: 1.08rem;
+  line-height: 1.55;
+}
+
+.static-page__content {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.static-page__section {
+  min-height: 160px;
+  padding: 18px;
+  background: rgba(255, 253, 246, 0.9);
+  border: 1px solid #d4b985;
+  border-radius: 8px;
+  box-shadow: 0 3px 8px rgba(32, 25, 19, 0.08);
+}
+
+.static-page__section h2 {
+  margin: 0 0 10px;
+  color: #2d2218;
+  font-size: 1.15rem;
+  line-height: 1.25;
+}
+
+.static-page__section p {
+  margin: 0;
+  color: #46392d;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.static-page__section p + p {
+  margin-top: 10px;
+}
+
+.static-page--legal {
+  width: min(860px, 100%);
+}
+
+.static-page--legal .static-page__hero {
+  padding-bottom: 18px;
+  border-bottom: 1px solid #d4b985;
+}
+
+.static-page--legal .static-page__content {
+  display: block;
+  margin-top: 28px;
+}
+
+.static-page--legal .static-page__section {
+  min-height: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.static-page--legal .static-page__section + .static-page__section {
+  margin-top: 28px;
+}
+
+.static-page--legal .static-page__section h2 {
+  margin-bottom: 10px;
+  font-size: 1.35rem;
+}
+
+.static-page--legal .static-page__section p {
+  color: #3f3329;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.static-page__actions {
+  display: flex;
+  margin-top: 24px;
+}
+
+.static-page__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 150px;
+  min-height: 44px;
+  padding: 0 18px;
+  color: #fff7ef;
+  background: #b33a32;
+  border: 1px solid #b33a32;
+  border-radius: 8px;
+  font-weight: 710;
+  text-decoration: none;
+  box-shadow: 0 3px 8px rgba(32, 25, 19, 0.1);
+}
+
+.static-page__button:hover,
+.static-page__button:focus-visible {
+  background: #922a24;
+  border-color: #922a24;
+}
+
+@media (max-width: 780px) {
+  .static-page {
+    padding: 30px 18px 44px;
+  }
+
+  .static-page__content {
+    grid-template-columns: 1fr;
+  }
+
+  .static-page__section {
+    min-height: auto;
+  }
+}

--- a/frontend/src/StaticPage.jsx
+++ b/frontend/src/StaticPage.jsx
@@ -3,52 +3,14 @@ import usePageTitle from "./hooks/usePageTitle";
 import "./StaticPage.css";
 
 const pages = {
-  about: {
-    title: "About ClashRecruit",
-    eyebrow: "About",
-    intro: "A focused recruiting hub for Clash of Clans players and clan leaders.",
-    sections: [
-      {
-        title: "What this is",
-        body: "ClashRecruit helps clans publish recruiting listings and gives players a cleaner way to compare clans by requirements, activity, and war style."
-      },
-      {
-        title: "Who it is for",
-        body: "The app is built for leaders who want better visibility and players who want enough context to choose a clan before joining."
-      },
-      {
-        title: "Current status",
-        body: "This page is a rough layout placeholder while the final product copy is being written."
-      }
-    ]
-  },
-  faq: {
-    title: "Frequently Asked Questions",
-    eyebrow: "FAQ",
-    intro: "Quick answers for common ClashRecruit workflows.",
-    sections: [
-      {
-        title: "How do I list my clan?",
-        body: "Sign in with your player tag and API token, then use the dashboard to create or manage a recruiting listing."
-      },
-      {
-        title: "How do I find a clan?",
-        body: "Use the clan search page to browse active listings and filter by town hall, league, location, and activity preferences."
-      },
-      {
-        title: "Is ClashRecruit official?",
-        body: "No. ClashRecruit is an unofficial fan project and is not endorsed by Supercell."
-      }
-    ]
-  },
   contact: {
     title: "Contact",
     eyebrow: "Contact",
-    intro: "A rough contact page for support, project questions, and bug reports.",
+    intro: "For support, project questions, bug reports, and clan listing issues.",
     sections: [
       {
         title: "General questions",
-        body: "Add the preferred support email, form, or community contact method here."
+        body: "For support or project questions, email clashrecruitsupport@gmail.com or reach out through the ClashRecruit Discord."
       },
       {
         title: "Report a bug",
@@ -59,161 +21,16 @@ const pages = {
         body: "For problems with a clan listing, include the clan tag and a short description of the issue."
       }
     ]
-  },
-  discord: {
-    title: "Discord",
-    eyebrow: "Community",
-    intro: "A placeholder page for the ClashRecruit Discord community link.",
-    sections: [
-      {
-        title: "Join the community",
-        body: "Add the Discord invite, community guidelines, and support channels here once they are ready."
-      },
-      {
-        title: "What to share",
-        body: "Players can ask recruiting questions, report listing issues, or share feedback on the app."
-      }
-    ]
-  },
-  privacy: {
-    title: "Privacy Policy",
-    eyebrow: "Legal",
-    intro: "Last Updated: June 6, 2026",
-    layout: "legal",
-    sections: [
-      {
-        title: "Introduction",
-        body: [
-          "ClashRecruit is a web app that helps Clash of Clans players and clans connect for recruitment.",
-          "This Privacy Policy explains how ClashRecruit collects, uses, stores, shares, and protects information when users access or use the service. ClashRecruit is currently operated as a hobby project."
-        ]
-      },
-      {
-        title: "Data Collection",
-        body: [
-          "ClashRecruit does not require user registration or account creation.",
-          "ClashRecruit may collect or process Clash of Clans player tags, Clash of Clans API tokens entered by users for account ownership verification, Clash of Clans player and clan information retrieved through the Clash of Clans API, user-generated clan listings and related listing metadata, saved or favorited clans associated with a player tag, creator identifiers tied to clan listings, IP-based rate limiting identifiers, session cookie data used to maintain session state, and listing ownership tokens or similar pseudonymous identifiers used to maintain functionality and prevent abuse.",
-          "Clash of Clans API tokens are used only temporarily for verification with the Clash of Clans API and are discarded after verification. ClashRecruit does not store Clash of Clans API tokens.",
-          "ClashRecruit does not collect user messaging or private communication data. However, it does process user-generated clan listings and related metadata.",
-          "ClashRecruit does not collect government ID, financial data, precise location, health data, children's data, private messages, or other sensitive data."
-        ]
-      },
-      {
-        title: "Data Usage",
-        body: [
-          "ClashRecruit uses collected information to verify that a user owns a Clash of Clans account, retrieve Clash of Clans player and clan information, allow users to create, update, extend, delete, browse, save, and favorite clan listings, display public clan listings to other users, maintain session state, apply rate limits and protect the service from abuse, and respond to privacy-related requests."
-        ]
-      },
-      {
-        title: "Cookies",
-        body: [
-          "ClashRecruit uses cookies for session functionality.",
-          "ClashRecruit does not use analytics cookies and does not currently use analytics tools."
-        ]
-      },
-      {
-        title: "Third Parties",
-        body: [
-          "ClashRecruit uses the Clash of Clans API / Supercell to verify Clash of Clans account ownership and retrieve Clash of Clans player and clan information.",
-          "Data shared with the Clash of Clans API / Supercell includes the Clash of Clans player tag and Clash of Clans API token entered by the user.",
-          "ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.",
-          "ClashRecruit does not sell user data."
-        ]
-      },
-      {
-        title: "Data Sharing",
-        body: [
-          "Clan listings may be visible to other users of ClashRecruit.",
-          "ClashRecruit shares data with the Clash of Clans API / Supercell only as needed to verify account ownership and retrieve Clash of Clans player or clan information.",
-          "ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.",
-          "ClashRecruit does not sell personal data."
-        ]
-      },
-      {
-        title: "Retention",
-        body: [
-          "Clan listings are kept for one week unless the user extends or deletes the listing.",
-          "Saved clan records and listing ownership metadata are retained until the user deletes the associated saved clan or listing.",
-          "Session cookies are temporary and used for session management.",
-          "IP-based rate limiting data is retained temporarily on a rolling short-term basis for security and abuse prevention purposes.",
-          "Users do not have ClashRecruit accounts, so account deletion is not available. Users may manually delete their clan listings and saved clans."
-        ]
-      },
-      {
-        title: "Security",
-        body: [
-          "ClashRecruit uses HTTPS for the deployed service.",
-          "ClashRecruit uses TLS encryption in transit for all network communications through MongoDB Atlas and supported infrastructure.",
-          "Stored database data is encrypted at rest by MongoDB Atlas using provider-managed encryption keys. Customer-managed encryption keys are not enabled.",
-          "ClashRecruit does not use end-to-end encryption, client-side encryption, or user-managed encryption keys.",
-          "ClashRecruit does not collect passwords, so password hashing is not applicable.",
-          "ClashRecruit uses access controls so users can update or delete their own listings."
-        ]
-      },
-      {
-        title: "User Rights",
-        body: [
-          "Users may delete their clan listings and saved clans through ClashRecruit functionality. Users may also contact ClashRecruit to request deletion of any data associated with them where applicable.",
-          "Users may correct or update their clan listings through ClashRecruit functionality.",
-          "Users may contact ClashRecruit with privacy-related questions."
-        ]
-      },
-      {
-        title: "Contact",
-        body: [
-          <>
-            For privacy-related questions or requests, contact ClashRecruit by email at{" "} 
-            <a href="mailto:clashrecruitsupport@gmail.com">
-              clashrecruitsupport@gmail.com 
-            </a>{" "}
-            or through our{" "}
-            <a href="https://discord.gg/9zTNTfVhBD"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Discord
-            </a>
-            .
-          </>
-        ]
-      },
-      {
-        title: "Disclaimer",
-        body: [
-          "ClashRecruit is an unofficial fan-made service and is not affiliated with, endorsed by, sponsored by, or specifically approved by Supercell. Clash of Clans and related names, marks, and assets are the property of Supercell. Use of Supercell-related content is intended to comply with Supercell's Fan Content Policy."
-        ]
-      }
-    ]
-  },
-  terms: {
-    title: "Terms of Service",
-    eyebrow: "Legal",
-    intro: "A placeholder layout for the future ClashRecruit terms of service.",
-    sections: [
-      {
-        title: "Use of the service",
-        body: "Outline acceptable use, account responsibilities, and expectations for listing content."
-      },
-      {
-        title: "Unofficial fan project",
-        body: "Clarify that ClashRecruit is unofficial and not endorsed by Supercell."
-      },
-      {
-        title: "Changes and availability",
-        body: "Describe how terms may change and that features may be updated, paused, or removed."
-      }
-    ]
   }
 };
 
 function StaticPage({ page }) {
   const content = pages[page];
-  const isLegalLayout = content.layout === "legal";
 
   usePageTitle(`${content.title} | ClashRecruit`);
 
   return (
-    <div className={`static-page${isLegalLayout ? " static-page--legal" : ""}`}>
+    <div className="static-page">
       <section className="static-page__hero">
         <span className="static-page__eyebrow">{content.eyebrow}</span>
         <h1>{content.title}</h1>
@@ -224,9 +41,7 @@ function StaticPage({ page }) {
         {content.sections.map((section) => (
           <article className="static-page__section" key={section.title}>
             <h2>{section.title}</h2>
-            {(Array.isArray(section.body) ? section.body : [section.body]).map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
+            <p>{section.body}</p>
           </article>
         ))}
       </section>

--- a/frontend/src/StaticPage.jsx
+++ b/frontend/src/StaticPage.jsx
@@ -1,0 +1,230 @@
+import { Link } from "react-router-dom";
+import usePageTitle from "./hooks/usePageTitle";
+import "./StaticPage.css";
+
+const pages = {
+  about: {
+    title: "About ClashRecruit",
+    eyebrow: "About",
+    intro: "A focused recruiting hub for Clash of Clans players and clan leaders.",
+    sections: [
+      {
+        title: "What this is",
+        body: "ClashRecruit helps clans publish recruiting listings and gives players a cleaner way to compare clans by requirements, activity, and war style."
+      },
+      {
+        title: "Who it is for",
+        body: "The app is built for leaders who want better visibility and players who want enough context to choose a clan before joining."
+      },
+      {
+        title: "Current status",
+        body: "This page is a rough layout placeholder while the final product copy is being written."
+      }
+    ]
+  },
+  faq: {
+    title: "Frequently Asked Questions",
+    eyebrow: "FAQ",
+    intro: "Quick answers for common ClashRecruit workflows.",
+    sections: [
+      {
+        title: "How do I list my clan?",
+        body: "Sign in with your player tag and API token, then use the dashboard to create or manage a recruiting listing."
+      },
+      {
+        title: "How do I find a clan?",
+        body: "Use the clan search page to browse active listings and filter by town hall, league, location, and activity preferences."
+      },
+      {
+        title: "Is ClashRecruit official?",
+        body: "No. ClashRecruit is an unofficial fan project and is not endorsed by Supercell."
+      }
+    ]
+  },
+  contact: {
+    title: "Contact",
+    eyebrow: "Contact",
+    intro: "A rough contact page for support, project questions, and bug reports.",
+    sections: [
+      {
+        title: "General questions",
+        body: "Add the preferred support email, form, or community contact method here."
+      },
+      {
+        title: "Report a bug",
+        body: "Describe what happened, what you expected, whether it happens every time, and include your browser, page URL, screenshots, or any clan or player tag involved."
+      },
+      {
+        title: "Clan listing issues",
+        body: "For problems with a clan listing, include the clan tag and a short description of the issue."
+      }
+    ]
+  },
+  discord: {
+    title: "Discord",
+    eyebrow: "Community",
+    intro: "A placeholder page for the ClashRecruit Discord community link.",
+    sections: [
+      {
+        title: "Join the community",
+        body: "Add the Discord invite, community guidelines, and support channels here once they are ready."
+      },
+      {
+        title: "What to share",
+        body: "Players can ask recruiting questions, report listing issues, or share feedback on the app."
+      }
+    ]
+  },
+  privacy: {
+    title: "Privacy Policy",
+    eyebrow: "Legal",
+    intro: "Effective Date: June 5, 2026",
+    layout: "legal",
+    sections: [
+      {
+        title: "Introduction",
+        body: [
+          "ClashRecruit is a web app that helps Clash of Clans players and clans connect for recruitment.",
+          "This Privacy Policy explains how ClashRecruit collects, uses, stores, shares, and protects information when users access or use the service. ClashRecruit is currently operated as a hobby project."
+        ]
+      },
+      {
+        title: "Data Collection",
+        body: [
+          "ClashRecruit does not require user registration or account creation.",
+          "ClashRecruit may collect or process Clash of Clans player tags, Clash of Clans API tokens entered by users for account ownership verification, Clash of Clans player and clan information retrieved through the Clash of Clans API, user-generated clan listings and related listing metadata, saved or favorited clans associated with a player tag, creator identifiers tied to clan listings, IP-based rate limiting identifiers, session cookie data used to maintain session state, and listing ownership tokens or similar pseudonymous identifiers used to maintain functionality and prevent abuse.",
+          "Clash of Clans API tokens are used only temporarily for verification with the Clash of Clans API and are discarded after verification. ClashRecruit does not store Clash of Clans API tokens.",
+          "ClashRecruit does not collect user messaging or private communication data. However, it does process user-generated clan listings and related metadata.",
+          "ClashRecruit does not collect government ID, financial data, precise location, health data, children's data, private messages, or other sensitive data."
+        ]
+      },
+      {
+        title: "Data Usage",
+        body: [
+          "ClashRecruit uses collected information to verify that a user owns a Clash of Clans account, retrieve Clash of Clans player and clan information, allow users to create, update, extend, delete, browse, save, and favorite clan listings, display public clan listings to other users, maintain session state, apply rate limits and protect the service from abuse, and respond to privacy-related requests."
+        ]
+      },
+      {
+        title: "Cookies",
+        body: [
+          "ClashRecruit uses cookies for session functionality.",
+          "ClashRecruit does not use analytics cookies and does not currently use analytics tools."
+        ]
+      },
+      {
+        title: "Third Parties",
+        body: [
+          "ClashRecruit uses the Clash of Clans API / Supercell to verify Clash of Clans account ownership and retrieve Clash of Clans player and clan information.",
+          "Data shared with the Clash of Clans API / Supercell includes the Clash of Clans player tag and Clash of Clans API token entered by the user.",
+          "ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.",
+          "ClashRecruit does not sell user data."
+        ]
+      },
+      {
+        title: "Data Sharing",
+        body: [
+          "Clan listings may be visible to other users of ClashRecruit.",
+          "ClashRecruit shares data with the Clash of Clans API / Supercell only as needed to verify account ownership and retrieve Clash of Clans player or clan information.",
+          "ClashRecruit uses MongoDB Atlas as its database provider to store clan listings, saved clan records, player tags associated with saved clans or listing ownership, and related metadata required for core functionality.",
+          "ClashRecruit does not sell personal data."
+        ]
+      },
+      {
+        title: "Retention",
+        body: [
+          "Clan listings are kept for one week unless the user extends or deletes the listing.",
+          "Saved clan records and listing ownership metadata are retained until the user deletes the associated saved clan or listing.",
+          "Session cookies are temporary and used for session management.",
+          "IP-based rate limiting data is retained temporarily on a rolling short-term basis for security and abuse prevention purposes.",
+          "Users do not have ClashRecruit accounts, so account deletion is not available. Users may manually delete their clan listings and saved clans."
+        ]
+      },
+      {
+        title: "Security",
+        body: [
+          "ClashRecruit uses HTTPS for the deployed service.",
+          "ClashRecruit uses TLS encryption in transit for all network communications through MongoDB Atlas and supported infrastructure.",
+          "Stored database data is encrypted at rest by MongoDB Atlas using provider-managed encryption keys. Customer-managed encryption keys are not enabled.",
+          "ClashRecruit does not use end-to-end encryption, client-side encryption, or user-managed encryption keys.",
+          "ClashRecruit does not collect passwords, so password hashing is not applicable.",
+          "ClashRecruit uses access controls so users can update or delete their own listings."
+        ]
+      },
+      {
+        title: "User Rights",
+        body: [
+          "Users may delete their clan listings and saved clans through ClashRecruit functionality. Users may also contact ClashRecruit to request deletion of any data associated with them where applicable.",
+          "Users may correct or update their clan listings through ClashRecruit functionality.",
+          "Users may contact ClashRecruit with privacy-related questions."
+        ]
+      },
+      {
+        title: "Contact",
+        body: [
+          "For privacy-related questions or requests, contact ClashRecruit by email at clashrecruitsupport@gmail.com or through Discord at https://discord.gg/9zTNTfVhBD."
+        ]
+      },
+      {
+        title: "Disclaimer",
+        body: [
+          "ClashRecruit is an unofficial fan-made service and is not affiliated with, endorsed by, sponsored by, or specifically approved by Supercell. Clash of Clans and related names, marks, and assets are the property of Supercell. Use of Supercell-related content is intended to comply with Supercell's Fan Content Policy."
+        ]
+      }
+    ]
+  },
+  terms: {
+    title: "Terms of Service",
+    eyebrow: "Legal",
+    intro: "A placeholder layout for the future ClashRecruit terms of service.",
+    sections: [
+      {
+        title: "Use of the service",
+        body: "Outline acceptable use, account responsibilities, and expectations for listing content."
+      },
+      {
+        title: "Unofficial fan project",
+        body: "Clarify that ClashRecruit is unofficial and not endorsed by Supercell."
+      },
+      {
+        title: "Changes and availability",
+        body: "Describe how terms may change and that features may be updated, paused, or removed."
+      }
+    ]
+  }
+};
+
+function StaticPage({ page }) {
+  const content = pages[page];
+  const isLegalLayout = content.layout === "legal";
+
+  usePageTitle(`${content.title} | ClashRecruit`);
+
+  return (
+    <div className={`static-page${isLegalLayout ? " static-page--legal" : ""}`}>
+      <section className="static-page__hero">
+        <span className="static-page__eyebrow">{content.eyebrow}</span>
+        <h1>{content.title}</h1>
+        <p>{content.intro}</p>
+      </section>
+
+      <section className="static-page__content" aria-label={`${content.title} content`}>
+        {content.sections.map((section) => (
+          <article className="static-page__section" key={section.title}>
+            <h2>{section.title}</h2>
+            {(Array.isArray(section.body) ? section.body : [section.body]).map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </article>
+        ))}
+      </section>
+
+      <div className="static-page__actions">
+        <Link to="/" className="static-page__button">
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default StaticPage;

--- a/frontend/src/StaticPage.jsx
+++ b/frontend/src/StaticPage.jsx
@@ -78,7 +78,7 @@ const pages = {
   privacy: {
     title: "Privacy Policy",
     eyebrow: "Legal",
-    intro: "Effective Date: June 5, 2026",
+    intro: "Last Updated: June 6, 2026",
     layout: "legal",
     sections: [
       {
@@ -161,7 +161,20 @@ const pages = {
       {
         title: "Contact",
         body: [
-          "For privacy-related questions or requests, contact ClashRecruit by email at clashrecruitsupport@gmail.com or through Discord at https://discord.gg/9zTNTfVhBD."
+          <>
+            For privacy-related questions or requests, contact ClashRecruit by email at{" "} 
+            <a href="mailto:clashrecruitsupport@gmail.com">
+              clashrecruitsupport@gmail.com 
+            </a>{" "}
+            or through our{" "}
+            <a href="https://discord.gg/9zTNTfVhBD"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Discord
+            </a>
+            .
+          </>
         ]
       },
       {

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -3,29 +3,68 @@
     flex-direction: column;
     align-items: center;
     border-top: solid 1px #d7dbe0;
-    padding: 14px 24px;
+    padding: 18px 24px;
     background: rgba(255, 250, 241, 0.9);
     justify-content: center;
-    gap: 6px;
+    gap: 14px;
+}
+
+.footer__nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 10px 18px;
+}
+
+.footer__legal {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    max-width: 860px;
+    padding-top: 12px;
+    border-top: solid 1px rgba(15, 23, 42, 0.12);
 }
 
 .footer__copyright {
     margin: 0;
     font-size: 12px;
     color: #0f172a;
+    text-align: center;
 }
 
-.footer label {
+.footer__fan-policy {
     font-size: 10px;
     text-align: center;
 }
 
-.footer a {
+.footer__link,
+.footer__fan-policy a {
     color: #0f172a;
     text-decoration: underline;
+    text-underline-offset: 3px;
 }
 
-.footer a:hover,
-.footer a:focus-visible {
+.footer__link {
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.footer__link:hover,
+.footer__link:focus-visible,
+.footer__fan-policy a:hover,
+.footer__fan-policy a:focus-visible {
     text-decoration-thickness: 2px;
+}
+
+@media (max-width: 560px) {
+    .footer {
+        padding: 16px;
+    }
+
+    .footer__nav {
+        gap: 8px 14px;
+    }
 }

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,16 +1,40 @@
 import './Footer.css';
+import { Link } from 'react-router-dom';
+
+const navigationLinks = [
+    { label: 'Home', to: '/' },
+    { label: 'Contact', to: '/contact' },
+    { label: 'Discord', to: 'https://discord.gg/9zTNTfVhBD', target: '_blank' },
+    { label: 'Privacy Policy', to: '/privacy' },
+    { label: 'Terms of Service', to: '/terms' }
+];
 
 function Footer() {
-    
     return (
-        <div className="footer">
-            <p className="footer__copyright">© 2026 ClashRecruit</p>
-            <label> 
-                This material is unofficial and is not endorsed by Supercell.
-                For more information see Supercell's Fan Content Policy:{' '}
-                <a target="_blank" href="https://supercell.com/en/fan-content-policy/" rel="noopener noreferrer">www.supercell.com/fan-content-policy</a>.
-            </label>
-        </div>
+        <footer className="footer">
+            <nav className="footer__nav" aria-label="Footer navigation">
+                {navigationLinks.map((link) => (
+                    <Link
+                        key={link.to}
+                        to={link.to}
+                        className="footer__link"
+                        target={link.target}
+                        rel={link.target === '_blank' ? 'noopener noreferrer' : undefined}
+                    >
+                        {link.label}
+                    </Link>
+                ))}
+            </nav>
+
+            <section className="footer__legal" aria-label="Legal information">
+                <p className="footer__copyright">© 2026 ClashRecruit</p>
+                <label className="footer__fan-policy">
+                    This material is unofficial and is not endorsed by Supercell.
+                    For more information see Supercell's Fan Content Policy:{' '}
+                    <a target="_blank" href="https://supercell.com/en/fan-content-policy/" rel="noopener noreferrer">www.supercell.com/fan-content-policy</a>.
+                </label>
+            </section>
+        </footer>
     )
 }
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Navigate, useOutletContext } from 'react-router-dom';
+import { useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, useLocation, useOutletContext } from 'react-router-dom';
 import './index.css';
 import Login from './Login';
 import Dashboard from './Dashboard';
@@ -10,6 +11,7 @@ import ClanDetails from "./ClanDetails"
 import Landing from "./Landing"
 import LoadingScreen from "./components/LoadingScreen";
 import StaticPage from "./StaticPage";
+import LegalPage from "./LegalPage";
 
 function DashboardRouteGuard() {
   const { user, sessionStateLoaded } = useOutletContext();
@@ -26,9 +28,26 @@ function DashboardRouteGuard() {
   return <Dashboard />;
 }
 
+function ScrollToTop() {
+  const { hash, pathname } = useLocation();
+
+  useEffect(() => {
+    if (hash) {
+      const section = document.querySelector(hash);
+      section?.scrollIntoView();
+      return;
+    }
+
+    window.scrollTo({ top: 0, left: 0 });
+  }, [hash, pathname]);
+
+  return null;
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
 
         <Route element={<Layout />}>
@@ -39,12 +58,9 @@ root.render(
           <Route path="/recruit" element={<Recruiter/>} />
           <Route path="/looking-for-clan" element={<LookingForClan/>}/>
           <Route path="/looking-for-clan/:clanTag" element={<ClanDetails/>}/>
-          <Route path="/about" element={<StaticPage page="about" />} />
-          <Route path="/faq" element={<StaticPage page="faq" />} />
           <Route path="/contact" element={<StaticPage page="contact" />} />
-          <Route path="/discord" element={<StaticPage page="discord" />} />
-          <Route path="/privacy" element={<StaticPage page="privacy" />} />
-          <Route path="/terms" element={<StaticPage page="terms" />} />
+          <Route path="/privacy" element={<LegalPage page="privacy" />} />
+          <Route path="/terms" element={<LegalPage page="terms" />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -9,6 +9,7 @@ import Layout from "./components/Layout"
 import ClanDetails from "./ClanDetails"
 import Landing from "./Landing"
 import LoadingScreen from "./components/LoadingScreen";
+import StaticPage from "./StaticPage";
 
 function DashboardRouteGuard() {
   const { user, sessionStateLoaded } = useOutletContext();
@@ -38,6 +39,12 @@ root.render(
           <Route path="/recruit" element={<Recruiter/>} />
           <Route path="/looking-for-clan" element={<LookingForClan/>}/>
           <Route path="/looking-for-clan/:clanTag" element={<ClanDetails/>}/>
+          <Route path="/about" element={<StaticPage page="about" />} />
+          <Route path="/faq" element={<StaticPage page="faq" />} />
+          <Route path="/contact" element={<StaticPage page="contact" />} />
+          <Route path="/discord" element={<StaticPage page="discord" />} />
+          <Route path="/privacy" element={<StaticPage page="privacy" />} />
+          <Route path="/terms" element={<StaticPage page="terms" />} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary

Adds public legal pages for ClashRecruit and updates routing/footer navigation to support them.

## Changes

- Added a dedicated `LegalPage` component for Privacy Policy and Terms of Service pages
- Added full Privacy Policy content with section anchors
- Added full Terms of Service content with section anchors
- Removed unused internal About, FAQ, and Discord static routes/pages
- Kept Contact as the remaining generic static page
- Added scroll-to-top behavior on route changes while preserving hash anchor navigation
- Updated footer links for legal/static pages
- Updated `robots.txt` to discourage crawling app workflow routes and allow legal pages

## Verification

- Ran `npm run build` with Node `v20.20.2`
- Build completed successfully