### PR TITLE
Stop publishing Redis port in Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ For a small deployment, configure at minimum:
 - `DBURI`
 - `APIKEY`
 - Redis/Celery if scheduled import or refresh jobs are needed
+- Redis bound only to the private app network; do not publish port `6379`
 - a production frontend build
 - a production Flask runner such as Gunicorn rather than `flask run`
 - a trusted CORS/frontend origin instead of local development defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- Remove the Redis host port mapping from Docker Compose
- Keep Redis accessible internally to web, worker, and beat via `redis:6379`
- Document that Redis should stay bound to the private app network in deployment notes

## Testing
- Not run; configuration-only change