### PR TITLE
fix: update mobile dashboard so the clan icon is centered for logged in users

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -837,10 +837,19 @@
 
     .dashboard-hero-right {
         transform: none;
+        width: 100%;
+        min-width: 0;
+        justify-self: center;
     }
 
     .dashboard-hero-left {
         justify-content: center;
+    }
+
+    .dashboard-clan-link,
+    .dashboard-clan-summary {
+        width: min(100%, 220px);
+        margin: 0 auto;
     }
 
     .dashboard-townhall-shell {


### PR DESCRIPTION
## Summary
- updated the mobile dashboard so that clan icons are centred

## Images
### Before
<img width="372" height="529" alt="{6FB85EFE-2E16-476D-9726-463FC25BA6C3}" src="https://github.com/user-attachments/assets/9ecd10ec-d3e3-4136-93e2-a9133ee36e3b" />

### After
<img width="361" height="489" alt="{9FA26C5F-68D1-441E-B0D8-9E0878B2203F}" src="https://github.com/user-attachments/assets/29d68b73-dfee-4005-9bd5-ee5f9318bc76" />
