### PR TITLE
fix: nginx setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+*.pyc
+frontend/node_modules
+frontend/build
+frontend/npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,8 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-COPY . /app/ClashRecruiter
+COPY . /app/ClashRecruit
+
+ENV PYTHONPATH=/app
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--threads", "4", "--timeout", "120", "ClashRecruit.app:app"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ClashRecruit/
 ├── app.py               Flask application entrypoint
 ├── clash_http_client.py Shared Clash API HTTP client
 ├── config.py            Environment-backed config
-├── docker-compose.yml   Local backend/worker/Redis stack
+├── docker-compose.yml   Local Nginx/Gunicorn/worker/Redis stack
 ├── Dockerfile           Backend image
 ├── pyproject.toml       Ruff and pytest config
 └── requirements.txt     Pinned backend dependencies
@@ -70,7 +70,7 @@ CLASH_INIT_DB_ON_START=False
 
 ## Local Development
 
-### Backend with Docker Compose
+### Full Stack with Docker Compose
 
 From the repository root:
 
@@ -79,10 +79,13 @@ docker compose up --build
 ```
 
 This starts:
-- Flask backend on `http://127.0.0.1:5000`
+- Nginx on `http://127.0.0.1`
+- Gunicorn-backed Flask app on the private Docker network
 - Redis
 - Celery worker
 - Celery beat scheduler
+
+Nginx serves the production React build and proxies backend requests to Gunicorn.
 
 Stop the stack:
 
@@ -123,6 +126,8 @@ npm start
 ```
 
 The frontend runs at `http://localhost:3000` and proxies API requests to `http://127.0.0.1:5000`.
+
+When running through Docker Compose, Nginx serves the frontend at `http://127.0.0.1` and proxies API requests to the `web` service at `http://web:5000`.
 
 ## Checks
 
@@ -169,6 +174,7 @@ For a small deployment, configure at minimum:
 - a production frontend build
 - a production Flask runner such as Gunicorn rather than `flask run`
 - a trusted CORS/frontend origin instead of local development defaults
+- Cloudflare set to Full or Full (strict) SSL mode, with only ports `80`, `443`, and restricted SSH open on EC2
 
 Before deploying publicly, verify:
 - backend tests pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,19 +10,27 @@ services:
   web:
     build: .
     working_dir: /app
-    command: flask --app ClashRecruit.app run --host=0.0.0.0 --port=5000
+    command: gunicorn --bind 0.0.0.0:5000 --workers 2 --threads 4 --timeout 120 ClashRecruit.app:app
     env_file:
       - .env
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
-    volumes:
-      - .:/app/ClashRecruit
-    ports:
-      - "5000:5000"
+    expose:
+      - "5000"
     depends_on:
       redis:
         condition: service_healthy
+    restart: unless-stopped
+
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+    ports:
+      - "80:80"
+    depends_on:
+      - web
     restart: unless-stopped
 
   worker:
@@ -34,8 +42,6 @@ services:
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
-    volumes:
-      - .:/app/ClashRecruit
     depends_on:
       redis:
         condition: service_healthy
@@ -50,8 +56,6 @@ services:
     environment:
       PYTHONPATH: /app
       CELERY_BROKER_URL: redis://redis:6379/0
-    volumes:
-      - .:/app/ClashRecruit
     depends_on:
       redis:
         condition: service_healthy

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+build
+npm-debug.log
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,6 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy" : "http://127.0.0.1:5000/",
   "engines": {
     "node": "20.x",
     "npm": "10.x"

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,30 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const apiProxyTarget = process.env.API_PROXY_TARGET || "http://127.0.0.1:5000";
+
+const apiPathPrefixes = [
+  "/clash_locations",
+  "/database_count",
+  "/logout",
+  "/recruitee",
+  "/recruiter",
+  "/saved-clans",
+  "/session-state",
+];
+
+const shouldProxy = (pathname, req) => {
+  if (pathname === "/" && req.method !== "GET") {
+    return true;
+  }
+
+  return apiPathPrefixes.some((prefix) => pathname.startsWith(prefix));
+};
+
+module.exports = function setupProxy(app) {
+  app.use(
+    createProxyMiddleware(shouldProxy, {
+      target: apiProxyTarget,
+      changeOrigin: true,
+    }),
+  );
+};

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine AS frontend-build
+
+WORKDIR /app/frontend
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=frontend-build /app/frontend/build /usr/share/nginx/html
+
+EXPOSE 80

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,53 @@
+upstream clashrecruit_backend {
+    server web:5000;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 2m;
+
+    location @backend {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_pass http://clashrecruit_backend;
+    }
+
+    location = / {
+        error_page 418 = @backend;
+        if ($request_method !~ ^(GET|HEAD)$) {
+            return 418;
+        }
+
+        try_files /index.html =404;
+    }
+
+    location ~ ^/(clash_locations|database_count|imported_clans|logout|recruitee|recruiter|saved-clans|search_clans|session-state)(/|$) {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_pass http://clashrecruit_backend;
+    }
+
+    location /static/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask==3.1.2
 flask-cors==6.0.2
+gunicorn==23.0.0
 python-dotenv==1.2.1
 pymongo==4.16.0
 requests==2.32.5


### PR DESCRIPTION
## Summary

- Dockerized the React frontend and added a production Nginx image that builds and serves the React app
- Switched the backend Docker runtime from `flask run` to Gunicorn
- Updated Docker Compose so Nginx is the only public entrypoint and proxies backend routes to Gunicorn
- Kept Redis, Celery worker, Celery beat, and Gunicorn private on the Docker network
- Updated README documentation for the new Nginx/Gunicorn Docker setup

## Details

The stack now runs as:

```text
Nginx :80
  ├─ serves React production build
  └─ proxies API/backend routes to Gunicorn web:5000