### PR TITLE
fix: updated looking for clan page to follow same colours as dashboard

### DIFF
--- a/frontend/src/LookingForClan.css
+++ b/frontend/src/LookingForClan.css
@@ -1,4 +1,16 @@
 .looking-page {
+    --looking-surface: rgba(255, 255, 255, 0.9);
+    --looking-surface-soft: #f7efe0;
+    --looking-border: #d4b985;
+    --looking-border-strong: #c8a04d;
+    --looking-text-main: #201913;
+    --looking-text-muted: #594b3f;
+    --looking-accent-red: #b33a32;
+    --looking-accent-red-hover: #922a24;
+    --looking-status: #2f7d32;
+    --looking-shadow: rgba(32, 25, 19, 0.1);
+    --looking-shadow-strong: rgba(32, 25, 19, 0.16);
+
     padding: 24px;
     max-width: 1100px;
     margin: 0 auto;
@@ -62,11 +74,12 @@
     display: grid;
     grid-template-columns: repeat(4, minmax(140px, 1fr));
     gap: 12px;
-    padding: 14px;
+    padding: 16px;
     margin-bottom: 20px;
-    border: 1px solid #d8e0ea;
-    border-radius: 12px;
-    background: #f8fbff;
+    border: none;
+    border-radius: 18px;
+    background: rgba(255, 249, 236, 0.95);
+    box-shadow: 0 22px 40px rgba(54, 35, 17, 0.12);
 }
 
 .looking-filters label {
@@ -74,15 +87,25 @@
     flex-direction: column;
     gap: 6px;
     font-size: 0.86rem;
-    color: #334155;
+    color: #51361d;
+    font-weight: 700;
 }
 
 .looking-filters input,
 .looking-filters select {
-    border: 1px solid #cbd5e1;
+    border: 1px solid #d5bb94;
     border-radius: 8px;
+    background: rgba(255, 253, 249, 0.95);
+    color: var(--looking-text-main);
     padding: 8px 10px;
     font-size: 0.95rem;
+}
+
+.looking-filters input:focus,
+.looking-filters select:focus {
+    border-color: var(--looking-border-strong);
+    box-shadow: 0 0 0 3px rgba(200, 160, 77, 0.18);
+    outline: none;
 }
 
 .looking-filters-actions {
@@ -93,16 +116,18 @@
 
 .looking-filter-submit {
     border: none;
-    border-radius: 8px;
+    border-radius: 10px;
     padding: 9px 14px;
     font-size: 0.92rem;
+    font-weight: 700;
     cursor: pointer;
-    background: #2563eb;
-    color: #ffffff;
+    background: var(--looking-accent-red);
+    color: #fff8f2;
+    box-shadow: 0 8px 16px rgba(128, 58, 44, 0.2);
 }
 
 .looking-filter-submit:hover {
-    background: #1d4ed8;
+    background: var(--looking-accent-red-hover);
 }
 
 .listing-grid {
@@ -114,14 +139,15 @@
 .listing-card {
     text-align: left;
     width: auto;
-    border: 1px solid #dbe3ec;
+    border: none;
     border-radius: 14px;
-    background: #ffffff;
+    background: rgba(255, 248, 234, 0.96);
     padding: 20px;
     min-height: 230px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    box-shadow: 0 10px 20px rgba(108, 74, 41, 0.1);
     transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
@@ -131,8 +157,7 @@
 
 .listing-card:hover {
     transform: translateY(-1px);
-    border-color: #93c5fd;
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+    box-shadow: 0 14px 24px var(--looking-shadow-strong);
 }
 
 .listing-top {
@@ -144,7 +169,7 @@
 
 .listing-top h3 {
     margin: 0;
-    color: #0f172a;
+    color: var(--looking-text-main);
     font-size: 1.15rem;
 }
 
@@ -160,7 +185,7 @@
     border: none;
     background: transparent;
     padding: 0;
-    color: #475569;
+    color: #51361d;
     font-size: 0.86rem;
     font-weight: 700;
     cursor: pointer;
@@ -168,7 +193,7 @@
 }
 
 .listing-tag-copy-btn:hover {
-    color: #1d4ed8;
+    color: var(--looking-accent-red);
 }
 
 .listing-tag-copied {
@@ -189,7 +214,7 @@
 }
 
 .listing-location {
-    color: #1d4ed8;
+    color: #8b672f;
     font-size: 0.92rem;
     font-weight: 600;
 }
@@ -205,43 +230,43 @@
     margin: 0;
     padding: 10px;
     border-radius: 8px;
-    background: #f8fafc;
+    background: rgba(255, 250, 241, 0.95);
     font-size: 0.9rem;
-    color: #334155;
+    color: #51361d;
 }
 
 .listing-description {
     margin: 14px 0 0;
-    color: #475569;
+    color: var(--looking-text-muted);
     font-size: 0.98rem;
     line-height: 1.4;
     flex: 1;
 }
 
 .listing-card-actions {
-    margin-top: 14px;
+    margin-top: auto;
     display: flex;
     justify-content: flex-end;
 }
 
 .listing-action-btn {
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--looking-border);
     border-radius: 8px;
     padding: 8px 12px;
     font-size: 0.88rem;
     cursor: pointer;
-    background: #ffffff;
-    color: #0f172a;
+    background: var(--looking-surface-soft);
+    color: #51361d;
 }
 
 .listing-action-btn:hover {
-    background: #f8fafc;
+    background: #fff2df;
 }
 
 .listing-save-btn.is-saved {
-    border-color: #86efac;
-    background: #f0fdf4;
-    color: #166534;
+    border-color: #78a76e;
+    background: #eaf8e4;
+    color: var(--looking-status);
 }
 
 .listing-save-btn.has-error {

--- a/frontend/src/LookingForClan.jsx
+++ b/frontend/src/LookingForClan.jsx
@@ -625,9 +625,9 @@ return (
               <p><strong>Clan Points:</strong> {clan.clan_info?.clanPoints ?? 0}</p>
             </div>
 
-            <p className="listing-description">
-              {clan.clan_info?.description || "No description provided."}
-            </p>
+            {clan.clan_info?.description && <p className="listing-description">
+              {clan.clan_info.description}
+            </p>}
 
             <div className="listing-card-actions">
               {isLoggedIn && (


### PR DESCRIPTION
## Summary

- Updates the Looking For Clan page styling to better match the dashboard color palette
- Refreshes filter controls, clan listing cards, buttons, hover states, and saved-state styling
- Hides the placeholder “No description provided.” text when a clan has no description

## Testing

- Not run; visual/CSS-only change with a small conditional rendering update