### PR TITLE
feat: Updated header to split up dropdown menu into header content an…

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,7 +1,10 @@
 import './Header.css';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
-import { AUTH_STATUS_CHANGED_EVENT } from '../utils/appEvents';
+import {
+    AUTH_STATUS_CHANGED_EVENT,
+    OPEN_SAVED_CLANS_EVENT
+} from '../utils/appEvents';
 import logoWithoutText from '../assets/logo_without_text.png';
 
 function Header({ user , hasActiveListing}) {
@@ -48,15 +51,12 @@ function Header({ user , hasActiveListing}) {
     const handleSignin = () => {
         setOpen(false);
     };
-    
-    const handleListings = () => {
+
+    const handleSavedClans = () => {
         setOpen(false);
+        window.dispatchEvent(new CustomEvent(OPEN_SAVED_CLANS_EVENT));
     };
     
-    const handleFindClan = () => {
-        setOpen(false);
-    }
-
     return (
         <header className="header">
             <Link to='/' className='logo'>
@@ -64,10 +64,18 @@ function Header({ user , hasActiveListing}) {
             </Link>
 
             <div className="header-right">
+                <Link to="/looking-for-clan" className="header-nav-link">
+                    Find a Clan
+                </Link>
                 {isLoggedIn && (
-                    <Link to="/dashboard" className="header-nav-link">
-                        Dashboard
-                    </Link>
+                    <>
+                        <Link to="/dashboard" className="header-nav-link">
+                            Dashboard
+                        </Link>
+                        <Link to="/recruit" className="header-nav-link">
+                            {hasActiveListing ? "View Listing" : "Recruit"}
+                        </Link>
+                    </>
                 )}
                 <span className="header-divider" aria-hidden="true"></span>
                 <div className="dropdown" ref={dropdownRef}>
@@ -89,18 +97,15 @@ function Header({ user , hasActiveListing}) {
                         className={`dropdown-menu ${open ? "is-open" : "is-closed"}`}
                         aria-hidden={!open}
                     >
-                    <Link to="/looking-for-clan" onClick={handleFindClan} className="dropdown-item">
-                            Find a Clan
-                    </Link>
-                        {hasActiveListing && (
-                            <Link to="/recruit" onClick={handleListings} className="dropdown-item">
-                                My Listings
-                            </Link>
-                        )}
                         {isLoggedIn ?(
-                            <button onClick={handleLogout} className="dropdown-item">
-                                Logout
-                            </button>
+                            <>
+                                <button type="button" onClick={handleSavedClans} className="dropdown-item">
+                                    Saved Clans
+                                </button>
+                                <button type="button" onClick={handleLogout} className="dropdown-item">
+                                    Logout
+                                </button>
+                            </>
                         ): (
                             <Link to="/login" onClick={handleSignin} className="dropdown-item"> 
                                 Login

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,10 +1,12 @@
 import Header from './Header.jsx';
 import Footer from './Footer.jsx'
+import SavedClansModal from './SavedClansModal.jsx';
 import { Outlet } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import {
     AUTH_STATUS_CHANGED_EVENT,
-    LISTING_STATUS_CHANGED_EVENT
+    LISTING_STATUS_CHANGED_EVENT,
+    OPEN_SAVED_CLANS_EVENT
 } from '../utils/appEvents';
 
 function normalizeUser(userValue) {
@@ -76,6 +78,7 @@ const Layout = () => {
         () => storedShellState.townhallWeaponLevel
     );
     const [sessionStateLoaded, setSessionStateLoaded] = useState(false);
+    const [savedClansModalOpen, setSavedClansModalOpen] = useState(false);
 
     useEffect(() => {
         let isMounted = true;
@@ -137,14 +140,20 @@ const Layout = () => {
             loadSessionState({ resetBeforeLoad: true });
         };
 
+        const handleOpenSavedClans = () => {
+            setSavedClansModalOpen(true);
+        };
+
         loadSessionState();
         window.addEventListener(LISTING_STATUS_CHANGED_EVENT, handleListingStatusChanged);
         window.addEventListener(AUTH_STATUS_CHANGED_EVENT, handleAuthStatusChanged);
+        window.addEventListener(OPEN_SAVED_CLANS_EVENT, handleOpenSavedClans);
 
         return () => {
             isMounted = false;
             window.removeEventListener(LISTING_STATUS_CHANGED_EVENT, handleListingStatusChanged);
             window.removeEventListener(AUTH_STATUS_CHANGED_EVENT, handleAuthStatusChanged);
+            window.removeEventListener(OPEN_SAVED_CLANS_EVENT, handleOpenSavedClans);
         };
     }, []);
 
@@ -154,6 +163,10 @@ const Layout = () => {
             <main>
                 <Outlet context={{ user, townhall, townhallWeaponLevel, recruitStatus, hasActiveListing, sessionStateLoaded }} />
             </main>
+            <SavedClansModal
+                open={savedClansModalOpen}
+                onClose={() => setSavedClansModalOpen(false)}
+            />
             <Footer />
         </div>
     )

--- a/frontend/src/components/SavedClansModal.css
+++ b/frontend/src/components/SavedClansModal.css
@@ -1,0 +1,199 @@
+.saved-clans-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(22, 16, 11, 0.44);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 22px;
+    z-index: 1200;
+    box-sizing: border-box;
+}
+
+.saved-clans-modal {
+    width: min(640px, 100%);
+    max-height: 76vh;
+    overflow: hidden;
+    border: 1px solid #d4b985;
+    border-radius: 16px;
+    background: rgba(255, 251, 245, 0.98);
+    box-shadow: 0 18px 42px rgba(25, 16, 8, 0.24);
+    display: flex;
+    flex-direction: column;
+}
+
+.saved-clans-modal-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid #e8d6ba;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.saved-clans-modal-header h2 {
+    margin: 0;
+    font-size: 1.04rem;
+    color: #3b2a18;
+}
+
+.saved-clans-modal-close {
+    width: 30px;
+    height: 30px;
+    border: 1px solid #e5d4b8;
+    background: rgba(255, 253, 249, 0.95);
+    color: #6d5639;
+    border-radius: 8px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 1.05rem;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.saved-clans-modal-close:hover {
+    background: #fff6ea;
+    border-color: #d9be92;
+    color: #4f381f;
+}
+
+.saved-clans-modal-close:focus-visible {
+    outline: 2px solid #c8a04d;
+    outline-offset: 2px;
+}
+
+.saved-clans-modal-list {
+    overflow: auto;
+    padding: 10px 14px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    scroll-behavior: smooth;
+    overscroll-behavior: contain;
+}
+
+.saved-clans-item {
+    border-bottom: 1px solid rgba(208, 177, 133, 0.45);
+    background: transparent;
+    min-height: 44px;
+    padding: 9px 4px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.saved-clans-item:last-of-type {
+    border-bottom: none;
+}
+
+.saved-clans-item-content {
+    min-width: 0;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.saved-clans-item-clickable {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background-color 120ms ease, transform 120ms ease;
+}
+
+.saved-clans-item-clickable:hover {
+    background: rgba(255, 244, 224, 0.72);
+}
+
+.saved-clans-text {
+    min-width: 0;
+}
+
+.saved-clans-name {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #4d3218;
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.saved-clans-meta {
+    margin: 0;
+    font-size: 0.73rem;
+    color: #866846;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.saved-clans-row-icon {
+    flex: 0 0 auto;
+    color: #a6834d;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1;
+    opacity: 0.78;
+}
+
+.saved-clans-remove-btn {
+    flex: 0 0 auto;
+    border: none;
+    background: transparent;
+    color: #a6834d;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    font-weight: 800;
+    line-height: 1;
+    padding: 4px;
+    transition: color 120ms ease;
+}
+
+.saved-clans-remove-btn:hover:not(:disabled) {
+    color: #b33a32;
+}
+
+.saved-clans-remove-btn:disabled {
+    cursor: wait;
+    opacity: 0.56;
+}
+
+.saved-clans-remove-btn:focus-visible,
+.saved-clans-item-clickable:focus-visible {
+    outline: 2px solid #c8a04d;
+    outline-offset: 2px;
+}
+
+.saved-clans-empty {
+    margin: 0;
+    font-size: 0.82rem;
+    color: #7a5d3d;
+    line-height: 1.4;
+}
+
+.saved-clans-action-error {
+    margin: 0 0 8px;
+    border: 1px solid rgba(179, 58, 50, 0.28);
+    border-radius: 8px;
+    background: rgba(255, 239, 235, 0.82);
+    color: #8f3029;
+    padding: 8px 10px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.35;
+}

--- a/frontend/src/components/SavedClansModal.jsx
+++ b/frontend/src/components/SavedClansModal.jsx
@@ -1,0 +1,212 @@
+import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import './SavedClansModal.css';
+
+function normalizeSavedClanTag(tagValue) {
+    if (!tagValue) {
+        return null;
+    }
+
+    const normalized = String(tagValue).trim().replace(/^#+/, "");
+    if (!normalized) {
+        return null;
+    }
+
+    return normalized;
+}
+
+function SavedClansModal({ open, onClose }) {
+    const [savedClans, setSavedClans] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+    const [actionError, setActionError] = useState("");
+    const [removingSavedClanTag, setRemovingSavedClanTag] = useState("");
+
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        let isMounted = true;
+        setLoading(true);
+        setError("");
+        setActionError("");
+
+        fetch("/saved-clans", { credentials: "include" })
+            .then(async (res) => {
+                if (!res.ok) {
+                    throw new Error("Saved clans are temporarily unavailable.");
+                }
+
+                return res.json();
+            })
+            .then((data) => {
+                if (!isMounted) {
+                    return;
+                }
+
+                setSavedClans(Array.isArray(data.saved_clans) ? data.saved_clans : []);
+            })
+            .catch((requestError) => {
+                if (!isMounted) {
+                    return;
+                }
+
+                setSavedClans([]);
+                setError(requestError.message || "Saved clans are temporarily unavailable.");
+            })
+            .finally(() => {
+                if (isMounted) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        const previousOverflow = document.body.style.overflow;
+        const handleEscClose = (event) => {
+            if (event.key === "Escape") {
+                onClose();
+            }
+        };
+
+        document.body.style.overflow = "hidden";
+        window.addEventListener("keydown", handleEscClose);
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            window.removeEventListener("keydown", handleEscClose);
+        };
+    }, [open, onClose]);
+
+    const removeSavedClan = async (clanTag) => {
+        const normalizedTag = normalizeSavedClanTag(clanTag);
+        if (!normalizedTag || removingSavedClanTag) {
+            return;
+        }
+
+        setRemovingSavedClanTag(normalizedTag);
+        setActionError("");
+
+        try {
+            const response = await fetch(`/saved-clans/${encodeURIComponent(normalizedTag)}`, {
+                method: "DELETE",
+                credentials: "include",
+            });
+
+            if (!response.ok) {
+                throw new Error("Could not remove saved clan.");
+            }
+
+            setSavedClans((currentSavedClans) => (
+                currentSavedClans.filter((savedClan) => (
+                    normalizeSavedClanTag(savedClan.clan_tag) !== normalizedTag
+                ))
+            ));
+        } catch (requestError) {
+            setActionError(requestError.message || "Could not remove saved clan.");
+        } finally {
+            setRemovingSavedClanTag("");
+        }
+    };
+
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <div className="saved-clans-modal-overlay" onClick={onClose} role="presentation">
+            <section
+                className="saved-clans-modal"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Saved Clans"
+                onClick={(event) => event.stopPropagation()}
+            >
+                <header className="saved-clans-modal-header">
+                    <h2>Saved Clans</h2>
+                    <button
+                        type="button"
+                        className="saved-clans-modal-close"
+                        onClick={onClose}
+                        aria-label="Close saved clans modal"
+                    >
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </header>
+
+                <div className="saved-clans-modal-list">
+                    {loading && (
+                        <p className="saved-clans-empty">Loading saved clans...</p>
+                    )}
+                    {error && (
+                        <p className="saved-clans-empty">{error}</p>
+                    )}
+                    {actionError && (
+                        <p className="saved-clans-action-error">{actionError}</p>
+                    )}
+                    {!loading && !error && savedClans.length === 0 && (
+                        <p className="saved-clans-empty">Save clans from search to keep a shortlist here.</p>
+                    )}
+                    {!loading && !error && savedClans.map((savedClan, index) => {
+                        const savedClanTag = normalizeSavedClanTag(savedClan.clan_tag);
+                        const savedClanName = savedClan.name || savedClan.clan_info?.name || savedClanTag || "Saved Clan";
+                        const savedClanLocation = savedClan.clan_info?.location?.name;
+                        const savedClanMeta = savedClan.listing_available
+                            ? (savedClanLocation || "Listing active")
+                            : "Listing no longer available";
+                        const canOpenListing = Boolean(savedClan.listing_available && savedClanTag);
+                        const isRemoving = savedClanTag === removingSavedClanTag;
+
+                        return (
+                            <div key={savedClanTag || `${savedClanName}-${index}`} className="saved-clans-item">
+                                {canOpenListing ? (
+                                    <Link
+                                        to={`/looking-for-clan/${savedClanTag}`}
+                                        className="saved-clans-item-content saved-clans-item-clickable"
+                                        onClick={onClose}
+                                    >
+                                        <div className="saved-clans-text">
+                                            <p className="saved-clans-name">{savedClanName}</p>
+                                            <p className="saved-clans-meta">{savedClanMeta}</p>
+                                        </div>
+                                        <span className="saved-clans-row-icon" aria-hidden="true">&rsaquo;</span>
+                                    </Link>
+                                ) : (
+                                    <div className="saved-clans-item-content">
+                                        <div className="saved-clans-text">
+                                            <p className="saved-clans-name">{savedClanName}</p>
+                                            <p className="saved-clans-meta">{savedClanMeta}</p>
+                                        </div>
+                                    </div>
+                                )}
+                                {savedClanTag ? (
+                                    <button
+                                        type="button"
+                                        className="saved-clans-remove-btn"
+                                        onClick={() => removeSavedClan(savedClanTag)}
+                                        disabled={isRemoving}
+                                        aria-label={`Remove ${savedClanName} from saved clans`}
+                                        title="Remove saved clan"
+                                    >
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                ) : null}
+                            </div>
+                        );
+                    })}
+                </div>
+            </section>
+        </div>
+    );
+}
+
+export default SavedClansModal;

--- a/frontend/src/utils/appEvents.js
+++ b/frontend/src/utils/appEvents.js
@@ -1,2 +1,3 @@
 export const AUTH_STATUS_CHANGED_EVENT = "auth-status-changed";
 export const LISTING_STATUS_CHANGED_EVENT = "listing-status-changed";
+export const OPEN_SAVED_CLANS_EVENT = "open-saved-clans";


### PR DESCRIPTION
## Summary

Updates the header navigation and user dropdown behavior.

## Changes

- Moved `Find a Clan` out of the user dropdown and into the main header nav.
- Added a logged-in-only `Recruit` header link.
- Changes the recruit link label to `View Listing` when the user already has an active listing.
- Added `Saved Clans` to the logged-in user dropdown.
- Added a global Saved Clans modal that can open on top of any page.
- Kept the existing Dashboard saved clans behavior intact.
