### PR TITLE
Add clan source sorting and paged pagination windows

### DIFF
--- a/frontend/src/LookingForClan.css
+++ b/frontend/src/LookingForClan.css
@@ -310,6 +310,10 @@
     color: #ffffff;
 }
 
+.listing-page-arrow {
+    font-weight: 700;
+}
+
 @media (max-width: 820px) {
     .looking-filters {
         grid-template-columns: repeat(2, minmax(140px, 1fr));

--- a/frontend/src/LookingForClan.jsx
+++ b/frontend/src/LookingForClan.jsx
@@ -11,6 +11,9 @@ import LoadingScreen from "./components/LoadingScreen";
 import "./LookingForClan.css";
 
 const PAGE_SIZE = 10;
+const PAGE_WINDOW_SIZE = 10;
+const DEFAULT_SOURCE_SORT = "community";
+const SOURCE_SORT_OPTIONS = new Set(["community", "discovered"]);
 
 function toNumberOrNull(value) {
     return value === "" || value === null ? null : Number(value);
@@ -19,6 +22,10 @@ function toNumberOrNull(value) {
 function parsePageParam(value) {
   const pageNumber = Number(value);
   return Number.isInteger(pageNumber) && pageNumber > 0 ? pageNumber : 1;
+}
+
+function parseSourceSortParam(value) {
+  return SOURCE_SORT_OPTIONS.has(value) ? value : DEFAULT_SOURCE_SORT;
 }
 
 function readFilterParam(searchParams, name) {
@@ -36,22 +43,33 @@ function parseFiltersFromSearchParams(searchParams) {
     warFrequency: readFilterParam(searchParams, "warFrequency"),
     clanPoints: readFilterParam(searchParams, "clanPoints"),
     location: readFilterParam(searchParams, "location"),
+    sourceSort: parseSourceSortParam(searchParams.get("sourceSort")),
   };
 }
 
 function hasActiveFilters(filters) {
-  return Object.values(filters).some((value) => String(value).trim() !== "");
+  return Object.entries(filters).some(([key, value]) => (
+    key !== "sourceSort" && String(value).trim() !== ""
+  ));
 }
 
 function buildListingSearchParams(filters, page) {
   const nextParams = new URLSearchParams();
 
   Object.entries(filters).forEach(([key, value]) => {
+    if (key === "sourceSort") {
+      return;
+    }
+
     const normalizedValue = String(value ?? "").trim();
     if (normalizedValue) {
       nextParams.set(key, normalizedValue);
     }
   });
+
+  if (filters.sourceSort && filters.sourceSort !== DEFAULT_SOURCE_SORT) {
+    nextParams.set("sourceSort", filters.sourceSort);
+  }
 
   if (page > 1) {
     nextParams.set("page", String(page));
@@ -303,8 +321,10 @@ function LookingForClan() {
     }, []);
 
     const fetchClanPage = useCallback(async (page, filters, signal) => {
-      const offset = (page - 1) * PAGE_SIZE;
-      const url = `/recruitee?limit=${PAGE_SIZE}&offset=${offset}&includeTotal=1`;
+    const offset = (page - 1) * PAGE_SIZE;
+      const sourceSort = parseSourceSortParam(filters.sourceSort);
+      const sourceSortParam = encodeURIComponent(sourceSort);
+      const url = `/recruitee?limit=${PAGE_SIZE}&offset=${offset}&includeTotal=1&sourceSort=${sourceSortParam}`;
       const filterPayload = buildFilterPayload(filters);
       const response = hasActiveFilters(filters)
         ? await fetch(url, {
@@ -518,7 +538,19 @@ function LookingForClan() {
       }
     };
     const totalPages = Math.max(1, Math.ceil(totalResults / PAGE_SIZE));
-    const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+    const pageWindowStart = (
+      Math.floor((currentPage - 1) / PAGE_WINDOW_SIZE) * PAGE_WINDOW_SIZE
+    ) + 1;
+    const pageWindowEnd = Math.min(
+      pageWindowStart + PAGE_WINDOW_SIZE - 1,
+      totalPages
+    );
+    const pageNumbers = Array.from(
+      { length: pageWindowEnd - pageWindowStart + 1 },
+      (_, i) => pageWindowStart + i
+    );
+    const hasPreviousPageWindow = pageWindowStart > 1;
+    const hasNextPageWindow = pageWindowEnd < totalPages;
 
 if (!sessionStateLoaded || loading){
   return <LoadingScreen />;
@@ -595,6 +627,14 @@ return (
               {location.name}
             </option>
           ))}
+        </select>
+      </label>
+
+      <label>
+        Sort
+        <select name="sourceSort" value={Filters.sourceSort} onChange={handleFilterChange}>
+          <option value="community">Community listings first</option>
+          <option value="discovered">Discovered clans first</option>
         </select>
       </label>
 
@@ -687,8 +727,18 @@ return (
         );
       })}
     </div>
-    {pageNumbers.length > 1 && (
-      <div className="listing-pagination-wrap">
+    {totalPages > 1 && (
+      <div className="listing-pagination-wrap" aria-label="Clan listing pages">
+        {hasPreviousPageWindow && (
+          <button
+            type="button"
+            className="listing-page-btn listing-page-arrow"
+            onClick={() => handlePageChange(pageWindowStart - PAGE_WINDOW_SIZE)}
+            aria-label="Previous 10 pages"
+          >
+            &lt;
+          </button>
+        )}
         {pageNumbers.map((pageNumber) => (
           <button
             key={pageNumber}
@@ -699,6 +749,16 @@ return (
             {pageNumber}
           </button>
         ))}
+        {hasNextPageWindow && (
+          <button
+            type="button"
+            className="listing-page-btn listing-page-arrow"
+            onClick={() => handlePageChange(pageWindowEnd + 1)}
+            aria-label="Next 10 pages"
+          >
+            &gt;
+          </button>
+        )}
       </div>
     )}
 

--- a/routes/recruitee_route.py
+++ b/routes/recruitee_route.py
@@ -47,6 +47,7 @@ RECRUITEE_FILTER_FIELDS = {
 }
 RECRUITEE_REQUIREMENT_FIELDS = {"townhall", "league", "members"}
 MEMBER_FILTER_FIELDS = {"min", "max"}
+SOURCE_SORT_VALUES = {"community", "discovered"}
 
 
 def _get_requested_limit(default_limit):
@@ -70,6 +71,14 @@ def _should_include_total():
     return query_bool(request, "includeTotal", default=False)
 
 
+def _get_requested_source_sort():
+    """Return source ordering preference for mixed live/imported results."""
+    source_sort = request.args.get("sourceSort", "community").strip()
+    if source_sort not in SOURCE_SORT_VALUES:
+        raise RequestValidationError("sourceSort is invalid.")
+    return source_sort
+
+
 @recruitee_bp.get("/recruitee")
 @rate_limit("recruitee_get", limit=60, window_seconds=60)
 def recruitee_get():
@@ -79,6 +88,7 @@ def recruitee_get():
         requested_limit = _get_requested_limit(default_limit)
         requested_offset = _get_requested_offset()
         include_total = _should_include_total()
+        source_sort = _get_requested_source_sort()
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
 
@@ -88,6 +98,7 @@ def recruitee_get():
             limit=requested_limit,
             offset=requested_offset,
             include_total=include_total,
+            source_sort=source_sort,
             clan_collection=get_clan_collection(),
         )
     except RequestValidationError as exc:
@@ -116,6 +127,7 @@ def recruitee_post():
         requested_limit = _get_requested_limit(default_limit)
         requested_offset = _get_requested_offset()
         include_total = _should_include_total()
+        source_sort = _get_requested_source_sort()
         raw_form = _validate_recruitee_payload(get_json_object(request))
     except RequestValidationError as exc:
         return jsonify({"error": exc.message}), 400
@@ -125,6 +137,7 @@ def recruitee_post():
         limit=requested_limit,
         offset=requested_offset,
         include_total=include_total,
+        source_sort=source_sort,
         clan_collection=get_clan_collection(),
     )
     return jsonify(payload), status_code

--- a/services/clan_search_sorting.py
+++ b/services/clan_search_sorting.py
@@ -1,0 +1,82 @@
+"""Shared sort helpers for clan listing search results."""
+
+from typing import Any
+
+ENGLISH_PRIORITY_LOCATIONS = (
+    "australia",
+    "canada",
+    "india",
+    "international",
+    "ireland",
+    "new zealand",
+    "philippines",
+    "singapore",
+    "south africa",
+    "united kingdom",
+    "united states",
+)
+
+LISTING_SOURCE_PRIORITY_FIELD = "_listing_source_priority"
+ENGLISH_PRIORITY_FIELD = "_english_priority"
+
+
+def priority_sort_pipeline(
+    query: dict[str, Any],
+    sort_fields: list[tuple[str, int]],
+    *,
+    offset: int,
+    limit: int,
+    source_sort: str = "community",
+) -> list[dict[str, Any]]:
+    """Return an aggregation pipeline that sorts by listing quality first."""
+    imported_priority = 0 if source_sort == "discovered" else 1
+    live_priority = 1 if source_sort == "discovered" else 0
+    return [
+        {"$match": query},
+        {
+            "$addFields": {
+                LISTING_SOURCE_PRIORITY_FIELD: {
+                    "$cond": [
+                        {"$eq": ["$source", "clash_api_import"]},
+                        imported_priority,
+                        live_priority,
+                    ],
+                },
+                ENGLISH_PRIORITY_FIELD: {
+                    "$cond": [
+                        {
+                            "$in": [
+                                {
+                                    "$toLower": {
+                                        "$ifNull": [
+                                            "$clan_info.location.name",
+                                            "",
+                                        ],
+                                    },
+                                },
+                                list(ENGLISH_PRIORITY_LOCATIONS),
+                            ],
+                        },
+                        0,
+                        1,
+                    ],
+                },
+            },
+        },
+        {
+            "$sort": {
+                LISTING_SOURCE_PRIORITY_FIELD: 1,
+                ENGLISH_PRIORITY_FIELD: 1,
+                **dict(sort_fields),
+            },
+        },
+        {"$skip": offset},
+        {"$limit": limit},
+        {
+            "$project": {
+                "_id": 0,
+                LISTING_SOURCE_PRIORITY_FIELD: 0,
+                ENGLISH_PRIORITY_FIELD: 0,
+            },
+        },
+    ]

--- a/services/imported_clan_search.py
+++ b/services/imported_clan_search.py
@@ -4,6 +4,8 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
+from .clan_search_sorting import priority_sort_pipeline
+
 IMPORTED_CLAN_SORT = [
     ("last_discovered", -1),
     ("last_updated", -1),
@@ -32,12 +34,24 @@ def get_imported_clans_response(
     filters = payload.get("filters", {})
     query = build_imported_query(filters)
     total = clan_collection.count_documents(query)
-    items = list(
-        clan_collection.find(query, {"_id": 0})
-        .sort(IMPORTED_CLAN_SORT)
-        .skip(offset)
-        .limit(limit)
-    )
+    if hasattr(clan_collection, "aggregate"):
+        items = list(
+            clan_collection.aggregate(
+                priority_sort_pipeline(
+                    query,
+                    IMPORTED_CLAN_SORT,
+                    offset=offset,
+                    limit=limit,
+                )
+            )
+        )
+    else:
+        items = list(
+            clan_collection.find(query, {"_id": 0})
+            .sort(IMPORTED_CLAN_SORT)
+            .skip(offset)
+            .limit(limit)
+        )
 
     return (
         {

--- a/services/recruitee_search.py
+++ b/services/recruitee_search.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..routes.validation import RequestValidationError
 from .builder_base_leagues import builder_base_league_id_from_trophies
+from .clan_search_sorting import priority_sort_pipeline
 
 MATCHMAKING_SESSION_FIELDS = {
     "player_league": "requirements.0",
@@ -22,6 +23,7 @@ def get_recruitee_list_response(
     offset: int,
     include_total: bool,
     clan_collection: Any,
+    source_sort: str = "community",
 ) -> tuple[Any, int]:
     """Return clans for a session with optional total metadata."""
     query = active_listing_query(get_matchmaking_base_query(session_data))
@@ -30,6 +32,7 @@ def get_recruitee_list_response(
         limit=limit,
         offset=offset,
         include_total=include_total,
+        source_sort=source_sort,
         clan_collection=clan_collection,
     ), 200
 
@@ -41,6 +44,7 @@ def get_recruitee_post_response(
     offset: int,
     include_total: bool,
     clan_collection: Any,
+    source_sort: str = "community",
 ) -> tuple[Any, int]:
     """Return clan details by tag or a filtered clan list."""
     clan_tag = payload.get("clanTag")
@@ -61,6 +65,7 @@ def get_recruitee_post_response(
         limit=limit,
         offset=offset,
         include_total=include_total,
+        source_sort=source_sort,
         clan_collection=clan_collection,
     ), 200
 
@@ -154,13 +159,27 @@ def _paginated_response(
     offset: int,
     include_total: bool,
     clan_collection: Any,
+    source_sort: str = "community",
 ) -> Any:
-    data = list(
-        clan_collection.find(query, {"_id": 0})
-        .sort(RECRUITEE_SORT)
-        .skip(offset)
-        .limit(limit)
-    )
+    if hasattr(clan_collection, "aggregate"):
+        data = list(
+            clan_collection.aggregate(
+                priority_sort_pipeline(
+                    query,
+                    RECRUITEE_SORT,
+                    offset=offset,
+                    limit=limit,
+                    source_sort=source_sort,
+                )
+            )
+        )
+    else:
+        data = list(
+            clan_collection.find(query, {"_id": 0})
+            .sort(RECRUITEE_SORT)
+            .skip(offset)
+            .limit(limit)
+        )
 
     if not include_total:
         return data

--- a/tests/routes/test_recruitee_route.py
+++ b/tests/routes/test_recruitee_route.py
@@ -336,6 +336,30 @@ def test_recruitee_get_returns_400_for_invalid_include_total(
     assert collection.count_query is None
 
 
+def test_recruitee_get_returns_400_for_invalid_source_sort(
+    client,
+    monkeypatch,
+    set_session,
+):
+    import ClashRecruit.routes.recruitee_route as recruitee_route
+
+    collection = DummyClanCollection()
+
+    set_session(player_name="Guest")
+    monkeypatch.setattr(
+        recruitee_route,
+        "get_clan_collection",
+        lambda: collection,
+    )
+
+    response = client.get("/recruitee?sourceSort=unknown")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "sourceSort is invalid."}
+    assert collection.find_query is None
+    assert collection.count_query is None
+
+
 def test_recruitee_post_filters_and_paginates_with_total(
     client,
     monkeypatch,

--- a/tests/test_imported_clan_search_service.py
+++ b/tests/test_imported_clan_search_service.py
@@ -47,6 +47,16 @@ class DummyClanCollection:
         return self.cursor
 
 
+class AggregateClanCollection(DummyClanCollection):
+    def __init__(self, docs):
+        super().__init__(docs)
+        self.aggregate_pipeline = None
+
+    def aggregate(self, pipeline):
+        self.aggregate_pipeline = pipeline
+        return iter(self.cursor.docs)
+
+
 def test_build_imported_query_uses_filters():
     query = build_imported_query(
         {
@@ -97,6 +107,33 @@ def test_imported_clans_response_returns_paginated_search():
     assert collection.find_query["clan_info.location.name"] == "Canada"
     assert collection.find_projection == {"_id": 0}
     assert collection.cursor.sort_fields == IMPORTED_CLAN_SORT
+
+
+def test_imported_clans_response_prioritizes_english_clans():
+    collection = AggregateClanCollection(
+        [{"clan_tag": "ONE", "name": "First"}]
+    )
+
+    payload, status_code = get_imported_clans_response(
+        {"filters": {}},
+        limit=10,
+        offset=0,
+        clan_collection=collection,
+        imported_clan_lookup=lambda clan_tag: None,
+    )
+
+    assert status_code == 200
+    assert payload["items"] == [{"clan_tag": "ONE", "name": "First"}]
+    assert collection.aggregate_pipeline[0] == {"$match": collection.count_query}
+    assert collection.aggregate_pipeline[2]["$sort"] == {
+        "_listing_source_priority": 1,
+        "_english_priority": 1,
+        "last_discovered": -1,
+        "last_updated": -1,
+        "clan_info.clan_level": -1,
+        "clan_info.member_count": -1,
+        "clan_tag": 1,
+    }
 
 
 def test_imported_clans_response_returns_tag_lookup():

--- a/tests/test_imported_clan_search_service.py
+++ b/tests/test_imported_clan_search_service.py
@@ -124,7 +124,9 @@ def test_imported_clans_response_prioritizes_english_clans():
 
     assert status_code == 200
     assert payload["items"] == [{"clan_tag": "ONE", "name": "First"}]
-    assert collection.aggregate_pipeline[0] == {"$match": collection.count_query}
+    assert collection.aggregate_pipeline[0] == {
+        "$match": collection.count_query,
+    }
     assert collection.aggregate_pipeline[2]["$sort"] == {
         "_listing_source_priority": 1,
         "_english_priority": 1,

--- a/tests/test_recruitee_search_service.py
+++ b/tests/test_recruitee_search_service.py
@@ -187,7 +187,9 @@ def test_recruitee_list_response_prioritizes_community_and_english_clans():
 
     assert status_code == 200
     assert payload["items"] == [{"clan_tag": "TEST1", "name": "test_clan_1"}]
-    assert collection.aggregate_pipeline[0] == {"$match": collection.count_query}
+    assert collection.aggregate_pipeline[0] == {
+        "$match": collection.count_query,
+    }
     assert collection.aggregate_pipeline[1]["$addFields"][
         "_listing_source_priority"
     ] == {

--- a/tests/test_recruitee_search_service.py
+++ b/tests/test_recruitee_search_service.py
@@ -59,6 +59,16 @@ class DummyClanCollection:
         return self.tag_result
 
 
+class AggregateClanCollection(DummyClanCollection):
+    def __init__(self, docs=None, tag_result=None):
+        super().__init__(docs, tag_result)
+        self.aggregate_pipeline = None
+
+    def aggregate(self, pipeline):
+        self.aggregate_pipeline = pipeline
+        return iter(self.cursor.docs)
+
+
 def test_matchmaking_base_query_uses_logged_in_player_stats():
     query = get_matchmaking_base_query(
         {
@@ -160,6 +170,60 @@ def test_recruitee_list_response_filters_and_includes_total():
     assert collection.count_query == collection.find_query
     assert collection.find_projection == {"_id": 0}
     assert collection.cursor.sort_fields == RECRUITEE_SORT
+
+
+def test_recruitee_list_response_prioritizes_community_and_english_clans():
+    collection = AggregateClanCollection(
+        [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    )
+
+    payload, status_code = get_recruitee_list_response(
+        {},
+        limit=10,
+        offset=0,
+        include_total=True,
+        clan_collection=collection,
+    )
+
+    assert status_code == 200
+    assert payload["items"] == [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    assert collection.aggregate_pipeline[0] == {"$match": collection.count_query}
+    assert collection.aggregate_pipeline[1]["$addFields"][
+        "_listing_source_priority"
+    ] == {
+        "$cond": [{"$eq": ["$source", "clash_api_import"]}, 1, 0],
+    }
+    assert collection.aggregate_pipeline[2]["$sort"] == {
+        "_listing_source_priority": 1,
+        "_english_priority": 1,
+        "last_updated": -1,
+        "clan_tag": 1,
+    }
+    assert collection.aggregate_pipeline[3] == {"$skip": 0}
+    assert collection.aggregate_pipeline[4] == {"$limit": 10}
+
+
+def test_recruitee_list_response_can_prioritize_discovered_clans():
+    collection = AggregateClanCollection(
+        [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    )
+
+    payload, status_code = get_recruitee_list_response(
+        {},
+        limit=10,
+        offset=0,
+        include_total=True,
+        source_sort="discovered",
+        clan_collection=collection,
+    )
+
+    assert status_code == 200
+    assert payload["items"] == [{"clan_tag": "TEST1", "name": "test_clan_1"}]
+    assert collection.aggregate_pipeline[1]["$addFields"][
+        "_listing_source_priority"
+    ] == {
+        "$cond": [{"$eq": ["$source", "clash_api_import"]}, 0, 1],
+    }
 
 
 def test_recruitee_post_response_returns_tag_lookup():


### PR DESCRIPTION
## Summary
- Limit clan search pagination controls to 10 pages at a time with previous/next page-window arrows
- Add source sorting for clan search with Community listings first and Discovered clans first options
- Prioritize community/discovered source ordering in backend search results while preserving English-priority and existing tie-breaker sorting
- Add focused service and route coverage for source sorting

## Testing
- `venv/bin/pytest tests/test_recruitee_search_service.py tests/test_imported_clan_search_service.py tests/routes/test_recruitee_route.py tests/routes/test_imported_clans_route.py`
- `npm run build`