### PR TITLE
fix ranked league tier metadata

### DIFF
--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -7,6 +7,7 @@ import usePageTitle from "./hooks/usePageTitle"
 import "./Landing.css";
 
 const leagueLabelByValue = new Map(leagueOptions.map((option) => [option.value, option.label]));
+const maxLeagueValue = Math.max(...leagueOptions.map((option) => option.value));
 
 function getLeagueLabel(leagueValue) {
     const parsedValue = Number(leagueValue);
@@ -15,7 +16,7 @@ function getLeagueLabel(leagueValue) {
         return `League ${leagueValue ?? "?"}`;
     }
 
-    return label === "Legend League" ? label : `${label}+`;
+    return parsedValue === maxLeagueValue ? label : `${label}+`;
 }
 
 function Landing() {

--- a/frontend/src/LookingForClan.jsx
+++ b/frontend/src/LookingForClan.jsx
@@ -1,6 +1,10 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate, useOutletContext, useSearchParams } from "react-router-dom";
-import { formatBuilderBaseLeague } from "./utils/builderBaseLeagues";
+import {
+  defaultBuilderBaseLeagueOptions,
+  normalizeBuilderBaseLeagueOptions
+} from "./utils/builderBaseLeagues";
+import { defaultLeagueOptions, normalizeLeagueOptions } from "./utils/recruiter";
 import { formatWarFrequency, WAR_FREQUENCY_OPTIONS } from "./utils/warFrequency";
 import usePageTitle from "./hooks/usePageTitle"
 import LoadingScreen from "./components/LoadingScreen";
@@ -67,6 +71,11 @@ function normalizeClanTag(tagValue) {
     }
 
     return normalized;
+}
+
+function formatBuilderBaseLeague(value, labels) {
+  const leagueId = Number(value);
+  return labels.get(leagueId) || "Unknown";
 }
 
 function buildFilterPayload(filters) {
@@ -157,6 +166,10 @@ function LookingForClan() {
     const [savingClanTag, setSavingClanTag] = useState("");
     const [copiedClanTag, setCopiedClanTag] = useState("");
     const [Locations, setLocations] = useState([]);
+    const [builderBaseLeagueOptions, setBuilderBaseLeagueOptions] = useState(
+      defaultBuilderBaseLeagueOptions
+    );
+    const [leagueOptions, setLeagueOptions] = useState(defaultLeagueOptions);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState("");
     const [filterError, setFilterError] = useState("");
@@ -168,6 +181,12 @@ function LookingForClan() {
     const searchParamsKey = searchParams.toString();
     const isLoggedIn = Boolean(user && user !== "Guest");
     const savedTagSet = new Set(savedClanTags);
+    const builderBaseLeagueLabels = useMemo(
+      () => new Map(
+        builderBaseLeagueOptions.map((option) => [option.value, option.label])
+      ),
+      [builderBaseLeagueOptions]
+    );
 
     useEffect(() => {
       filtersRef.current = Filters;
@@ -270,6 +289,19 @@ function LookingForClan() {
       setLocations(Array.isArray(locations) ? locations : [])
     }, []);
 
+    const getMetadata = useCallback(async () => {
+      const response = await fetch("/recruitee/metadata");
+      if (!response.ok) {
+        throw new Error("Failed to load metadata.");
+      }
+
+      const metadata = await response.json();
+      setBuilderBaseLeagueOptions(
+        normalizeBuilderBaseLeagueOptions(metadata.builderBaseLeagueOptions)
+      );
+      setLeagueOptions(normalizeLeagueOptions(metadata.leagueOptions));
+    }, []);
+
     const fetchClanPage = useCallback(async (page, filters, signal) => {
       const offset = (page - 1) * PAGE_SIZE;
       const url = `/recruitee?limit=${PAGE_SIZE}&offset=${offset}&includeTotal=1`;
@@ -332,7 +364,7 @@ function LookingForClan() {
         setLoadError("");
 
         try {
-          const loadJobs = [getLocations()];
+          const loadJobs = [getLocations(), getMetadata()];
           if (isLoggedIn) {
             loadJobs.push(getSavedClans());
           } else {
@@ -345,7 +377,7 @@ function LookingForClan() {
         }
       };
       loadData();
-    }, [isLoggedIn, getLocations, getSavedClans, sessionStateLoaded]);
+    }, [isLoggedIn, getLocations, getMetadata, getSavedClans, sessionStateLoaded]);
 
     useEffect(() => {
       if (!sessionStateLoaded) {
@@ -512,7 +544,14 @@ return (
 
       <label>
         Min League
-        <input type="number" name="minLeague" value={Filters.minLeague} onChange={handleFilterChange} min={0} max={34} />
+        <select name="minLeague" value={Filters.minLeague} onChange={handleFilterChange}>
+          <option value="">Any League</option>
+          {leagueOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
       </label>
 
       <label>
@@ -618,7 +657,7 @@ return (
             <div className="listing-stats">
               <p><strong>Townhall:</strong> {clan.requirements?.[2] ?? "?"}</p>
               <p><strong>League:</strong> {clan.requirements?.[0] ?? "?"}</p>
-              <p><strong>Builder League:</strong> {formatBuilderBaseLeague(clan.requirements?.[1] ?? 0)}</p>
+              <p><strong>Builder League:</strong> {formatBuilderBaseLeague(clan.requirements?.[1] ?? 0, builderBaseLeagueLabels)}</p>
               {clan.clan_info?.warFrequency !== "unknown" &&
                 <p><strong>War Freq:</strong> {formatWarFrequency(clan.clan_info?.warFrequency)}</p>
               }

--- a/frontend/src/Recruiter.jsx
+++ b/frontend/src/Recruiter.jsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useOutletContext } from "react-router-dom";
-import { builderBaseLeagueOptions } from "./utils/builderBaseLeagues";
-import { leagueOptions } from "./utils/recruiter";
+import {
+  defaultBuilderBaseLeagueOptions,
+  normalizeBuilderBaseLeagueOptions
+} from "./utils/builderBaseLeagues";
+import { defaultLeagueOptions, normalizeLeagueOptions } from "./utils/recruiter";
 import { LISTING_STATUS_CHANGED_EVENT } from "./utils/appEvents";
 import usePageTitle from "./hooks/usePageTitle"
 import LoadingScreen from "./components/LoadingScreen";
@@ -15,6 +18,10 @@ function Recruiter() {
   const [requiredLeague, setRequiredLeague] = useState("");
   const [requiredBuilderLeague, setRequiredBuilderLeague] = useState("");
   const [requiredTownhall, setRequiredTownhall] = useState("");
+  const [builderBaseLeagueOptions, setBuilderBaseLeagueOptions] = useState(
+    defaultBuilderBaseLeagueOptions
+  );
+  const [leagueOptions, setLeagueOptions] = useState(defaultLeagueOptions);
   const [clanDescription, setClanDescription] = useState("");
   const [maxTownhall, setmaxTownhall] = useState(0);
   const [status, setStatus] = useState(null);
@@ -68,6 +75,12 @@ function Recruiter() {
         }
 
         setmaxTownhall(recruiterData.MAXTOWNHALL);
+        setBuilderBaseLeagueOptions(
+          normalizeBuilderBaseLeagueOptions(
+            recruiterData.builderBaseLeagueOptions
+          )
+        );
+        setLeagueOptions(normalizeLeagueOptions(recruiterData.leagueOptions));
         setRequiredLeague(recruiterData.oldRequiredLeague);
         setRequiredBuilderLeague(recruiterData.oldRequiredBuilderLeague);
         setRequiredTownhall(recruiterData.oldRequiredTownhall);

--- a/frontend/src/utils/builderBaseLeagues.js
+++ b/frontend/src/utils/builderBaseLeagues.js
@@ -1,4 +1,4 @@
-export const builderBaseLeagueOptions = [
+export const defaultBuilderBaseLeagueOptions = [
   { value: 0, label: "No Builder Base Requirement" },
   { value: 1, label: "Wood V" },
   { value: 2, label: "Wood IV" },
@@ -44,8 +44,16 @@ export const builderBaseLeagueOptions = [
   { value: 42, label: "Diamond" }
 ];
 
+export const builderBaseLeagueOptions = defaultBuilderBaseLeagueOptions;
+
+export function normalizeBuilderBaseLeagueOptions(options) {
+  return Array.isArray(options) && options.length > 0
+    ? options
+    : defaultBuilderBaseLeagueOptions;
+}
+
 const builderBaseLeagueLabels = new Map(
-  builderBaseLeagueOptions.map((option) => [option.value, option.label])
+  defaultBuilderBaseLeagueOptions.map((option) => [option.value, option.label])
 );
 
 export function formatBuilderBaseLeague(value) {

--- a/frontend/src/utils/recruiter.js
+++ b/frontend/src/utils/recruiter.js
@@ -1,4 +1,4 @@
-export const leagueOptions = [
+export const defaultLeagueOptions = [
   { value: 0, label: "Unranked" },
   { value: 1, label: "Skeleton 1" },
   { value: 2, label: "Skeleton 2" },
@@ -33,5 +33,15 @@ export const leagueOptions = [
   { value: 31, label: "Electro Dragon 31" },
   { value: 32, label: "Electro Dragon 32" },
   { value: 33, label: "Electro Dragon 33" },
-  { value: 34, label: "Legend League" }
+  { value: 34, label: "Legend League 1" },
+  { value: 35, label: "Legend League 2" },
+  { value: 36, label: "Legend League 3" }
 ];
+
+export const leagueOptions = defaultLeagueOptions;
+
+export function normalizeLeagueOptions(options) {
+  return Array.isArray(options) && options.length > 0
+    ? options
+    : defaultLeagueOptions;
+}

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -3,6 +3,11 @@
 from flask import Blueprint, jsonify, request, session
 
 from ..config import headers
+from ..services.leagues import (
+    get_builder_base_league_options,
+    get_max_ranked_league,
+    get_ranked_league_options,
+)
 from ..services.maxtownhall import refresh
 from ..services.mongo_db_client import get_clan_collection
 from ..services.recruitee_search import (
@@ -90,6 +95,18 @@ def recruitee_get():
     return jsonify(payload), status_code
 
 
+@recruitee_bp.get("/recruitee/metadata")
+@rate_limit("recruitee_metadata_get", limit=60, window_seconds=60)
+def recruitee_metadata_get():
+    """Return metadata needed to render recruitee filters."""
+    return jsonify(
+        {
+            "builderBaseLeagueOptions": get_builder_base_league_options(),
+            "leagueOptions": get_ranked_league_options(),
+        }
+    ), 200
+
+
 @recruitee_bp.post("/recruitee")
 @rate_limit("recruitee_post", limit=30, window_seconds=60)
 def recruitee_post():
@@ -161,8 +178,13 @@ def _validate_filter_payload(filters):
                 f"townhall must be at most {max_townhall}."
             )
         normalized_requirements["townhall"] = townhall
-    league = optional_int(requirements, "league", min_value=0, max_value=34)
+    league = optional_int(requirements, "league", min_value=0)
     if league is not None:
+        max_ranked_league = get_max_ranked_league()
+        if league > max_ranked_league:
+            raise RequestValidationError(
+                f"league must be at most {max_ranked_league}."
+            )
         normalized_requirements["league"] = league
 
     members = ensure_object(

--- a/routes/recruiter_route.py
+++ b/routes/recruiter_route.py
@@ -3,7 +3,10 @@
 from flask import Blueprint, jsonify, request, session
 
 from ..config import headers
-from ..services.builder_base_leagues import BUILDER_BASE_LEAGUE_MAX_ID
+from ..services.leagues import (
+    get_max_builder_base_league,
+    get_max_ranked_league,
+)
 from ..services.maxtownhall import refresh
 from ..services.rate_limiter import is_rate_limited
 from ..services.recruiter_listing import (
@@ -150,13 +153,13 @@ def _validate_recruiter_payload(data):
         data,
         "requiredLeague",
         min_value=0,
-        max_value=34,
+        max_value=get_max_ranked_league(),
     )
     normalized["requiredBuilderLeague"] = required_int(
         data,
         "requiredBuilderLeague",
         min_value=0,
-        max_value=BUILDER_BASE_LEAGUE_MAX_ID,
+        max_value=get_max_builder_base_league(),
     )
     normalized["requiredTownhall"] = required_int(
         data,

--- a/services/leagues.py
+++ b/services/leagues.py
@@ -1,0 +1,272 @@
+"""League metadata helpers backed by MongoDB and the Clash API."""
+
+import re
+from typing import Any
+
+from ..clash_http_client import get as clash_get
+from ..config import headers
+from .builder_base_leagues import BUILDER_BASE_LEAGUES
+from .mongo_db_client import get_league_metadata_collection
+
+BUILDER_BASE_LEAGUES_ENDPOINT = "builderbaseleagues"
+RANKED_LEAGUE_TIERS_ENDPOINT = "rankedleaguetiers"
+BUILDER_BASE_LEAGUE_KIND = "builder_base_league"
+RANKED_LEAGUE_TIER_KIND = "ranked_league_tier"
+TRAILING_NUMBER_PATTERN = re.compile(r"(\d+)$")
+
+FALLBACK_RANKED_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "Unranked"},
+    {"value": 1, "label": "Skeleton 1"},
+    {"value": 2, "label": "Skeleton 2"},
+    {"value": 3, "label": "Skeleton 3"},
+    {"value": 4, "label": "Barbarian 4"},
+    {"value": 5, "label": "Barbarian 5"},
+    {"value": 6, "label": "Barbarian 6"},
+    {"value": 7, "label": "Archer 7"},
+    {"value": 8, "label": "Archer 8"},
+    {"value": 9, "label": "Archer 9"},
+    {"value": 10, "label": "Wizard 10"},
+    {"value": 11, "label": "Wizard 11"},
+    {"value": 12, "label": "Wizard 12"},
+    {"value": 13, "label": "Valkyrie 13"},
+    {"value": 14, "label": "Valkyrie 14"},
+    {"value": 15, "label": "Valkyrie 15"},
+    {"value": 16, "label": "Witch 16"},
+    {"value": 17, "label": "Witch 17"},
+    {"value": 18, "label": "Witch 18"},
+    {"value": 19, "label": "Golem 19"},
+    {"value": 20, "label": "Golem 20"},
+    {"value": 21, "label": "Golem 21"},
+    {"value": 22, "label": "P.E.K.K.A 22"},
+    {"value": 23, "label": "P.E.K.K.A 23"},
+    {"value": 24, "label": "P.E.K.K.A 24"},
+    {"value": 25, "label": "Electro Titan 25"},
+    {"value": 26, "label": "Electro Titan 26"},
+    {"value": 27, "label": "Electro Titan 27"},
+    {"value": 28, "label": "Dragon 28"},
+    {"value": 29, "label": "Dragon 29"},
+    {"value": 30, "label": "Dragon 30"},
+    {"value": 31, "label": "Electro Dragon 31"},
+    {"value": 32, "label": "Electro Dragon 32"},
+    {"value": 33, "label": "Electro Dragon 33"},
+    {"value": 34, "label": "Legend League 1"},
+    {"value": 35, "label": "Legend League 2"},
+    {"value": 36, "label": "Legend League 3"},
+]
+FALLBACK_BUILDER_BASE_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "No Builder Base Requirement"},
+    *[
+        {"value": league_id, "label": name}
+        for league_id, name, _ in BUILDER_BASE_LEAGUES
+    ],
+]
+
+
+def get_ranked_league_options() -> list[dict[str, object]]:
+    """Return stored ranked league tier options."""
+    return _get_options_from_db(
+        RANKED_LEAGUE_TIER_KIND,
+        FALLBACK_RANKED_LEAGUE_OPTIONS,
+    )
+
+
+def get_builder_base_league_options() -> list[dict[str, object]]:
+    """Return stored Builder Base league options."""
+    return _get_options_from_db(
+        BUILDER_BASE_LEAGUE_KIND,
+        FALLBACK_BUILDER_BASE_LEAGUE_OPTIONS,
+    )
+
+
+def get_max_ranked_league() -> int:
+    """Return the highest stored ranked league tier value."""
+    return _max_option_value(get_ranked_league_options())
+
+
+def get_max_builder_base_league() -> int:
+    """Return the highest stored Builder Base league value."""
+    return _max_option_value(get_builder_base_league_options())
+
+
+def ranked_league_name(value: object) -> str:
+    """Return the display label for a ranked league tier value."""
+    return _option_label(
+        value,
+        get_ranked_league_options(),
+        "Unranked",
+        "Unknown",
+    )
+
+
+def builder_base_league_name(value: object) -> str:
+    """Return the display label for a Builder Base league value."""
+    return _option_label(
+        value,
+        get_builder_base_league_options(),
+        "No Builder Base Requirement",
+        "Unknown",
+    )
+
+
+def update_league_metadata_collection() -> None:
+    """Refresh ranked and Builder Base league metadata in MongoDB."""
+    update_ranked_league_tier_collection()
+    update_builder_base_league_collection()
+
+
+def update_ranked_league_tier_collection() -> None:
+    """Fetch ranked league tiers from Clash and store them in MongoDB."""
+    response = clash_get(RANKED_LEAGUE_TIERS_ENDPOINT, headers=headers)
+    options = _build_options(response.payload, fallback_prefix="League")
+    _replace_options(RANKED_LEAGUE_TIER_KIND, options)
+
+
+def update_builder_base_league_collection() -> None:
+    """Fetch Builder Base leagues from Clash and store them in MongoDB."""
+    response = clash_get(BUILDER_BASE_LEAGUES_ENDPOINT, headers=headers)
+    options = _build_options(
+        response.payload,
+        fallback_prefix="Builder Base League",
+        initial_option={
+            "value": 0,
+            "label": "No Builder Base Requirement",
+        },
+    )
+    _replace_options(BUILDER_BASE_LEAGUE_KIND, options)
+
+
+def _get_options_from_db(
+    kind: str,
+    fallback_options: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    collection = get_league_metadata_collection()
+    options = list(
+        collection.find(
+            {"kind": kind},
+            {"_id": 0, "kind": 0},
+        ).sort("value", 1)
+    )
+    if _is_valid_options(options):
+        return options
+
+    return list(fallback_options)
+
+
+def _replace_options(kind: str, options: list[dict[str, object]]) -> None:
+    collection = get_league_metadata_collection()
+    collection.delete_many({"kind": kind})
+    for option in options:
+        collection.insert_one({"kind": kind, **option})
+
+
+def _build_options(
+    payload: dict[str, Any],
+    *,
+    fallback_prefix: str,
+    initial_option: dict[str, object] | None = None,
+) -> list[dict[str, object]]:
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise ValueError("Missing league items in Clash API response.")
+
+    options = [initial_option] if initial_option else []
+    for index, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            continue
+
+        value = _league_value_from_item(item, index)
+        label = _league_label_from_item(item, fallback_prefix, value)
+        options.append({"value": value, "label": label})
+
+    options = _dedupe_options(options)
+    if not options:
+        raise ValueError("Clash API returned no usable league items.")
+
+    return options
+
+
+def _league_value_from_item(item: dict[str, Any], fallback_value: int) -> int:
+    for key in ("rank", "tier"):
+        try:
+            value = int(item[key])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+
+    name = item.get("name")
+    if isinstance(name, str):
+        match = TRAILING_NUMBER_PATTERN.search(name.strip())
+        if match:
+            return int(match.group(1))
+
+    return fallback_value
+
+
+def _league_label_from_item(
+    item: dict[str, Any],
+    fallback_prefix: str,
+    value: int,
+) -> str:
+    name = item.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+
+    return f"{fallback_prefix} {value}"
+
+
+def _dedupe_options(
+    options: list[dict[str, object] | None],
+) -> list[dict[str, object]]:
+    deduped = []
+    seen_values = set()
+    for option in options:
+        if not isinstance(option, dict):
+            continue
+        value = option.get("value")
+        if value in seen_values:
+            continue
+        seen_values.add(value)
+        deduped.append(option)
+
+    return deduped
+
+
+def _is_valid_options(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    if not value:
+        return False
+
+    return all(
+        isinstance(option, dict)
+        and isinstance(option.get("value"), int)
+        and isinstance(option.get("label"), str)
+        for option in value
+    )
+
+
+def _max_option_value(options: list[dict[str, object]]) -> int:
+    return max(option["value"] for option in options)
+
+
+def _option_label(
+    value: object,
+    options: list[dict[str, object]],
+    zero_label: str,
+    unknown_label: str,
+) -> str:
+    try:
+        normalized_value = int(value)
+    except (TypeError, ValueError):
+        return zero_label
+
+    if normalized_value == 0:
+        return zero_label
+
+    labels = {option["value"]: option["label"] for option in options}
+    return labels.get(normalized_value, unknown_label)
+
+
+if __name__ == "__main__":
+    update_league_metadata_collection()

--- a/services/mongo_db_client.py
+++ b/services/mongo_db_client.py
@@ -37,6 +37,11 @@ def get_location_collection() -> Collection[Any]:
     return _get_database()["locations"]
 
 
+def get_league_metadata_collection() -> Collection[Any]:
+    """Return the league metadata collection."""
+    return _get_database()["league_metadata"]
+
+
 def get_clan_collection() -> Collection[Any]:
     """Return the clans collection."""
     return _get_database()["clans"]
@@ -63,6 +68,7 @@ def _ping_mongo() -> None:
 def _ensure_indexes() -> None:
     """Create indexes required by the application."""
     clan_collection = get_clan_collection()
+    league_metadata_collection = get_league_metadata_collection()
     user_collection = get_user_collection()
     import_state_collection = get_import_state_collection()
 
@@ -85,6 +91,10 @@ def _ensure_indexes() -> None:
     clan_collection.create_index("clan_info.clan_level")
     clan_collection.create_index("clan_info.clanPoints")
     clan_collection.create_index("clan_info.warFrequency")
+    league_metadata_collection.create_index(
+        [("kind", 1), ("value", 1)],
+        unique=True,
+    )
 
     import_state_collection.create_index("seed_key", unique=True)
 

--- a/services/recruiter_listing.py
+++ b/services/recruiter_listing.py
@@ -4,6 +4,10 @@ from datetime import datetime, timedelta, timezone
 
 from ..api.recruiter_api import Recruiter
 from ..config import headers
+from .leagues import (
+    get_builder_base_league_options,
+    get_ranked_league_options,
+)
 from .maxtownhall import refresh
 from .mongo_db_client import get_clan_collection
 
@@ -43,6 +47,8 @@ def get_recruiter_listing_page(
             "oldRequiredBuilderLeague": required_builder_league,
             "oldRequiredTownhall": required_townhall,
             "MAXTOWNHALL": refresh(headers),
+            "builderBaseLeagueOptions": get_builder_base_league_options(),
+            "leagueOptions": get_ranked_league_options(),
             "clanDescription": clan_description,
             "status": status,
         },

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -48,6 +48,16 @@ class DummyClanCollection:
         return self.tag_result
 
 
+TEST_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "Unranked"},
+    {"value": 36, "label": "Legend League 3"},
+]
+TEST_BUILDER_BASE_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "No Builder Base Requirement"},
+    {"value": 42, "label": "Diamond"},
+]
+
+
 def expected_active_query(collection, query=None):
     expected = dict(query or {})
     expected["expires"] = collection.find_query["expires"]
@@ -346,6 +356,11 @@ def test_recruitee_post_filters_and_paginates_with_total(
         lambda: collection,
     )
     monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_max_ranked_league",
+        lambda: 36,
+    )
 
     response = client.post(
         "/recruitee?includeTotal=1&limit=2&offset=0",
@@ -397,6 +412,29 @@ def test_recruitee_post_filters_and_paginates_with_total(
     ]
     assert collection.cursor.skip_count == 0
     assert collection.cursor.limit_count == 2
+
+
+def test_recruitee_metadata_returns_league_options(client, monkeypatch):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_ranked_league_options",
+        lambda: TEST_LEAGUE_OPTIONS,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_builder_base_league_options",
+        lambda: TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+    )
+
+    response = client.get("/recruitee/metadata")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "builderBaseLeagueOptions": TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+        "leagueOptions": TEST_LEAGUE_OPTIONS,
+    }
 
 
 def test_recruitee_post_returns_clan_by_tag(
@@ -761,6 +799,11 @@ def test_recruitee_post_rejects_townhall_above_current_max(
         lambda: collection,
     )
     monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_max_ranked_league",
+        lambda: 36,
+    )
 
     response = client.post(
         "/recruitee",
@@ -769,6 +812,34 @@ def test_recruitee_post_rejects_townhall_above_current_max(
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "townhall must be at most 17."}
+    assert collection.find_query is None
+
+
+def test_recruitee_post_rejects_league_above_current_api_max(
+    client,
+    monkeypatch,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_max_ranked_league",
+        lambda: 36,
+    )
+
+    response = client.post(
+        "/recruitee",
+        json={"filters": {"requirements": {"league": 37}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "league must be at most 36."}
     assert collection.find_query is None
 
 
@@ -882,6 +953,11 @@ def test_recruitee_post_normalizes_numeric_string_filters(
         lambda: collection,
     )
     monkeypatch.setattr(recruitee_route, "refresh", lambda headers: 17)
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_max_ranked_league",
+        lambda: 36,
+    )
 
     response = client.post(
         "/recruitee",

--- a/tests/routes/test_recruiter_route.py
+++ b/tests/routes/test_recruiter_route.py
@@ -62,13 +62,43 @@ class DummyRecruiter:
         }
 
 
+TEST_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "Unranked"},
+    {"value": 36, "label": "Legend League 3"},
+]
+TEST_BUILDER_BASE_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "No Builder Base Requirement"},
+    {"value": 42, "label": "Diamond"},
+]
+
+
 def setup_recruiter_route(monkeypatch, collection):
     import ClashRecruit.routes.recruiter_route as recruiter_route
     import ClashRecruit.services.recruiter_listing as recruiter_listing
 
     DummyRecruiter.instances = []
     monkeypatch.setattr(recruiter_route, "refresh", lambda headers: 17)
+    monkeypatch.setattr(
+        recruiter_route,
+        "get_max_ranked_league",
+        lambda: 36,
+    )
+    monkeypatch.setattr(
+        recruiter_route,
+        "get_max_builder_base_league",
+        lambda: 42,
+    )
     monkeypatch.setattr(recruiter_listing, "Recruiter", DummyRecruiter)
+    monkeypatch.setattr(
+        recruiter_listing,
+        "get_ranked_league_options",
+        lambda: TEST_LEAGUE_OPTIONS,
+    )
+    monkeypatch.setattr(
+        recruiter_listing,
+        "get_builder_base_league_options",
+        lambda: TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+    )
     monkeypatch.setattr(
         recruiter_listing,
         "get_clan_collection",
@@ -142,6 +172,8 @@ def test_recruiter_get_returns_existing_listing(
         "oldRequiredBuilderLeague": 19,
         "oldRequiredTownhall": 12,
         "MAXTOWNHALL": 17,
+        "builderBaseLeagueOptions": TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+        "leagueOptions": TEST_LEAGUE_OPTIONS,
         "clanDescription": "existing_description",
         "status": "existing_expiry",
     }
@@ -172,6 +204,8 @@ def test_recruiter_get_returns_default_listing_and_lookup_description(
         "oldRequiredBuilderLeague": 2,
         "oldRequiredTownhall": 3,
         "MAXTOWNHALL": 17,
+        "builderBaseLeagueOptions": TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+        "leagueOptions": TEST_LEAGUE_OPTIONS,
         "clanDescription": "test_clan_description",
         "status": None,
     }
@@ -232,6 +266,60 @@ def test_recruiter_post_creates_new_listing(
         collection.inserted_doc,
         True,
     )
+
+
+def test_recruiter_post_accepts_current_api_max_league(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(
+        recruiter_status=True,
+        clan_tag="TEST123",
+        player_tag="PLAYER123",
+    )
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 36,
+            "requiredBuilderLeague": 23,
+            "requiredTownhall": 13,
+            "description": "new_description",
+        },
+    )
+
+    assert response.status_code == 200
+    assert collection.inserted_doc["requirements"] == [36, 23, 13]
+
+
+def test_recruiter_post_rejects_league_above_current_api_max(
+    client,
+    monkeypatch,
+    set_session,
+):
+    collection = DummyClanCollection()
+    setup_recruiter_route(monkeypatch, collection)
+    set_session(recruiter_status=True, clan_tag="TEST123")
+
+    response = client.post(
+        "/recruiter",
+        json={
+            "status": "new",
+            "requiredLeague": 37,
+            "requiredBuilderLeague": 23,
+            "requiredTownhall": 13,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "requiredLeague must be at most 36."
+    }
+    assert collection.inserted_doc is None
 
 
 def test_recruiter_post_create_returns_400_without_player_tag(

--- a/tests/test_leagues_service.py
+++ b/tests/test_leagues_service.py
@@ -1,0 +1,199 @@
+from ClashRecruit.clash_http_client import ClashApiResponse
+from ClashRecruit.services import leagues
+
+
+class DummyCursor:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def sort(self, field, direction):
+        reverse = direction < 0
+        return sorted(
+            self.docs,
+            key=lambda doc: doc.get(field, 0),
+            reverse=reverse,
+        )
+
+
+class DummyLeagueMetadataCollection:
+    def __init__(self, docs=None):
+        self.docs = docs or []
+        self.find_calls = []
+        self.deleted_queries = []
+        self.inserted = []
+
+    def find(self, query, projection):
+        self.find_calls.append((query, projection))
+        kind = query["kind"]
+        docs = [
+            {key: value for key, value in doc.items() if key not in {"_id", "kind"}}
+            for doc in self.docs
+            if doc.get("kind") == kind
+        ]
+        return DummyCursor(docs)
+
+    def delete_many(self, query):
+        self.deleted_queries.append(query)
+        self.docs = [
+            doc for doc in self.docs if doc.get("kind") != query.get("kind")
+        ]
+
+    def insert_one(self, doc):
+        self.inserted.append(doc)
+        self.docs.append(doc)
+
+
+def test_get_ranked_league_options_reads_database(monkeypatch):
+    collection = DummyLeagueMetadataCollection(
+        [
+            {"kind": "ranked_league_tier", "value": 2, "label": "Skeleton 2"},
+            {"kind": "ranked_league_tier", "value": 1, "label": "Skeleton 1"},
+        ]
+    )
+    monkeypatch.setattr(
+        leagues,
+        "get_league_metadata_collection",
+        lambda: collection,
+    )
+
+    assert leagues.get_ranked_league_options() == [
+        {"value": 1, "label": "Skeleton 1"},
+        {"value": 2, "label": "Skeleton 2"},
+    ]
+    assert collection.find_calls == [
+        (
+            {"kind": "ranked_league_tier"},
+            {"_id": 0, "kind": 0},
+        )
+    ]
+
+
+def test_get_builder_base_league_options_reads_database(monkeypatch):
+    collection = DummyLeagueMetadataCollection(
+        [
+            {"kind": "builder_base_league", "value": 42, "label": "Diamond"},
+            {"kind": "builder_base_league", "value": 0, "label": "No Builder Base Requirement"},
+        ]
+    )
+    monkeypatch.setattr(
+        leagues,
+        "get_league_metadata_collection",
+        lambda: collection,
+    )
+
+    assert leagues.get_builder_base_league_options() == [
+        {"value": 0, "label": "No Builder Base Requirement"},
+        {"value": 42, "label": "Diamond"},
+    ]
+
+
+def test_get_options_falls_back_when_database_is_empty(monkeypatch):
+    collection = DummyLeagueMetadataCollection()
+    monkeypatch.setattr(
+        leagues,
+        "get_league_metadata_collection",
+        lambda: collection,
+    )
+
+    assert leagues.get_ranked_league_options() == (
+        leagues.FALLBACK_RANKED_LEAGUE_OPTIONS
+    )
+    assert leagues.get_builder_base_league_options() == (
+        leagues.FALLBACK_BUILDER_BASE_LEAGUE_OPTIONS
+    )
+
+
+def test_get_max_values_use_database_options(monkeypatch):
+    collection = DummyLeagueMetadataCollection(
+        [
+            {"kind": "ranked_league_tier", "value": 36, "label": "Legend League 3"},
+            {"kind": "builder_base_league", "value": 42, "label": "Diamond"},
+        ]
+    )
+    monkeypatch.setattr(
+        leagues,
+        "get_league_metadata_collection",
+        lambda: collection,
+    )
+
+    assert leagues.get_max_ranked_league() == 36
+    assert leagues.get_max_builder_base_league() == 42
+
+
+def test_update_ranked_league_tier_collection_fetches_and_replaces(
+    monkeypatch,
+):
+    collection = DummyLeagueMetadataCollection(
+        [{"kind": "ranked_league_tier", "value": 999, "label": "Old"}]
+    )
+    calls = []
+
+    def fake_clash_get(path, headers):
+        calls.append((path, headers))
+        return ClashApiResponse(
+            200,
+            {
+                "items": [
+                    {"name": "Skeleton 1"},
+                    {"name": "Legend League 2"},
+                    {"name": "Legend League 3"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(leagues, "get_league_metadata_collection", lambda: collection)
+    monkeypatch.setattr(leagues, "headers", {"Authorization": "Bearer test"})
+    monkeypatch.setattr(leagues, "clash_get", fake_clash_get)
+
+    leagues.update_ranked_league_tier_collection()
+
+    assert calls == [
+        ("rankedleaguetiers", {"Authorization": "Bearer test"}),
+    ]
+    assert collection.deleted_queries == [{"kind": "ranked_league_tier"}]
+    assert collection.inserted == [
+        {"kind": "ranked_league_tier", "value": 1, "label": "Skeleton 1"},
+        {"kind": "ranked_league_tier", "value": 2, "label": "Legend League 2"},
+        {"kind": "ranked_league_tier", "value": 3, "label": "Legend League 3"},
+    ]
+
+
+def test_update_builder_base_league_collection_fetches_and_replaces(
+    monkeypatch,
+):
+    collection = DummyLeagueMetadataCollection(
+        [{"kind": "builder_base_league", "value": 999, "label": "Old"}]
+    )
+    calls = []
+
+    def fake_clash_get(path, headers):
+        calls.append((path, headers))
+        return ClashApiResponse(
+            200,
+            {
+                "items": [
+                    {"name": "Wood V"},
+                    {"name": "Diamond"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(leagues, "get_league_metadata_collection", lambda: collection)
+    monkeypatch.setattr(leagues, "headers", {"Authorization": "Bearer test"})
+    monkeypatch.setattr(leagues, "clash_get", fake_clash_get)
+
+    leagues.update_builder_base_league_collection()
+
+    assert calls == [
+        ("builderbaseleagues", {"Authorization": "Bearer test"}),
+    ]
+    assert collection.deleted_queries == [{"kind": "builder_base_league"}]
+    assert collection.inserted == [
+        {
+            "kind": "builder_base_league",
+            "value": 0,
+            "label": "No Builder Base Requirement",
+        },
+        {"kind": "builder_base_league", "value": 1, "label": "Wood V"},
+        {"kind": "builder_base_league", "value": 2, "label": "Diamond"},
+    ]

--- a/tests/test_recruiter_listing_service.py
+++ b/tests/test_recruiter_listing_service.py
@@ -3,6 +3,14 @@ from datetime import datetime, timedelta, timezone
 import ClashRecruit.services.recruiter_listing as recruiter_listing
 
 FROZEN_NOW = datetime(2026, 5, 12, 12, 30, tzinfo=timezone.utc)
+TEST_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "Unranked"},
+    {"value": 36, "label": "Legend League 3"},
+]
+TEST_BUILDER_BASE_LEAGUE_OPTIONS = [
+    {"value": 0, "label": "No Builder Base Requirement"},
+    {"value": 42, "label": "Diamond"},
+]
 
 
 class DummyDeleteResult:
@@ -81,6 +89,16 @@ def setup_recruiter_listing(monkeypatch, collection):
         lambda: collection,
     )
     monkeypatch.setattr(recruiter_listing, "refresh", lambda headers: 17)
+    monkeypatch.setattr(
+        recruiter_listing,
+        "get_ranked_league_options",
+        lambda: TEST_LEAGUE_OPTIONS,
+    )
+    monkeypatch.setattr(
+        recruiter_listing,
+        "get_builder_base_league_options",
+        lambda: TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+    )
     monkeypatch.setattr(recruiter_listing, "datetime", FakeDatetime)
 
 
@@ -103,6 +121,8 @@ def test_get_recruiter_listing_page_returns_existing_listing(monkeypatch):
         "oldRequiredBuilderLeague": 19,
         "oldRequiredTownhall": 12,
         "MAXTOWNHALL": 17,
+        "builderBaseLeagueOptions": TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+        "leagueOptions": TEST_LEAGUE_OPTIONS,
         "clanDescription": "existing_description",
         "status": "existing_expiry",
     }
@@ -129,6 +149,8 @@ def test_get_recruiter_listing_page_uses_clash_defaults(monkeypatch):
         "oldRequiredBuilderLeague": 2,
         "oldRequiredTownhall": 3,
         "MAXTOWNHALL": 17,
+        "builderBaseLeagueOptions": TEST_BUILDER_BASE_LEAGUE_OPTIONS,
+        "leagueOptions": TEST_LEAGUE_OPTIONS,
         "clanDescription": "test_clan_description",
         "status": None,
     }


### PR DESCRIPTION
## Summary

- Added a cached ranked league tier metadata service backed by the official Clash API.
- Replaced hardcoded required league max validation with the API-derived ranked league tier max.
- Returned dynamic league options to recruiter and clan search UI flows.
- Updated fallback league options through `Legend League 3`.
- Added tests for ranked league tier metadata, recruiter validation, recruitee validation, and metadata responses.

## Why

Clash added new ranked Legend tiers, so the previous hardcoded `34` cap rejected valid league requirements. This keeps backend validation and frontend options aligned with the official ranked league tier metadata.

## Validation

- `venv/bin/python -m pytest tests/test_leagues_service.py tests/test_recruiter_listing_service.py tests/routes/test_recruiter_route.py tests/routes/test_recruitee_route.py`
- `npm run build`