### PR TITLE
fix: update landing page on mobile to stop horizontal overflow

### DIFF
--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -558,6 +558,10 @@
   .landing-hero {
     min-height: calc(100vh - 96px);
     padding-top: clamp(34px, 8vh, 62px);
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 24px;
   }
 
   .landing-hero-layout {
@@ -569,16 +573,27 @@
     max-width: 620px;
     width: 100%;
   }
+
+  .landing-block {
+    width: 100%;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .landing-cards {
+    flex: 1 1 0;
+    min-width: 0;
+  }
 }
 
 @media (max-width: 760px) {
   .landing {
-    padding: 20px 16px 30px;
+    padding: 20px 0 30px;
   }
 
   .landing-hero {
     min-height: calc(100vh - 110px);
-    padding: clamp(30px, 7vh, 52px) 16px 34px;
+    padding: clamp(30px, 7vh, 52px) 16px 112px;
   }
 
   .landing-btn {
@@ -613,6 +628,16 @@
 }
 
 @media (max-width: 680px) {
+  .landing-block {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 20px;
+  }
+
+  .landing-cards {
+    width: min(100%, 280px);
+  }
+
   .landing-clan-card {
     min-height: 196px;
   }


### PR DESCRIPTION
## Summary
- Fixed mobile landing page overflow issues
- Previously had horizonal overflow which extended the page on mobile

## Images

### Before

<img width="386" height="737" alt="{E3EFE569-5AA2-49A5-8998-73FA8CBADD99}" src="https://github.com/user-attachments/assets/b1c73377-1d29-49ac-a289-a9bb6fe73665" />

- Two extra blocks cannot be seen in this prior version

### After

<img width="382" height="692" alt="{1C835225-79E4-41AB-B138-9EFBA6EE945D}" src="https://github.com/user-attachments/assets/7a302806-76fa-444d-a82e-2f97bf4e3be5" />
