### PR TITLE
fix: update mobile header to not have weird overflow issues

### DIFF
--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -38,6 +38,13 @@
     min-width: 0;
 }
 
+.header-nav {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+}
+
 .header-nav-link {
     text-decoration: none;
     color: #0f172a;
@@ -182,17 +189,86 @@
 
 @media (max-width: 720px) {
     .header-inner {
-        flex-wrap: wrap;
-        gap: 8px 12px;
+        gap: 10px;
+        min-width: 0;
     }
 
     .header-right {
-        flex: 1 1 100%;
+        flex: 1 1 auto;
         justify-content: flex-end;
-        flex-wrap: wrap;
+        gap: 8px;
+        min-width: 0;
+    }
+
+    .header-nav {
+        gap: 8px;
+        min-width: 0;
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+
+    .header-nav::-webkit-scrollbar {
+        display: none;
+    }
+
+    .logo {
+        width: min(176px, 38vw);
+        max-width: none;
+    }
+
+    .header-nav-link {
+        padding: 6px 8px;
+        font-size: 0.82rem;
+    }
+
+    .header-divider {
+        height: 22px;
+    }
+
+    .user-button {
+        padding: 6px 8px;
+        font-size: 0.84rem;
     }
 
     .user-button-name {
-        max-width: min(170px, 42vw);
+        max-width: min(140px, 28vw);
+        font-size: 0.84rem;
+    }
+
+    .header-inner.is-logged-in {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        column-gap: 12px;
+        row-gap: 8px;
+    }
+
+    .header-inner.is-logged-in .logo {
+        grid-column: 1;
+        width: min(150px, 42vw);
+    }
+
+    .header-inner.is-logged-in .header-right {
+        display: contents;
+    }
+
+    .header-inner.is-logged-in .header-nav {
+        grid-column: 1 / -1;
+        order: 3;
+        width: 100%;
+        justify-content: center;
+        gap: 10px;
+        border-top: 1px solid rgba(203, 213, 225, 0.8);
+        padding-top: 7px;
+    }
+
+    .header-inner.is-logged-in .header-divider {
+        display: none;
+    }
+
+    .header-inner.is-logged-in .dropdown {
+        grid-column: 3;
+        order: 2;
+        margin-left: auto;
     }
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -63,25 +63,27 @@ function Header({ user , hasActiveListing}) {
     
     return (
         <header className="header">
-            <div className="header-inner">
+            <div className={`header-inner${isLoggedIn ? " is-logged-in" : ""}`}>
                 <Link to='/' className='logo'>
                     <img src={logo} alt="ClashRecruit logo" className="logo-image" />
                 </Link>
 
                 <div className="header-right">
-                    <NavLink to="/looking-for-clan" className={getNavLinkClassName}>
-                        Find a Clan
-                    </NavLink>
-                    {isLoggedIn && (
-                        <>
-                            <NavLink to="/dashboard" className={getNavLinkClassName}>
-                                Dashboard
-                            </NavLink>
-                            <NavLink to="/recruit" className={getNavLinkClassName}>
-                                {hasActiveListing ? "View Listing" : "Recruit"}
-                            </NavLink>
-                        </>
-                    )}
+                    <nav className="header-nav" aria-label="Primary navigation">
+                        <NavLink to="/looking-for-clan" className={getNavLinkClassName}>
+                            Find a Clan
+                        </NavLink>
+                        {isLoggedIn && (
+                            <>
+                                <NavLink to="/dashboard" className={getNavLinkClassName}>
+                                    Dashboard
+                                </NavLink>
+                                <NavLink to="/recruit" className={getNavLinkClassName}>
+                                    {hasActiveListing ? "View Listing" : "Recruit"}
+                                </NavLink>
+                            </>
+                        )}
+                    </nav>
                     <span className="header-divider" aria-hidden="true"></span>
                     <div className="dropdown" ref={dropdownRef}>
                         <button


### PR DESCRIPTION
## Summary
- Updated the mobile page header
- Had overflow issues and would not scale properly if the user was logged in previously
- Fixed by having a floating header where the logo sits above now

## Images

### Before
<img width="390" height="137" alt="{498CA41A-FD01-4385-9DCB-00210D647CC3}" src="https://github.com/user-attachments/assets/d889259e-37b5-435a-966f-778447f6d427" />

### After
<img width="386" height="93" alt="{E6BFD031-43DC-4C78-8113-0D64DA1B3BF2}" src="https://github.com/user-attachments/assets/df42e8d7-f43c-4ff5-865c-61ba709124a6" />
