### PR TITLE
Switch Builder Base requirements to league-based listings

### DIFF
--- a/api/recruiter_api.py
+++ b/api/recruiter_api.py
@@ -1,6 +1,9 @@
 """API helpers for recruiter workflows and clan listing metadata."""
 
 from ..clash_http_client import get as clash_get
+from ..services.builder_base_leagues import (
+    builder_base_league_id_from_trophies,
+)
 
 
 def extract_clan_requirements(payload: object) -> list[int]:
@@ -9,9 +12,12 @@ def extract_clan_requirements(payload: object) -> list[int]:
         return [0, 0, 0]
 
     required_league = 0
-    required_builder_trophies = payload.get("requiredBuilderBaseTrophies") or 0
+    required_builder_league = builder_base_league_id_from_trophies(
+        payload.get("requiredBuilderBaseTrophies"),
+        zero_as_no_requirement=True,
+    )
     required_townhall = payload.get("requiredTownhallLevel") or 0
-    return [required_league, required_builder_trophies, required_townhall]
+    return [required_league, required_builder_league, required_townhall]
 
 
 class Recruiter:
@@ -86,15 +92,15 @@ class Recruiter:
     def new_clan_requirements(
         self,
         required_league: int | None,
-        required_builder_trophies: int | None,
+        required_builder_league: int | None,
         required_townhall: int | None,
     ) -> None:
         """Set all clan requirements and store them in canonical list order."""
         self.required_league = required_league
-        self.required_builder_trophies = required_builder_trophies
+        self.required_builder_league = required_builder_league
         self.required_townhall = required_townhall
         self.requirements = [
             self.required_league,
-            self.required_builder_trophies,
+            self.required_builder_league,
             self.required_townhall,
         ]

--- a/frontend/src/ClanDetails.jsx
+++ b/frontend/src/ClanDetails.jsx
@@ -2,6 +2,7 @@ import "./ClanDetails.css";
 import { Link, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { formatWarFrequency } from "./utils/warFrequency";
+import { formatBuilderBaseLeague } from "./utils/builderBaseLeagues";
 
 function normalizeLocation(rawLocation) {
     if (!rawLocation) return "";
@@ -106,7 +107,7 @@ function ClanDetails() {
                     <div><span>War Frequency</span><strong>{formatWarFrequency(details.warFrequency ?? details.war_frequency)}</strong></div>
                     <div><span>Clan Points</span><strong>{details.clanPoints ?? details.clan_points ?? 0}</strong></div>
                     <div><span>Required League</span><strong>{requirements[0] ?? 0}</strong></div>
-                    <div><span>Required Builder Trophies</span><strong>{requirements[1] ?? 0}</strong></div>
+                    <div><span>Required Builder Base League</span><strong>{formatBuilderBaseLeague(requirements[1] ?? 0)}</strong></div>
                     <div><span>Required Town Hall</span><strong>{requirements[2] ?? 0}</strong></div>
                 </div>
 

--- a/frontend/src/LookingForClan.jsx
+++ b/frontend/src/LookingForClan.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate, useOutletContext, useSearchParams } from "react-router-dom";
+import { formatBuilderBaseLeague } from "./utils/builderBaseLeagues";
 import { formatWarFrequency, WAR_FREQUENCY_OPTIONS } from "./utils/warFrequency";
 import usePageTitle from "./hooks/usePageTitle"
 import LoadingScreen from "./components/LoadingScreen";
@@ -575,6 +576,7 @@ return (
             <div className="listing-stats">
               <p><strong>Townhall:</strong> {clan.requirements?.[2] ?? "?"}</p>
               <p><strong>League:</strong> {clan.requirements?.[0] ?? "?"}</p>
+              <p><strong>Builder League:</strong> {formatBuilderBaseLeague(clan.requirements?.[1] ?? 0)}</p>
               {clan.clan_info?.warFrequency !== "unknown" &&
                 <p><strong>War Freq:</strong> {formatWarFrequency(clan.clan_info?.warFrequency)}</p>
               }

--- a/frontend/src/Recruiter.jsx
+++ b/frontend/src/Recruiter.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useOutletContext } from "react-router-dom";
+import { builderBaseLeagueOptions } from "./utils/builderBaseLeagues";
 import { leagueOptions } from "./utils/recruiter";
 import { LISTING_STATUS_CHANGED_EVENT } from "./utils/appEvents";
 import usePageTitle from "./hooks/usePageTitle"
@@ -257,17 +258,19 @@ function Recruiter() {
             </div>
 
             <div className="recruiter-field">
-              <label htmlFor="builderleagues">Required Builder Trophies</label>
-              <input
+              <label htmlFor="builderleagues">Required Builder Base League</label>
+              <select
                 id="builderleagues"
-                type="number"
                 name="builderleagues"
                 value={requiredBuilderLeague}
                 onChange={(e) => setRequiredBuilderLeague(Number(e.target.value))}
-                max={6700}
-                min={0}
-                placeholder="Minimum trophies (e.g. 3200)"
-              />
+              >
+                {builderBaseLeagueOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
 
@@ -417,19 +420,21 @@ function Recruiter() {
               </div>
 
               <div className="recruiter-field">
-                <label htmlFor="builderleagues">Required Builder Trophies</label>
-                <input
+                <label htmlFor="builderleagues">Required Builder Base League</label>
+                <select
                   id="builderleagues"
-                  type="number"
                   name="builderleagues"
                   value={requiredBuilderLeague}
                   onChange={(e) =>
                     setRequiredBuilderLeague(Number(e.target.value))
                   }
-                  max={6700}
-                  min={0}
-                  placeholder="Minimum trophies (e.g. 3200)"
-                />
+                >
+                  {builderBaseLeagueOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div className="recruiter-field recruiter-field-full">

--- a/frontend/src/utils/builderBaseLeagues.js
+++ b/frontend/src/utils/builderBaseLeagues.js
@@ -1,0 +1,54 @@
+export const builderBaseLeagueOptions = [
+  { value: 0, label: "No Builder Base Requirement" },
+  { value: 1, label: "Wood V" },
+  { value: 2, label: "Wood IV" },
+  { value: 3, label: "Wood III" },
+  { value: 4, label: "Wood II" },
+  { value: 5, label: "Wood I" },
+  { value: 6, label: "Clay V" },
+  { value: 7, label: "Clay IV" },
+  { value: 8, label: "Clay III" },
+  { value: 9, label: "Clay II" },
+  { value: 10, label: "Clay I" },
+  { value: 11, label: "Stone V" },
+  { value: 12, label: "Stone IV" },
+  { value: 13, label: "Stone III" },
+  { value: 14, label: "Stone II" },
+  { value: 15, label: "Stone I" },
+  { value: 16, label: "Copper V" },
+  { value: 17, label: "Copper IV" },
+  { value: 18, label: "Copper III" },
+  { value: 19, label: "Copper II" },
+  { value: 20, label: "Copper I" },
+  { value: 21, label: "Brass III" },
+  { value: 22, label: "Brass II" },
+  { value: 23, label: "Brass I" },
+  { value: 24, label: "Iron III" },
+  { value: 25, label: "Iron II" },
+  { value: 26, label: "Iron I" },
+  { value: 27, label: "Steel III" },
+  { value: 28, label: "Steel II" },
+  { value: 29, label: "Steel I" },
+  { value: 30, label: "Titanium III" },
+  { value: 31, label: "Titanium II" },
+  { value: 32, label: "Titanium I" },
+  { value: 33, label: "Platinum III" },
+  { value: 34, label: "Platinum II" },
+  { value: 35, label: "Platinum I" },
+  { value: 36, label: "Emerald III" },
+  { value: 37, label: "Emerald II" },
+  { value: 38, label: "Emerald I" },
+  { value: 39, label: "Ruby III" },
+  { value: 40, label: "Ruby II" },
+  { value: 41, label: "Ruby I" },
+  { value: 42, label: "Diamond" }
+];
+
+const builderBaseLeagueLabels = new Map(
+  builderBaseLeagueOptions.map((option) => [option.value, option.label])
+);
+
+export function formatBuilderBaseLeague(value) {
+  const leagueId = Number(value);
+  return builderBaseLeagueLabels.get(leagueId) || "Unknown";
+}

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -3,6 +3,7 @@
 from flask import Blueprint, jsonify, request, session
 
 from ..config import headers
+from ..services.builder_base_leagues import BUILDER_BASE_LEAGUE_MAX_ID
 from ..services.maxtownhall import refresh
 from ..services.rate_limiter import is_rate_limited
 from ..services.recruiter_listing import (
@@ -27,7 +28,6 @@ RECRUITER_ACTION_RATE_LIMITS = {
     "new": 1,
     "update": 2,
 }
-MAX_BUILDER_BASE_TROPHIES = 10000
 NEW_LISTING_FIELDS = {
     "status",
     "requiredLeague",
@@ -156,7 +156,7 @@ def _validate_recruiter_payload(data):
         data,
         "requiredBuilderLeague",
         min_value=0,
-        max_value=MAX_BUILDER_BASE_TROPHIES,
+        max_value=BUILDER_BASE_LEAGUE_MAX_ID,
     )
     normalized["requiredTownhall"] = required_int(
         data,

--- a/scripts/migrate_builder_base_trophies_to_leagues.py
+++ b/scripts/migrate_builder_base_trophies_to_leagues.py
@@ -3,21 +3,21 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 import sys
+from pathlib import Path
 
 PACKAGE_PARENT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PACKAGE_PARENT))
 
-from ClashRecruit.services.builder_base_leagues import (  # noqa: E402
-    BUILDER_BASE_LEAGUE_MAX_ID,
-    builder_base_league_id_from_trophies,
-)
-from ClashRecruit.services.mongo_db_client import get_clan_collection  # noqa: E402
-
 
 def migrate_builder_base_requirements(*, apply: bool) -> int:
     """Convert legacy trophy values in ``requirements.1`` to league ids."""
+    from ClashRecruit.services.builder_base_leagues import (
+        BUILDER_BASE_LEAGUE_MAX_ID,
+        builder_base_league_id_from_trophies,
+    )
+    from ClashRecruit.services.mongo_db_client import get_clan_collection
+
     clan_collection = get_clan_collection()
     query = {"requirements.1": {"$gt": BUILDER_BASE_LEAGUE_MAX_ID}}
     documents = clan_collection.find(query, {"_id": 1, "requirements": 1})

--- a/scripts/migrate_builder_base_trophies_to_leagues.py
+++ b/scripts/migrate_builder_base_trophies_to_leagues.py
@@ -1,0 +1,68 @@
+"""Convert stored Builder Base trophy requirements to league ids."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PACKAGE_PARENT))
+
+from ClashRecruit.services.builder_base_leagues import (  # noqa: E402
+    BUILDER_BASE_LEAGUE_MAX_ID,
+    builder_base_league_id_from_trophies,
+)
+from ClashRecruit.services.mongo_db_client import get_clan_collection  # noqa: E402
+
+
+def migrate_builder_base_requirements(*, apply: bool) -> int:
+    """Convert legacy trophy values in ``requirements.1`` to league ids."""
+    clan_collection = get_clan_collection()
+    query = {"requirements.1": {"$gt": BUILDER_BASE_LEAGUE_MAX_ID}}
+    documents = clan_collection.find(query, {"_id": 1, "requirements": 1})
+
+    migrated_count = 0
+    for document in documents:
+        requirements = list(document.get("requirements") or [])
+        if len(requirements) < 2:
+            continue
+
+        old_value = requirements[1]
+        new_value = builder_base_league_id_from_trophies(
+            old_value,
+            zero_as_no_requirement=True,
+        )
+        requirements[1] = new_value
+        migrated_count += 1
+
+        print(f"{document['_id']}: {old_value} -> {new_value}")
+        if apply:
+            clan_collection.update_one(
+                {"_id": document["_id"]},
+                {"$set": {"requirements": requirements}},
+            )
+
+    mode = "updated" if apply else "would update"
+    print(f"{mode} {migrated_count} clan listing(s).")
+    return migrated_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert legacy requirements.1 Builder Base trophy values "
+            "to Builder Base league ids."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write converted values to MongoDB. Omit for a dry run.",
+    )
+    args = parser.parse_args()
+    migrate_builder_base_requirements(apply=args.apply)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/builder_base_leagues.py
+++ b/services/builder_base_leagues.py
@@ -1,0 +1,88 @@
+"""Builder Base league helpers."""
+
+from bisect import bisect_right
+from typing import Final
+
+BUILDER_BASE_LEAGUES: Final[list[tuple[int, str, int]]] = [
+    (1, "Wood V", 0),
+    (2, "Wood IV", 100),
+    (3, "Wood III", 200),
+    (4, "Wood II", 300),
+    (5, "Wood I", 400),
+    (6, "Clay V", 500),
+    (7, "Clay IV", 600),
+    (8, "Clay III", 700),
+    (9, "Clay II", 800),
+    (10, "Clay I", 900),
+    (11, "Stone V", 1000),
+    (12, "Stone IV", 1100),
+    (13, "Stone III", 1200),
+    (14, "Stone II", 1300),
+    (15, "Stone I", 1400),
+    (16, "Copper V", 1500),
+    (17, "Copper IV", 1600),
+    (18, "Copper III", 1700),
+    (19, "Copper II", 1800),
+    (20, "Copper I", 1900),
+    (21, "Brass III", 2000),
+    (22, "Brass II", 2200),
+    (23, "Brass I", 2400),
+    (24, "Iron III", 2600),
+    (25, "Iron II", 2800),
+    (26, "Iron I", 3000),
+    (27, "Steel III", 3200),
+    (28, "Steel II", 3400),
+    (29, "Steel I", 3600),
+    (30, "Titanium III", 3800),
+    (31, "Titanium II", 4000),
+    (32, "Titanium I", 4200),
+    (33, "Platinum III", 4400),
+    (34, "Platinum II", 4600),
+    (35, "Platinum I", 4800),
+    (36, "Emerald III", 5000),
+    (37, "Emerald II", 5200),
+    (38, "Emerald I", 5400),
+    (39, "Ruby III", 5600),
+    (40, "Ruby II", 5800),
+    (41, "Ruby I", 6000),
+    (42, "Diamond", 6200),
+]
+
+BUILDER_BASE_LEAGUE_MAX_ID: Final[int] = BUILDER_BASE_LEAGUES[-1][0]
+_BUILDER_BASE_THRESHOLDS: Final[list[int]] = [
+    threshold for _, _, threshold in BUILDER_BASE_LEAGUES
+]
+_BUILDER_BASE_NAMES_BY_ID: Final[dict[int, str]] = {
+    league_id: name for league_id, name, _ in BUILDER_BASE_LEAGUES
+}
+
+
+def builder_base_league_id_from_trophies(
+    trophies: object,
+    *,
+    zero_as_no_requirement: bool = False,
+) -> int:
+    """Return the Builder Base league id for a trophy value."""
+    try:
+        trophy_count = int(trophies)
+    except (TypeError, ValueError):
+        return 0 if zero_as_no_requirement else 1
+
+    if trophy_count <= 0 and zero_as_no_requirement:
+        return 0
+    if trophy_count < 0:
+        trophy_count = 0
+
+    return bisect_right(_BUILDER_BASE_THRESHOLDS, trophy_count)
+
+
+def builder_base_league_name(league_id: object) -> str:
+    """Return a display label for a Builder Base league id."""
+    try:
+        normalized_id = int(league_id)
+    except (TypeError, ValueError):
+        return "No Builder Base Requirement"
+
+    if normalized_id == 0:
+        return "No Builder Base Requirement"
+    return _BUILDER_BASE_NAMES_BY_ID.get(normalized_id, "Unknown")

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -8,13 +8,13 @@ from celery.signals import worker_ready
 from ..clash_http_client import ClashApiError
 from ..clash_http_client import get as clash_get
 from ..config import headers
+from .builder_base_leagues import builder_base_league_id_from_trophies
 from .celery_app import app
 from .mongo_db_client import (
     get_clan_collection,
     get_import_state_collection,
     get_location_collection,
 )
-from .builder_base_leagues import builder_base_league_id_from_trophies
 
 DISCOVERY_STALE_AFTER = timedelta(hours=6)
 IMPORTED_CLAN_RETENTION = timedelta(days=3)

--- a/services/import_clash_api_clans.py
+++ b/services/import_clash_api_clans.py
@@ -14,6 +14,7 @@ from .mongo_db_client import (
     get_import_state_collection,
     get_location_collection,
 )
+from .builder_base_leagues import builder_base_league_id_from_trophies
 
 DISCOVERY_STALE_AFTER = timedelta(hours=6)
 IMPORTED_CLAN_RETENTION = timedelta(days=3)
@@ -218,6 +219,10 @@ def _extract_requirements(
         if detail_clan.get("requiredBuilderBaseTrophies") is not None
         else search_clan.get("requiredBuilderBaseTrophies", 0)
     )
+    required_builder_league = builder_base_league_id_from_trophies(
+        required_builder_trophies,
+        zero_as_no_requirement=True,
+    )
     required_townhall = (
         detail_clan.get("requiredTownhallLevel")
         if detail_clan.get("requiredTownhallLevel") is not None
@@ -225,7 +230,7 @@ def _extract_requirements(
     )
     return [
         required_league or 0,
-        required_builder_trophies or 0,
+        required_builder_league,
         required_townhall or 0,
     ]
 

--- a/services/recruitee_search.py
+++ b/services/recruitee_search.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..routes.validation import RequestValidationError
+from .builder_base_leagues import builder_base_league_id_from_trophies
 
 MATCHMAKING_SESSION_FIELDS = {
     "player_league": "requirements.0",
@@ -78,6 +79,11 @@ def get_matchmaking_base_query(
         if value is None:
             return {}
         stats[query_key] = _session_int(value, session_key)
+
+    if "requirements.1" in stats:
+        stats["requirements.1"] = builder_base_league_id_from_trophies(
+            stats["requirements.1"],
+        )
 
     return {query_key: {"$lte": value} for query_key, value in stats.items()}
 

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -86,7 +86,7 @@ def test_recruitee_get_filters_logged_in_player_with_total(
 
     expected_query = {
         "requirements.0": {"$lte": 5},
-        "requirements.1": {"$lte": 2200},
+        "requirements.1": {"$lte": 22},
         "requirements.2": {"$lte": 13},
         "expires": collection.find_query["expires"],
     }
@@ -169,7 +169,7 @@ def test_recruitee_get_normalizes_string_matchmaking_stats(
         collection,
         {
             "requirements.0": {"$lte": 5},
-            "requirements.1": {"$lte": 2200},
+            "requirements.1": {"$lte": 22},
             "requirements.2": {"$lte": 13},
         },
     )

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -126,7 +126,7 @@ def test_recruiter_get_returns_existing_listing(
     set_session,
 ):
     existing = {
-        "requirements": [4, 1800, 12],
+        "requirements": [4, 19, 12],
         "clan_info": {"description": "existing_description"},
         "expires": "existing_expiry",
     }
@@ -139,7 +139,7 @@ def test_recruiter_get_returns_existing_listing(
     assert response.status_code == 200
     assert response.get_json() == {
         "oldRequiredLeague": 4,
-        "oldRequiredBuilderLeague": 1800,
+        "oldRequiredBuilderLeague": 19,
         "oldRequiredTownhall": 12,
         "MAXTOWNHALL": 17,
         "clanDescription": "existing_description",
@@ -203,7 +203,7 @@ def test_recruiter_post_creates_new_listing(
         json={
             "status": "new",
             "requiredLeague": 5,
-            "requiredBuilderLeague": 2400,
+            "requiredBuilderLeague": 23,
             "requiredTownhall": 13,
             "description": "new_description",
         },
@@ -213,7 +213,7 @@ def test_recruiter_post_creates_new_listing(
     assert response.status_code == 200
     assert response_json["message"] == "Listing created successfully."
     assert response_json["source"] == "live_listing"
-    assert response_json["requirements"] == [5, 2400, 13]
+    assert response_json["requirements"] == [5, 23, 13]
     assert response_json["name"] == "test_clan"
     assert response_json["clan_tag"] == "TEST123"
     assert response_json["player_tag"] == "PLAYER123"
@@ -221,7 +221,7 @@ def test_recruiter_post_creates_new_listing(
     assert response_json["expires"] == response_json["status"]
 
     assert collection.inserted_doc["source"] == "live_listing"
-    assert collection.inserted_doc["requirements"] == [5, 2400, 13]
+    assert collection.inserted_doc["requirements"] == [5, 23, 13]
     assert collection.inserted_doc["clan_info"]["description"] == (
         "new_description"
     )
@@ -248,7 +248,7 @@ def test_recruiter_post_create_returns_400_without_player_tag(
         json={
             "status": "new",
             "requiredLeague": 5,
-            "requiredBuilderLeague": 2400,
+            "requiredBuilderLeague": 23,
             "requiredTownhall": 13,
             "description": "new_description",
         },
@@ -273,7 +273,7 @@ def test_recruiter_post_updates_listing_and_refreshes_expiry(
         json={
             "status": "update",
             "requiredLeague": 6,
-            "requiredBuilderLeague": 2600,
+            "requiredBuilderLeague": 24,
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": True,
@@ -289,7 +289,7 @@ def test_recruiter_post_updates_listing_and_refreshes_expiry(
         "source": {"$ne": "clash_api_import"},
     }
     assert set_doc["source"] == "live_listing"
-    assert set_doc["requirements"] == [6, 2600, 14]
+    assert set_doc["requirements"] == [6, 24, 14]
     assert set_doc["clan_info.description"] == "updated_description"
     assert isinstance(set_doc["last_updated"], datetime)
     assert isinstance(set_doc["expires"], datetime)
@@ -314,7 +314,7 @@ def test_recruiter_post_updates_listing_and_preserves_existing_expiry(
         json={
             "status": "update",
             "requiredLeague": 6,
-            "requiredBuilderLeague": 2600,
+            "requiredBuilderLeague": 24,
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": False,
@@ -334,7 +334,7 @@ def test_recruiter_post_updates_listing_and_preserves_existing_expiry(
         "source": {"$ne": "clash_api_import"},
     }
     assert set_doc["source"] == "live_listing"
-    assert set_doc["requirements"] == [6, 2600, 14]
+    assert set_doc["requirements"] == [6, 24, 14]
     assert set_doc["clan_info.description"] == "updated_description"
     assert "expires" not in set_doc
 
@@ -455,7 +455,7 @@ def test_recruiter_post_returns_400_for_bad_requirement_type(
         json={
             "status": "new",
             "requiredLeague": "high",
-            "requiredBuilderLeague": 2400,
+            "requiredBuilderLeague": 23,
             "requiredTownhall": 13,
         },
     )
@@ -481,7 +481,7 @@ def test_recruiter_post_returns_400_for_unknown_new_field(
         json={
             "status": "new",
             "requiredLeague": 5,
-            "requiredBuilderLeague": 2400,
+            "requiredBuilderLeague": 23,
             "requiredTownhall": 13,
             "description": "new_description",
             "expiry": "not_allowed_for_new",
@@ -537,7 +537,7 @@ def test_recruiter_post_returns_400_for_huge_builder_league(
 
     assert response.status_code == 400
     assert response.get_json() == {
-        "error": "requiredBuilderLeague must be at most 10000."
+        "error": "requiredBuilderLeague must be at most 42."
     }
     assert collection.inserted_doc is None
 
@@ -556,7 +556,7 @@ def test_recruiter_post_returns_400_for_townhall_above_current_max(
         json={
             "status": "new",
             "requiredLeague": 5,
-            "requiredBuilderLeague": 2600,
+            "requiredBuilderLeague": 24,
             "requiredTownhall": 18,
         },
     )
@@ -580,7 +580,7 @@ def test_recruiter_update_allows_two_actions_per_minute(
     payload = {
         "status": "update",
         "requiredLeague": 6,
-        "requiredBuilderLeague": 2600,
+        "requiredBuilderLeague": 24,
         "requiredTownhall": 14,
         "description": "updated_description",
         "updateExpiry": False,
@@ -606,7 +606,7 @@ def test_recruiter_update_rate_limit_blocks_third_action_before_service(
     payload = {
         "status": "update",
         "requiredLeague": 6,
-        "requiredBuilderLeague": 2600,
+        "requiredBuilderLeague": 24,
         "requiredTownhall": 14,
         "description": "updated_description",
         "updateExpiry": False,
@@ -644,7 +644,7 @@ def test_recruiter_create_rate_limit_blocks_second_action_before_service(
     payload = {
         "status": "new",
         "requiredLeague": 5,
-        "requiredBuilderLeague": 2400,
+        "requiredBuilderLeague": 23,
         "requiredTownhall": 13,
         "description": "new_description",
     }
@@ -704,7 +704,7 @@ def test_recruiter_delete_still_runs_after_limited_updates(
     update_payload = {
         "status": "update",
         "requiredLeague": 6,
-        "requiredBuilderLeague": 2600,
+        "requiredBuilderLeague": 24,
         "requiredTownhall": 14,
         "description": "updated_description",
         "updateExpiry": False,

--- a/tests/test_builder_base_leagues_service.py
+++ b/tests/test_builder_base_leagues_service.py
@@ -1,0 +1,32 @@
+from ClashRecruit.services.builder_base_leagues import (
+    builder_base_league_id_from_trophies,
+    builder_base_league_name,
+)
+
+
+def test_builder_base_league_id_from_trophies_maps_thresholds():
+    assert builder_base_league_id_from_trophies(0) == 1
+    assert builder_base_league_id_from_trophies(99) == 1
+    assert builder_base_league_id_from_trophies(100) == 2
+    assert builder_base_league_id_from_trophies(1200) == 13
+    assert builder_base_league_id_from_trophies(2200) == 22
+    assert builder_base_league_id_from_trophies(6200) == 42
+    assert builder_base_league_id_from_trophies(9999) == 42
+
+
+def test_builder_base_league_id_from_trophies_can_treat_zero_as_no_requirement():
+    assert builder_base_league_id_from_trophies(
+        0,
+        zero_as_no_requirement=True,
+    ) == 0
+    assert builder_base_league_id_from_trophies(
+        1,
+        zero_as_no_requirement=True,
+    ) == 1
+
+
+def test_builder_base_league_name_formats_known_values():
+    assert builder_base_league_name(0) == "No Builder Base Requirement"
+    assert builder_base_league_name(1) == "Wood V"
+    assert builder_base_league_name(42) == "Diamond"
+    assert builder_base_league_name(999) == "Unknown"

--- a/tests/test_builder_base_leagues_service.py
+++ b/tests/test_builder_base_leagues_service.py
@@ -14,7 +14,7 @@ def test_builder_base_league_id_from_trophies_maps_thresholds():
     assert builder_base_league_id_from_trophies(9999) == 42
 
 
-def test_builder_base_league_id_from_trophies_can_treat_zero_as_no_requirement():
+def test_builder_base_league_id_from_trophies_can_map_zero_to_none():
     assert builder_base_league_id_from_trophies(
         0,
         zero_as_no_requirement=True,

--- a/tests/test_import_clash_api_clans_service.py
+++ b/tests/test_import_clash_api_clans_service.py
@@ -32,7 +32,7 @@ def test_extract_requirements_prefers_detail_values_over_search_values():
         },
     )
 
-    assert requirements == [0, 2400, 13]
+    assert requirements == [0, 23, 13]
 
 
 def test_extract_requirements_uses_search_fallbacks_and_zero_defaults():
@@ -41,7 +41,7 @@ def test_extract_requirements_uses_search_fallbacks_and_zero_defaults():
             "requiredBuilderBaseTrophies": 1200,
             "requiredTownhallLevel": 10,
         }
-    ) == [0, 1200, 10]
+    ) == [0, 13, 10]
     assert import_service._extract_requirements() == [0, 0, 0]
 
 
@@ -204,7 +204,7 @@ def test_build_enriched_import_document_uses_detail_with_search_fallbacks(
         "name": "test_clan",
         "source": "clash_api_import",
         "seed_key": "name:a|limit:10",
-        "requirements": [0, 2200, 13],
+        "requirements": [0, 22, 13],
         "requirements_source": "clash_api",
         "last_discovered": frozen_now,
         "last_updated": frozen_now,
@@ -755,7 +755,7 @@ def test_get_imported_clan_fetches_caches_and_returns_imported_document(
     assert upsert is True
     assert set_doc["clan_tag"] == "TEST123"
     assert set_doc["name"] == "test_clan"
-    assert set_doc["requirements"] == [0, 2200, 13]
+    assert set_doc["requirements"] == [0, 22, 13]
     assert set_doc["last_discovered"] == frozen_now
     assert set_doc["last_updated"] == frozen_now
     assert set_doc["expires"] == (

--- a/tests/test_recruitee_search_service.py
+++ b/tests/test_recruitee_search_service.py
@@ -71,7 +71,7 @@ def test_matchmaking_base_query_uses_logged_in_player_stats():
 
     assert query == {
         "requirements.0": {"$lte": 5},
-        "requirements.1": {"$lte": 2200},
+        "requirements.1": {"$lte": 22},
         "requirements.2": {"$lte": 13},
     }
 

--- a/tests/test_recruiter_api.py
+++ b/tests/test_recruiter_api.py
@@ -22,7 +22,7 @@ def test_pull_clan_requirements_success(monkeypatch) -> None:
 
     requirements = user.pull_clan_requirements()
 
-    assert requirements == [0, 2300, 12]
+    assert requirements == [0, 22, 12]
     mock_get.assert_called_once_with(
         f"https://api.clashofclans.com/v1/clans/%23{KNOWN_STABLE_TAG}",
         headers=MOCK_HEADERS,

--- a/tests/test_recruiter_listing_service.py
+++ b/tests/test_recruiter_listing_service.py
@@ -86,7 +86,7 @@ def setup_recruiter_listing(monkeypatch, collection):
 
 def test_get_recruiter_listing_page_returns_existing_listing(monkeypatch):
     existing = {
-        "requirements": [4, 1800, 12],
+        "requirements": [4, 19, 12],
         "clan_info": {"description": "existing_description"},
         "expires": "existing_expiry",
     }
@@ -100,7 +100,7 @@ def test_get_recruiter_listing_page_returns_existing_listing(monkeypatch):
     assert status_code == 200
     assert payload == {
         "oldRequiredLeague": 4,
-        "oldRequiredBuilderLeague": 1800,
+        "oldRequiredBuilderLeague": 19,
         "oldRequiredTownhall": 12,
         "MAXTOWNHALL": 17,
         "clanDescription": "existing_description",
@@ -144,7 +144,7 @@ def test_create_recruiter_listing_inserts_live_listing(monkeypatch):
         "PLAYER123",
         {
             "requiredLeague": 5,
-            "requiredBuilderLeague": 2400,
+            "requiredBuilderLeague": 23,
             "requiredTownhall": 13,
             "description": "new_description",
         },
@@ -154,7 +154,7 @@ def test_create_recruiter_listing_inserts_live_listing(monkeypatch):
     assert status_code == 200
     assert payload["message"] == "Listing created successfully."
     assert payload["source"] == "live_listing"
-    assert payload["requirements"] == [5, 2400, 13]
+    assert payload["requirements"] == [5, 23, 13]
     assert payload["name"] == "test_clan"
     assert payload["clan_tag"] == "TEST123"
     assert payload["player_tag"] == "PLAYER123"
@@ -179,7 +179,7 @@ def test_update_recruiter_listing_refreshes_expiry(monkeypatch):
         "TEST123",
         {
             "requiredLeague": 6,
-            "requiredBuilderLeague": 2600,
+            "requiredBuilderLeague": 24,
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": True,
@@ -200,7 +200,7 @@ def test_update_recruiter_listing_refreshes_expiry(monkeypatch):
     }
     assert set_doc == {
         "source": "live_listing",
-        "requirements": [6, 2600, 14],
+        "requirements": [6, 24, 14],
         "clan_info.description": "updated_description",
         "last_updated": FROZEN_NOW,
         "expires": expiry,
@@ -220,7 +220,7 @@ def test_update_recruiter_listing_preserves_existing_expiry(monkeypatch):
         "TEST123",
         {
             "requiredLeague": 6,
-            "requiredBuilderLeague": 2600,
+            "requiredBuilderLeague": 24,
             "requiredTownhall": 14,
             "description": "updated_description",
             "updateExpiry": False,


### PR DESCRIPTION
## Summary
- replace Builder Base trophy inputs with Builder Base League dropdowns for recruiter listings
- map outdated Clash API `requiredBuilderBaseTrophies` values into Builder Base league ids before storing
- display Builder Base League labels on clan listing cards and detail pages
- update matchmaking to compare player Builder Base trophies against stored league requirements
- add a one-shot migration script for converting legacy stored trophy requirements to league ids

## Database
- migrated existing `requirements[1]` values from Builder Base trophies to Builder Base league ids
- verified the migration dry-run reports 0 remaining legacy trophy values

## Tests
- `venv/bin/python -m pytest tests/test_builder_base_leagues_service.py tests/test_recruiter_api.py tests/test_import_clash_api_clans_service.py tests/test_recruitee_search_service.py tests/routes/test_recruiter_route.py tests/routes/test_recruitee_route.py tests/test_recruiter_listing_service.py`
- `npm run build`