### PR TITLE
seo: add sitemap and SEO metadata

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Looking to promote your clan or join a new one? Discover clans and post listings in one place."
+      content="Find active Clash of Clans clans recruiting players, browse clan requirements, or list your clan for recruitment on ClashRecruit."
     />
     
     <!--
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ClashRecruit</title>
+    <title>ClashRecruit | Clash of Clans Recruiting</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -6,3 +6,5 @@ Disallow: /recruit
 
 Allow: /privacy
 Allow: /terms
+
+Sitemap: https://www.clashrecruit.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.clashrecruit.com/</loc>
+  </url>
+  <url>
+    <loc>https://www.clashrecruit.com/looking-for-clan</loc>
+  </url>
+  <url>
+    <loc>https://www.clashrecruit.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://www.clashrecruit.com/privacy</loc>
+  </url>
+  <url>
+    <loc>https://www.clashrecruit.com/terms</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- Add a static `sitemap.xml` for stable public ClashRecruit pages
- Advertise the sitemap from `robots.txt`
- Update the default page title and meta description for better search discoverability

## Notes

The sitemap intentionally includes only stable public routes:

- `/`
- `/looking-for-clan`
- `/contact`
- `/privacy`
- `/terms`